### PR TITLE
Fixed #394; Removed unneeded doubled scripts' declarations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html>
-
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <title>Music Blocks - a collection of tools for exploring musical concepts</title>
@@ -17,11 +16,6 @@
   <script src="lib/tone.min.js"></script>
   <script src="lib/jquery.ruler.js"></script>
   <script src="lib/modernizr-2.6.2.min.js"></script>
-
-  <script type="text/javascript"></script>
-
-  <script src="//code.jquery.com/jquery-2.1.4.js"></script>
-  <script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
 
   <link rel="prefetch" type="application/l10n" href="./localization.ini" />
   <script data-main="js/loader" src="lib/require.js"></script>
@@ -345,5 +339,4 @@
   <div id="modewidget" overflow-x="auto" ondrag="moveModeWidget(event)" onmouseup="moveModeWidget(event)"></div>    
   <div id="helpElem"></div>
 </body>
-
 </html>


### PR DESCRIPTION
We have libararies stored locally, no needed to take them from websites what slowes down load time and additionally is double declaration of a one script. (However, FB SDK shouldn't be stored locally and we can't download it and put into `lib` folder.)

In the commit I have also removed completely blank `<script></script>` block and unnecessary new lines. 

