### PR TITLE
Replaced missing help icons

### DIFF
--- a/header-icons/plugins-button-white.svg
+++ b/header-icons/plugins-button-white.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg4239"
+   version="1.1"
+   width="55"
+   height="55">
+  <metadata
+     id="metadata4262">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4260" />
+  <g
+     transform="translate(-233.21351,-70.250047)"
+     id="plugins">
+    <g
+       style="fill:none;stroke:#ffffff;stroke-opacity:1"
+       id="g45"
+       transform="matrix(0.55205508,0,0,0.55205508,277.61846,85.235971)">
+      <g
+         style="fill:none;stroke:#ffffff;stroke-opacity:1"
+         id="g47"
+         transform="translate(-80.093659,12.220029)">
+        <g
+           style="fill:none;stroke:#ffffff;stroke-opacity:1"
+           id="g49">
+          <path
+             style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+             id="path51"
+             d="m 6.736,49.002 24.52,0 c 2.225,0 3.439,-1.447 3.439,-3.441 l 0,-27.28 c 0,-1.73 -1.732,-3.441 -3.439,-3.441 l -4.389,0" />
+        </g>
+      </g>
+      <g
+         style="fill:none;stroke:#ffffff;stroke-opacity:1"
+         id="g53"
+         transform="translate(-80.093659,12.220029)">
+        <g
+           style="fill:none;stroke:#ffffff;stroke-opacity:1"
+           id="g55">
+          <path
+             style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+             id="path57"
+             d="m 26.867,38.592 c 0,1.836 -1.345,3.201 -3.441,4.047 l -16.69,6.363 0,-34.162 16.69,-8.599 c 2.228,-0.394 3.441,0.84 3.441,2.834 l 0,29.517 z" />
+        </g>
+      </g>
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         id="path59"
+         d="m -70.669659,54.827029 c 0,0 -1.351,-0.543 -2.702,-0.543 -1.351,0 -2.703,0.543 -2.703,0.543" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         id="path61"
+         d="m -70.669659,44.226029 c 0,0 -1.239,-0.543 -2.815,-0.543 -1.577,0 -2.59,0.543 -2.59,0.543" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         id="path63"
+         d="m -70.669659,33.898029 c 0,0 -1.125,-0.544 -2.927,-0.544 -1.802,0 -2.478,0.544 -2.478,0.544" />
+      <line
+         id="line65"
+         style="fill:none;stroke:#ffffff;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         x1="-66.884659"
+         x2="-66.884659"
+         y1="58.753029"
+         y2="23.725029" />
+    </g>
+    <g
+       style="fill:none;stroke:#ffffff;stroke-opacity:1"
+       id="g67"
+       transform="matrix(0,-1,-1,0,276.9376,156.38657)">
+      <g
+         style="fill:none;stroke:#ffffff;stroke-opacity:1"
+         id="g69"
+         transform="translate(34.0803,-1006.42)">
+        <polyline
+           id="polyline71"
+           transform="matrix(-0.469241,0.469241,-0.469241,-0.469241,66.2906,1019.03)"
+           style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           points="51.562,15.306 41.17,16.188 42.053,5.794" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path73"
+           d="m 39.363241,1033.1291 -0.05636,9.9115 -8.750608,0.067" />
+      </g>
+    </g>
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path75"
+       d="m 256.54634,85.388888 0,-4.444445 a 4.444445,4.444445 0 0 1 4.44445,-4.444445 l 4.44444,0 0,2.222223 11.11111,0 0,-2.222223 4.44445,0 a 4.444445,4.444445 0 0 1 4.44444,4.444445 l 0,4.444445 0,4.444445 a 4.444445,4.444445 0 0 1 -4.44444,4.444445 l -4.44445,0 -1.11111,0 0,2.222223 -8.88889,0 0,-2.222223 -1.11111,0 -4.44444,0 a 4.444445,4.444445 0 0 1 -4.44445,-4.444445 l 0,-4.444445 z" />
+  </g>
+</svg>

