### PR TITLE
More fixes to Turtle Blink task - in particular removal of delay and volume scaling

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -4309,7 +4309,7 @@ function Logo(pitchtimematrix, pitchdrummatrix, rhythmruler, pitchstaircase, tem
                         }
 
                         console.log("notes to play " + notes + ' ' + noteBeatValue);
-                        logo.turtles.turtleList[turtle].blink(duration);
+                        logo.turtles.turtleList[turtle].blink(duration,last(logo.polyVolume[turtle]));
                         if (notes.length > 0) {
                             var len = notes[0].length;
 

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -39,6 +39,8 @@ function Turtle (name, turtles, drum) {
     this.y = 0;
     this.bitmap = null;
     this.skinChanged = false;  // Should we reskin the turtle on clear?
+    this.blinkFinished = true;
+    this.beforeBlinkSize = null;
 
     // Which start block is assocated with this turtle?
     this.startBlock = null;
@@ -976,32 +978,37 @@ function Turtle (name, turtles, drum) {
         }
     };
 
-    this.blink = function(duration) {
+    this.blink = function(duration,volume) {
         var turtle = this;
-        var scalefactor = 60/55;
+        var sizeinuse;
+        if (this.blinkFinished==false){
+            sizeinuse = this.beforeBlinkSize;
+        } else {
+            sizeinuse = turtle.bitmap.scaleX;
+            this.beforeBlinkSize = sizeinuse;
+        }
+        this.blinkFinished = false;
+        turtle.container.uncache();
+        var scalefactor = 60 / 55;
+        var volumescalefactor = 4 * (volume + 200) / 1000;
+        //Conversion: volume of 1 = 0.804, volume of 50 = 1, volume of 100 = 1.196
         turtle.bitmap.alpha = 0.5;
-        turtle.bitmap.scaleX = turtle.bitmap.scaleX*scalefactor;
+        turtle.bitmap.scaleX = sizeinuse * scalefactor * volumescalefactor;
         turtle.bitmap.scaleY = turtle.bitmap.scaleX;
         turtle.bitmap.scale = turtle.bitmap.scaleX;
         var isSkinChanged = turtle.skinChanged;
         turtle.skinChanged = true;
-        turtle.container.uncache();
-        turtle.turtles.refreshCanvas();
-        var bounds = turtle.container.getBounds();
-        turtle.container.cache(bounds.x, bounds.y, bounds.width, bounds.height);
-        turtle.turtles.refreshCanvas();
+        createjs.Tween.get(turtle.bitmap).to({alpha: 1, scaleX: sizeinuse, scaleY: sizeinuse, scale: sizeinuse}, 500 / duration);
         setTimeout(function() {
-            turtle.bitmap.alpha = 1;
-            turtle.bitmap.scaleX = turtle.bitmap.scaleX/scalefactor;
+            turtle.bitmap.scaleX = sizeinuse;
             turtle.bitmap.scaleY = turtle.bitmap.scaleX;
             turtle.bitmap.scale = turtle.bitmap.scaleX;
             turtle.skinChanged = isSkinChanged;
-            turtle.container.uncache();
             var bounds = turtle.container.getBounds();
             turtle.container.cache(bounds.x, bounds.y, bounds.width, bounds.height);
-            turtle.turtles.refreshCanvas();
-        //1000*(1/duration)/2
-        }, 500/duration);
+            this.blinkFinished = true;
+        //It's 500/duration because 1000ms * (1 / duration) / 2
+        }, 500 / duration);
     };
 };
 
@@ -1073,7 +1080,7 @@ function Turtles(canvas, stage, refreshCanvas) {
         this.stage.addChild(myTurtle.drawingCanvas);
         // In theory, this prevents some unnecessary refresh of the
         // canvas.
-        myTurtle.drawingCanvas.tickEnabled = false;
+        //myTurtle.drawingCanvas.tickEnabled = false;
 
         var turtleImage = new Image();
         i %= 10;


### PR DESCRIPTION
GCI 2016 - eohomegrownapps

I have implemented a note volume scale factor which scales the turtles
according to volume of notes - volume of 1 = 0.804*original, volume of
50 = 1*original, volume of 100 = 1.196*original where original is the
current turtle size * the scale factor of 60/55. You will notice that
this.blinkFinished and this.beforeBlinkSize have been added; these are
due to the fact that sometimes (i.e. when the tab is not in focus)
notes may play before the duration of the previous note is finished. So
if the blink function is called before the previous blink is finished
it will use a cached value of the turtle’s original size to prevent it
using the expanded size as the original size and expanding itself
further. I have also added tweening meaning the turtle will gradually
return to its original size making the exit from the blink more
elegant. However, for this to be possible (and for the delay to be
removed) I had to comment out myTurtle.drawingCanvas.tickEnabled =
false; in js/turtle.js - I hope this will not be an issue as the
comments state you only did this to “prevent some unnecessary refresh
of the canvas”.