### PR TITLE
Add bundle name org.sugarlabs.MusicBlocks

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -1,6 +1,6 @@
 [Activity]
 name = Mouse Music
 activity_version = 1
-bundle_id = null
+bundle_id = org.sugarlabs.MusicBlocks
 exec = null
 icon = activity-icon


### PR DESCRIPTION
Its hard to even track this activity in the log since entries were with the name null-1,null-2 etc giving this a bundle name would make it a lot easier to track the activity when necessary.