### PR TITLE
Denominator ==> Note Value

### DIFF
--- a/js/basicblocks.js
+++ b/js/basicblocks.js
@@ -281,11 +281,11 @@ function initBasicProtoBlocks(palettes, blocks) {
     var rhythm = new ProtoBlock('rhythm');
     rhythm.palette = palettes.dict['matrix'];
     blocks.protoBlockDict['rhythm'] = rhythm;
-    rhythm.staticLabels.push(_('rhythm'), _('number of notes'), _('denominator'));
+    rhythm.staticLabels.push(_('rhythm'), _('number of notes'), _('note value'));
     rhythm.extraWidth = 10;
     rhythm.adjustWidthToLabel();
     rhythm.defaults.push(3);
-    rhythm.defaults.push(1);
+    rhythm.defaults.push(4);
     rhythm.twoArgBlock();
     rhythm.dockTypes[1] = 'anyin';
     rhythm.dockTypes[2] = 'anyin';


### PR DESCRIPTION
Denominator ==> Note Value | Change default back for rhythm block; keep 3/1 for tuplet

>  I am checking out the latest commit--actually, I realized what the
> change was from reading the diffs directly on my phone (good for me! Anyhow...)
> 
> I like the change, but for /rhythm/ blocks nestled in tuplets only (for
> whatever reason, I thought we were only changing the defaults for the
> rhythm blocks within tuplets)
> 
> I do not like "denominator" instead of "note value" for just the rhythm
> block.
> 
> I really do not like having a default value of 1 (basically a whole
> note) for the rhythm block (aside from when it is inside tuplet).
> 
> **What I propose**
> 
> 1. Keep rhythm blocks how they were.
> 
> 2. Just change the default for the /rhythm/ block when a /tuplet/ block is pulled from the palette.
> 
> (I experimented with many things. Our current implementation may be "as good as it gets"--maybe it is the job a a widget to help a user understand the behind-the-scenes math a little better.