### PR TITLE
Moved Bracket in Lilypond output that was causing an issue for users …

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -1534,10 +1534,10 @@ function Logo(matrix, musicnotation, canvas, blocks, turtles, stage,
 
                     // Close the SCORE sections.
                     logo.lilypondOutput += '      >>%0A%25}%0A';
-                    logo.lilypondOutput += '%0A   >>%0A   %5Clayout {}%0A}%0A%0A';
+                    logo.lilypondOutput += '%0A   >>%0A   %5Clayout {}%0A%0A';
 
                     // Add MIDI OUTPUT in comments.
-                    logo.lilypondOutput += '%25 MIDI SECTION%0A%25 Delete the %25{ and %25} below to include MIDI output.%0A%25{%0A%5Cmidi {%0A   %5Ctempo 4=90%0A}%0A%25}%0A%0A';
+                    logo.lilypondOutput += '%25 MIDI SECTION%0A%25 Delete the %25{ and %25} below to include MIDI output.%0A%25{%0A%5Cmidi {%0A   %5Ctempo 4=90%0A}%0A%25}%0A%0A}%0A%0A';
 
                     // ADD TURTLE BLOCKS CODE HERE
                     logo.lilypondOutput += '%25 MUSIC BLOCKS CODE%0A';


### PR DESCRIPTION
Moved Bracket in Lilypond output that was causing an issue for users who want MIDI from ly.

Bracket was in the wrong spot.

I think I fixed it, but had sooooooooooooooooooooooo much trouble pushing the change back to github. So, please make sure that there is only the bracket change in the js/logo.js file before pulling it.

What I think I did:
1) checkout experimental
2) create new branch
3) made the change
4) pushed the branch to github

But who knows what I really did. At any rate, it works on my computer, see below:

Problem:
![screenshot - 11162015 - 05-00-36 pm bracket needs to be down here](https://cloud.githubusercontent.com/assets/13454579/11213639/05a340ec-8d0b-11e5-803c-0030ade09dde.png)

Solution:
![screenshot - 11172015 - 08-45-56 am devin seems to have successfully moved the bracket](https://cloud.githubusercontent.com/assets/13454579/11213644/0bd9c256-8d0b-11e5-84f5-2fbd1eccd537.png)
