### PR TITLE
Remove highlight of circles on the icons on scroll

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -927,6 +927,7 @@ define(function (require) {
 
             if (event.clientX < cellSize) {
                 palettes.menuScrollEvent(delta, scrollSpeed);
+                palettes.hidePaletteIconCircles();
             } else {
                 palette = palettes.findPalette(event.clientX / musicBlocksScale, event.clientY / musicBlocksScale);
                 if (palette) {

--- a/js/palette.js
+++ b/js/palette.js
@@ -68,6 +68,7 @@ function Palettes(canvas, refreshCanvas, stage, cellSize, refreshCanvas, trashca
     this.trashcan = trashcan;
     this.initial_x = 55;
     this.initial_y = 55;
+    this.circles = {};
     
     if (sugarizerCompatibility.isInsideSugarizer()) {
         storage = sugarizerCompatibility.data;
@@ -133,6 +134,10 @@ function Palettes(canvas, refreshCanvas, stage, cellSize, refreshCanvas, trashca
             this.buttons[name].mask = s;
         }
     };
+     
+    this.hidePaletteIconCircles = function(){
+        hideButtonHighlight(circles, this.stage);
+    }
 
     this.makePalettes = function(hide) {
         // First, an icon/button for each palette
@@ -323,7 +328,6 @@ function Palettes(canvas, refreshCanvas, stage, cellSize, refreshCanvas, trashca
         });
 
         // A palette button opens or closes a palette.
-        var circles = {};
         this.buttons[name].on('mouseover', function(event) {
             var r = palettes.cellSize / 2;
             circles = showButtonHighlight(


### PR DESCRIPTION
In the left palette menu,
a)If we hover over an icon, we get the circles highlight draw on the icon.
![screenshot from 2016-03-26 02 05 01](https://cloud.githubusercontent.com/assets/9864149/14053484/9cdecf88-f2f7-11e5-98fa-8a20558fcd87.png)

b)If we now scroll then the icon moves away from its original location but the highlight stays in its place.
Before:
![screenshot from 2016-03-26 02 05 57](https://cloud.githubusercontent.com/assets/9864149/14053485/9cdf9dfa-f2f7-11e5-8239-1695b542308f.png)
After:
![screenshot from 2016-03-26 02 05 16](https://cloud.githubusercontent.com/assets/9864149/14053483/9cdec704-f2f7-11e5-84a9-2e30f9b3baee.png)
 
I removed the highlight on scroll so that the problem does not occur.