### PR TITLE
Removed the background for the clear button

### DIFF
--- a/header-icons/clear-button.svg
+++ b/header-icons/clear-button.svg
@@ -23,17 +23,6 @@
 <defs
    id="defs5" />
 
-
-
-
-
-`  <rect
-   y="2.5"
-   x="2.5"
-   height="50"
-   width="50"
-   id="rect4703"
-   style="fill:#92b5c8;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 <g
    transform="matrix(0.88889004,0,0,0.88889004,5.2777496,3.0555239)"
    id="g4354">


### PR DESCRIPTION
Removing the background of the clear-button makes the button more consistent with the other icons on the navigation menu.

![screen shot 2016-02-16 at 3 57 40 pm](https://cloud.githubusercontent.com/assets/6411354/13145926/5554019e-d621-11e5-99d9-05e59dab444c.png)
