### PR TITLE
Extension: Duplicate notes functionality in the matrix

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -120,7 +120,7 @@ function Logo(matrix, canvas, blocks, turtles, stage,
     this.skipIndex = {};
     this.polyVolume = {};
     this.validNote = true;
-    this.duplicating = 0;
+    this.duplicating = false;
 
     // tuplet
     this.tuplet = false;
@@ -1856,21 +1856,22 @@ function Logo(matrix, canvas, blocks, turtles, stage,
                             num1 += 2 * delta;
                         }
                     }
-		if(logo.duplicating){
-			var dlen = logo.duplicateFactor[turtle];
+			if(logo.duplicating){
+				var dlen = logo.duplicateFactor[turtle];
 			} else {
-			var dlen = 1;
+				var dlen = 1;
 			}
-		for(var i = 0; i<dlen; i++){
-                        matrix.solfegeNotes.push(note);
-                        if (logo.inTranspositionClamp || logo.inFlatClamp || logo.inSharpClamp) {
-                            	matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
-                        } else {
-                            matrix.solfegeTranspositions.push(2 * delta);
-                        }
-                        matrix.solfegeOctaves.push(octave);
-		}    
-	
+			for(var i = 0; i<dlen; i++){
+				matrix.solfegeNotes.push(note);
+				if (logo.inTranspositionClamp || logo.inFlatClamp || logo.inSharpClamp) {
+					matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
+				} else {
+					matrix.solfegeTranspositions.push(2 * delta);
+					
+				}       
+				matrix.solfegeOctaves.push(octave);
+			}    
+		
 		} else {
                     logo.noteNotes[turtle].push(note);
                     logo.noteOctaves[turtle].push(octave);
@@ -2142,7 +2143,7 @@ function Logo(matrix, canvas, blocks, turtles, stage,
             case 'duplicatenotes':
                 var factor = args[0];
                	if(logo.inMatrix){
-			logo.duplicating = 1;
+			logo.duplicating = true;
                 }
                 if (factor == 0) {
                     logo.errorMsg(ZERODIVIDEERRORMSG, blk);
@@ -2157,10 +2158,10 @@ function Logo(matrix, canvas, blocks, turtles, stage,
 
                     var listener = function (event) {
                         logo.duplicateFactor[turtle] /= factor;
-                    
-                    	if(logo.inMatrix){
-				logo.duplicating = 0;
-                    	}
+                   
+                      	if(logo.inMatrix){
+				logo.duplicating = false;
+                   	}
                     }
 
                     logo.setListener(turtle, listenerName, listener);

--- a/js/logo.js
+++ b/js/logo.js
@@ -1856,22 +1856,22 @@ function Logo(matrix, canvas, blocks, turtles, stage,
                             num1 += 2 * delta;
                         }
                     }
-            		if(logo.duplicating){
-            	    	var dlen = logo.duplicateFactor[turtle];
-            		} else {
-            			var dlen = 1;
-            		}
-            		for(var i = 0; i<dlen; i++){
-            		    matrix.solfegeNotes.push(note);
-            		    if (logo.inTranspositionClamp || logo.inFlatClamp || logo.inSharpClamp) {
-            				matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
-            		    } else {
-            				matrix.solfegeTranspositions.push(2 * delta);
-            			}       
-            	        matrix.solfegeOctaves.push(octave);
-            			}    
-		        } else {
-                    logo.noteNotes[turtle].push(note);
+                    if(logo.duplicating){
+                        var dlen = logo.duplicateFactor[turtle];
+                    } else {
+                        var dlen = 1;
+                    }
+                    for(var i = 0; i<dlen; i++){
+                        matrix.solfegeNotes.push(note);
+                        if (logo.inTranspositionClamp || logo.inFlatClamp || logo.inSharpClamp) {
+                            matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
+                        } else {
+                            matrix.solfegeTranspositions.push(2 * delta);
+                        }       
+                        matrix.solfegeOctaves.push(octave);
+                    }    
+                } else {
+                logo.noteNotes[turtle].push(note);
                     logo.noteOctaves[turtle].push(octave);
                     if (!(logo.invertList[turtle].length === 0)) {
                         var len = logo.invertList[turtle].length;
@@ -2158,9 +2158,8 @@ function Logo(matrix, canvas, blocks, turtles, stage,
                         logo.duplicateFactor[turtle] /= factor;
                         if(logo.inMatrix){
                             logo.duplicating = false;
-                   	}
+                        }
                     }
-
                     logo.setListener(turtle, listenerName, listener);
                 }
                 break;
@@ -2181,9 +2180,8 @@ function Logo(matrix, canvas, blocks, turtles, stage,
                         logo.skipFactor[turtle] /= factor;
                         if (logo.skipFactor[turtle] === 1) {
                             logo.skipIndex[turtle] = 0;
-			}
+                        }
                     }
-
                     logo.setListener(turtle, listenerName, listener);
                 }
                 break;

