### PR TITLE
Fix Issue #142

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -902,7 +902,13 @@ function Logo(matrix, musicnotation, canvas, blocks, turtles, stage,
             case 'speak':
                 if (args.length == 1) {
                     if (logo.meSpeak) {
-                        logo.meSpeak.speak(args[0]);
+                        var text = args[0];
+                        var new_text = "";
+                        for(i=0;i<text.length;i++){
+                            if((text[i]>='a' && text[i]<='z') || (text[i]>='A' && text[i]<='Z') || text[i]==',' || text[i]=='.' || text[i]==' ')
+                                new_text+=text[i];
+                        }
+                        logo.meSpeak.speak(new_text);
                     }
                 }
                 break;


### PR DESCRIPTION
Only use 'a-z' , 'A-Z' , ',' , '.'  and ' ' with mespeak
Since mespeak does not recognize ! or ? etc. It only recognizes the above characters, so instead of passing it the entire string supplied, we could filer out characters that mespeak does not recognize.