### PR TITLE
Fixed #popdown-palette:last-child selector

### DIFF
--- a/css/activity.css
+++ b/css/activity.css
@@ -10,7 +10,7 @@
     background: rgba(255, 255, 255, 0.85);
 }
 
-#popdown-palette: last-child {
+#popdown-palette:last-child {
     margin-bottom: 2.5em;
 }
 


### PR DESCRIPTION
The space between "#popdown-palette:" and "last-child" was invalidating this selector. Removing the space fixed the issue.