--- a/header-icons/scroll-unlock-button-white.svg
+++ b/header-icons/scroll-unlock-button-white.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg2"
+   version="1.1"
+   width="55"
+   height="55">
+  <metadata
+     id="metadata27">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs25" />
+  <g
+     transform="translate(-296.34967,-66.15035)"
+     id="scrollunlock">
+    <g
+       style="fill:none;stroke:#ffffff;stroke-opacity:1"
+       id="g97"
+       transform="matrix(-1,0,0,1,397.30607,44.1294)">
+      <g
+         style="fill:none;stroke:#ffffff;stroke-opacity:1"
+         id="g99"
+         transform="translate(34.0803,-1006.42)">
+        <polyline
+           id="polyline101"
+           transform="matrix(-0.469241,0.469241,-0.469241,-0.469241,66.2906,1019.03)"
+           style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           points="51.562,15.306 41.17,16.188 42.053,5.794" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path103"
+           d="m 39.36277,1033.1291 0,8.6738" />
+      </g>
+    </g>
+    <g
+       style="fill:none;stroke:#ffffff;stroke-opacity:1"
+       id="g107"
+       transform="matrix(1,0,0,-1,284.47356,1149.5913)">
+      <polyline
+         points="51.562,15.306 41.17,16.188 42.053,5.794"
+         style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         transform="matrix(-0.469241,0.469241,-0.469241,-0.469241,66.2906,1019.03)"
+         id="polyline109" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path111"
+         d="m 39.363241,1033.0937 0.0262,8.0241" />
+    </g>
+    <g
+       style="fill:none;stroke:#ffffff;stroke-opacity:1"
+       id="g113"
+       transform="matrix(0,-1,1,0,276.82873,170.04644)">
+      <g
+         style="fill:none;stroke:#ffffff;stroke-opacity:1"
+         id="g115"
+         transform="translate(34.0803,-1006.42)">
+        <polyline
+           id="polyline117"
+           transform="matrix(-0.469241,0.469241,-0.469241,-0.469241,66.2906,1019.03)"
+           style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           points="51.562,15.306 41.17,16.188 42.053,5.794" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path119"
+           d="m 39.363241,1033.1291 -0.05636,9.4622" />
+      </g>
+    </g>
+    <g
+       style="fill:none;stroke:#ffffff;stroke-opacity:1"
+       id="g121"
+       transform="matrix(0,-1,-1,0,370.8706,170.04644)">
+      <g
+         style="fill:none;stroke:#ffffff;stroke-opacity:1"
+         id="g123"
+         transform="translate(34.0803,-1006.42)">
+        <polyline
+           id="polyline125"
+           transform="matrix(-0.469241,0.469241,-0.469241,-0.469241,66.2906,1019.03)"
+           style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           points="51.562,15.306 41.17,16.188 42.053,5.794" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path127"
+           d="m 39.363241,1033.1291 -0.05636,9.4115" />
+      </g>
+    </g>
+    <path
+       id="path3160"
+       style="fill:#ffffff"
+       d="m 312.59966,100.5625 0,-6.56249 q 0,-1.171875 0.82031,-1.992195 0.82031,-0.82031 1.99219,-0.82031 l 0,-3.75 q 0,-3.51563 2.46094,-5.97656 2.46093,-2.46094 5.97656,-2.46094 3.51562,0 5.97656,2.46094 2.46094,2.46093 2.46094,5.97656 l 0,3.75 q 1.17187,0 1.99219,0.82031 0.82031,0.82032 0.82031,1.992195 l 0,6.56249 q 0,3.51562 -2.46094,5.97656 Q 330.17778,109 326.66216,109 l -5.625,0 q -3.51563,0 -5.97656,-2.46094 -2.46094,-2.46094 -2.46094,-5.97656 z m 1.875,0 q 0,2.69531 1.93359,4.62891 1.9336,1.93359 4.62891,1.93359 l 5.625,0 q 2.69531,0 4.62891,-1.93359 1.93359,-1.9336 1.93359,-4.62891 l 0,-6.56249 q 0,-0.410165 -0.26369,-0.673845 -0.26368,-0.26369 -0.67384,-0.26369 l -16.875,0 q -0.41016,0 -0.67384,0.26369 -0.26369,0.26368 -0.26369,0.673845 l 0,6.56249 z m 2.8125,-9.374995 1.875,0 0,-3.75 q 0,-1.93359 1.37694,-3.31056 1.37694,-1.37697 3.31056,-1.37694 1.93362,3e-5 3.31056,1.37694 1.37694,1.37691 1.37694,3.31056 l 0,3.75 1.875,0 0,-3.75 q 0,-2.69531 -1.93359,-4.62891 -1.9336,-1.93359 -4.62891,-1.93359 -2.69531,0 -4.62891,1.93359 -1.93359,1.9336 -1.93359,4.62891 l 0,3.75 z m 2.8125,0 7.5,0 0,-3.75 q 0,-1.58203 -1.08397,-2.66603 -1.08397,-1.084 -2.66603,-1.08397 -1.58206,3e-5 -2.66603,1.08397 -1.08397,1.08394 -1.08397,2.66603 l 0,3.75 z m 1.875,7.499995 q 0,-0.76172 0.55663,-1.31836 0.55662,-0.55666 1.31837,-0.55663 0.76175,2e-5 1.31837,0.55663 0.55663,0.55658 0.55663,1.31836 0,0.82031 -0.64453,2.51953 -0.41016,1.23047 -1.23047,1.23047 -0.82031,0 -1.23047,-1.23047 -0.64453,-1.69922 -0.64453,-2.51953 z" />
+    <rect
+       style="fill:#282828;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3954"
+       y="86.87191"
+       x="326.6055"
+       height="4.3129773"
+       width="6.5671349" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3956"
+       d="m 327.65946,86.373344 3.81867,-0.0039" />
+  </g>
+</svg>

--- a/js/activity.js
+++ b/js/activity.js
@@ -251,8 +251,8 @@ define(function (require) {
             // [_('Decrease block size'), _('Decrease the size of the blocks.'), 'header-icons/smaller-button.svg'],
             // [_('Increase block size'), _('Increase the size of the blocks.'), 'header-icons/bigger-button.svg'],
             [_('Display statistics'), _('Display statistics about your Music project.'), 'header-icons/chart-button.svg'],
-            [_('Load plugin from file'), _('You can load new blocks from the file system.'), 'header-icons/plugin-button.svg'],
-            [_('Enable scrolling'), _('You can scroll the blocks on the canvas.'), 'header-icons/scroll-button.svg'],
+            [_('Load plugin from file'), _('You can load new blocks from the file system.'), 'header-icons/plugins-button-white.svg'],
+            [_('Enable scrolling'), _('You can scroll the blocks on the canvas.'), 'header-icons/scroll-unlock-button-white.svg'],
             [_('Delete all'), _('Remove all content on the canvas, including the blocks.'), 'header-icons/empty-trash-button.svg'],
             [_('Undo'), _('Restore blocks from the trash.'), 'header-icons/restore-trash-button.svg'],
             [_('Congratulations.'), _('You have finished the tour. Please enjoy Music Blocks!'), 'activity/activity-icon-mouse-color.svg']


### PR DESCRIPTION
Replaced `plugin-button.svg` and `scroll-button.svg` with
`plugins-button-white.svg` and `scroll-unlock-button-white.svg`, fixing
the tutorial, which was broken by 0cb41d8.