--- a/js/logo.js
+++ b/js/logo.js
@@ -1864,13 +1864,12 @@ function Logo(matrix, canvas, blocks, turtles, stage,
 			for(var i = 0; i<dlen; i++){
 			    matrix.solfegeNotes.push(note);
 			    if (logo.inTranspositionClamp || logo.inFlatClamp || logo.inSharpClamp) {
-				matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
-			    } else {
-				matrix.solfegeTranspositions.push(2 * delta);
+				    matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
+		        } else {
+				    matrix.solfegeTranspositions.push(2 * delta);
 			    }       
-			    matrix.solfegeOctaves.push(octave);
+	            matrix.solfegeOctaves.push(octave);
 			}    
-		
 		} else {
                     logo.noteNotes[turtle].push(note);
                     logo.noteOctaves[turtle].push(octave);
@@ -2141,8 +2140,8 @@ function Logo(matrix, canvas, blocks, turtles, stage,
                 break;
             case 'duplicatenotes':
                 var factor = args[0];
-               	if(logo.inMatrix){
-	            logo.duplicating = true;
+                if(logo.inMatrix){
+                    logo.duplicating = true;
                 }
                 if (factor == 0) {
                     logo.errorMsg(ZERODIVIDEERRORMSG, blk);
@@ -2158,7 +2157,7 @@ function Logo(matrix, canvas, blocks, turtles, stage,
                     var listener = function (event) {
                         logo.duplicateFactor[turtle] /= factor;
                         if(logo.inMatrix){
-	                    logo.duplicating = false;
+                            logo.duplicating = false;
                    	}
                     }
 

--- a/js/logo.js
+++ b/js/logo.js
@@ -1856,21 +1856,21 @@ function Logo(matrix, canvas, blocks, turtles, stage,
                             num1 += 2 * delta;
                         }
                     }
-			if(logo.duplicating){
-				var dlen = logo.duplicateFactor[turtle];
-			} else {
-				var dlen = 1;
-			}
-			for(var i = 0; i<dlen; i++){
-			    matrix.solfegeNotes.push(note);
-			    if (logo.inTranspositionClamp || logo.inFlatClamp || logo.inSharpClamp) {
-				    matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
+            		if(logo.duplicating){
+            	    	var dlen = logo.duplicateFactor[turtle];
+            		} else {
+            			var dlen = 1;
+            		}
+            		for(var i = 0; i<dlen; i++){
+            		    matrix.solfegeNotes.push(note);
+            		    if (logo.inTranspositionClamp || logo.inFlatClamp || logo.inSharpClamp) {
+            				matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
+            		    } else {
+            				matrix.solfegeTranspositions.push(2 * delta);
+            			}       
+            	        matrix.solfegeOctaves.push(octave);
+            			}    
 		        } else {
-				    matrix.solfegeTranspositions.push(2 * delta);
-			    }       
-	            matrix.solfegeOctaves.push(octave);
-			}    
-		} else {
                     logo.noteNotes[turtle].push(note);
                     logo.noteOctaves[turtle].push(octave);
                     if (!(logo.invertList[turtle].length === 0)) {

--- a/js/logo.js
+++ b/js/logo.js
@@ -120,6 +120,7 @@ function Logo(matrix, canvas, blocks, turtles, stage,
     this.skipIndex = {};
     this.polyVolume = {};
     this.validNote = true;
+    this.duplicating = 0;
 
     // tuplet
     this.tuplet = false;
@@ -1855,15 +1856,22 @@ function Logo(matrix, canvas, blocks, turtles, stage,
                             num1 += 2 * delta;
                         }
                     }
-                    matrix.solfegeNotes.push(note);
-                    if (turtle in logo.transposition) {
-                        matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
-                    } else {
-                        matrix.solfegeTranspositions.push(2 * delta);
-                    }
-
-                    matrix.solfegeOctaves.push(octave);
-                } else {
+		if(logo.duplicating){
+			var dlen = logo.duplicateFactor[turtle];
+			} else {
+			var dlen = 1;
+			}
+		for(var i = 0; i<dlen; i++){
+                        matrix.solfegeNotes.push(note);
+                        if (logo.inTranspositionClamp || logo.inFlatClamp || logo.inSharpClamp) {
+                            	matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
+                        } else {
+                            matrix.solfegeTranspositions.push(2 * delta);
+                        }
+                        matrix.solfegeOctaves.push(octave);
+		}    
+	
+		} else {
                     logo.noteNotes[turtle].push(note);
                     logo.noteOctaves[turtle].push(octave);
                     if (!(logo.invertList[turtle].length === 0)) {
@@ -2133,6 +2141,9 @@ function Logo(matrix, canvas, blocks, turtles, stage,
                 break;
             case 'duplicatenotes':
                 var factor = args[0];
+               	if(logo.inMatrix){
+			logo.duplicating = 1;
+                }
                 if (factor == 0) {
                     logo.errorMsg(ZERODIVIDEERRORMSG, blk);
                     logo.stopTurtle = true;
@@ -2146,6 +2157,10 @@ function Logo(matrix, canvas, blocks, turtles, stage,
 
                     var listener = function (event) {
                         logo.duplicateFactor[turtle] /= factor;
+                    
+                    	if(logo.inMatrix){
+				logo.duplicating = 0;
+                    	}
                     }
 
                     logo.setListener(turtle, listenerName, listener);

--- a/js/logo.js
+++ b/js/logo.js
@@ -1862,14 +1862,13 @@ function Logo(matrix, canvas, blocks, turtles, stage,
 				var dlen = 1;
 			}
 			for(var i = 0; i<dlen; i++){
-				matrix.solfegeNotes.push(note);
-				if (logo.inTranspositionClamp || logo.inFlatClamp || logo.inSharpClamp) {
-					matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
-				} else {
-					matrix.solfegeTranspositions.push(2 * delta);
-					
-				}       
-				matrix.solfegeOctaves.push(octave);
+			    matrix.solfegeNotes.push(note);
+			    if (logo.inTranspositionClamp || logo.inFlatClamp || logo.inSharpClamp) {
+				matrix.solfegeTranspositions.push(logo.transposition[turtle] + 2 * delta);
+			    } else {
+				matrix.solfegeTranspositions.push(2 * delta);
+			    }       
+			    matrix.solfegeOctaves.push(octave);
 			}    
 		
 		} else {
@@ -2143,7 +2142,7 @@ function Logo(matrix, canvas, blocks, turtles, stage,
             case 'duplicatenotes':
                 var factor = args[0];
                	if(logo.inMatrix){
-			logo.duplicating = true;
+	            logo.duplicating = true;
                 }
                 if (factor == 0) {
                     logo.errorMsg(ZERODIVIDEERRORMSG, blk);
@@ -2158,9 +2157,8 @@ function Logo(matrix, canvas, blocks, turtles, stage,
 
                     var listener = function (event) {
                         logo.duplicateFactor[turtle] /= factor;
-                   
-                      	if(logo.inMatrix){
-				logo.duplicating = false;
+                        if(logo.inMatrix){
+	                    logo.duplicating = false;
                    	}
                     }
 


### PR DESCRIPTION
This patch extends the duplicate note functionality to the matrix. The notes can now be seen multiple times in the matrix with the duplicate notes block