### PR TITLE
Hide "Stop Button" when fatal error reached, and make "no input in clamp" error non-fatal

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1885,14 +1885,14 @@ define(function (require) {
                 errorArtwork['zerodivide'].visible = true;
                 stage.setChildIndex(errorArtwork['zerodivide'], stage.getNumChildren() - 1);
                 break;
-  	   case NOINPUTERRORMSG:
-                errorArtwork['noinput'].visible = true;
-                stage.setChildIndex(errorArtwork['noinput'], stage.getNumChildren() - 1);
-                break;			    
-            case NANERRORMSG:
+  	    case NANERRORMSG:
                 errorArtwork['notanumber'].visible = true;
                 stage.setChildIndex(errorArtwork['notanumber'], stage.getNumChildren() - 1);
                 break;
+	    case NOINPUTERRORMSG:
+                errorArtwork['noinput'].visible = true;
+                stage.setChildIndex(errorArtwork['noinput'], stage.getNumChildren() - 1);
+                break;			    
             default:
                 var errorMsgContainer = errorMsgText.parent;
                 errorMsgContainer.visible = true;

--- a/js/activity.js
+++ b/js/activity.js
@@ -1816,6 +1816,7 @@ define(function (require) {
         };
 
         function errorMsg(msg, blk, text) {
+	     _hideStopButton(); //Hide the button, as the program is going to be terminated
             if (errorMsgText == null) {
                 // The container may not be ready yet... so do nothing
                 return;
@@ -1824,7 +1825,6 @@ define(function (require) {
 	    	//Do nothing if there's an empty clamp -- let it pass
 		return;
 	    }
-            _hideStopButton(); //Hide the button, as the program is going to be terminated
             if (blk !== undefined && blk != null && !blocks.blockList[blk].collapsed) {
                 var fromX = (canvas.width - 1000) / 2;
                 var fromY = 128;

--- a/js/activity.js
+++ b/js/activity.js
@@ -1821,10 +1821,6 @@ define(function (require) {
                 // The container may not be ready yet... so do nothing
                 return;
             }
-	    if (msg === NOINPUTERRORMSG) {
-	    	//Do nothing if there's an empty clamp -- let it pass
-		return;
-	    }
             if (blk !== undefined && blk != null && !blocks.blockList[blk].collapsed) {
                 var fromX = (canvas.width - 1000) / 2;
                 var fromY = 128;
@@ -1889,6 +1885,10 @@ define(function (require) {
                 errorArtwork['zerodivide'].visible = true;
                 stage.setChildIndex(errorArtwork['zerodivide'], stage.getNumChildren() - 1);
                 break;
+  	   case NOINPUTERRORMSG:
+                errorArtwork['noinput'].visible = true;
+                stage.setChildIndex(errorArtwork['noinput'], stage.getNumChildren() - 1);
+                break;			    
             case NANERRORMSG:
                 errorArtwork['notanumber'].visible = true;
                 stage.setChildIndex(errorArtwork['notanumber'], stage.getNumChildren() - 1);

--- a/js/activity.js
+++ b/js/activity.js
@@ -1820,6 +1820,10 @@ define(function (require) {
                 // The container may not be ready yet... so do nothing
                 return;
             }
+	    if (msg === NOINPUTERRORMSG) {
+	    	//Do nothing if there's an empty clamp -- let it pass
+		return;
+	    }
             _hideStopButton(); //Hide the button, as the program is going to be terminated
             if (blk !== undefined && blk != null && !blocks.blockList[blk].collapsed) {
                 var fromX = (canvas.width - 1000) / 2;
@@ -1888,10 +1892,6 @@ define(function (require) {
             case NANERRORMSG:
                 errorArtwork['notanumber'].visible = true;
                 stage.setChildIndex(errorArtwork['notanumber'], stage.getNumChildren() - 1);
-                break;
-            case NOINPUTERRORMSG:
-                errorArtwork['noinput'].visible = true;
-                stage.setChildIndex(errorArtwork['noinput'], stage.getNumChildren() - 1);
                 break;
             default:
                 var errorMsgContainer = errorMsgText.parent;

--- a/js/activity.js
+++ b/js/activity.js
@@ -562,8 +562,7 @@ define(function (require) {
         var msgText = null;
 
         // ErrorMsg block
-        var 
-	Text = null;
+        var errorMsgText = null;
         var errorMsgArrow = null;
         var errorArtwork = {};
         const ERRORARTWORK = ['emptybox', 'emptyheap', 'negroot', 'noinput', 'zerodivide', 'notanumber', 'nostack', 'notastring', 'nomicrophone'];

--- a/js/activity.js
+++ b/js/activity.js
@@ -562,7 +562,8 @@ define(function (require) {
         var msgText = null;
 
         // ErrorMsg block
-        var errorMsgText = null;
+        var 
+	Text = null;
         var errorMsgArrow = null;
         var errorArtwork = {};
         const ERRORARTWORK = ['emptybox', 'emptyheap', 'negroot', 'noinput', 'zerodivide', 'notanumber', 'nostack', 'notastring', 'nomicrophone'];
@@ -1820,7 +1821,7 @@ define(function (require) {
                 // The container may not be ready yet... so do nothing
                 return;
             }
-
+            _hideStopButton(); //Hide the button, as the program is going to be terminated
             if (blk !== undefined && blk != null && !blocks.blockList[blk].collapsed) {
                 var fromX = (canvas.width - 1000) / 2;
                 var fromY = 128;

--- a/js/logo.js
+++ b/js/logo.js
@@ -950,7 +950,11 @@ function Logo(pitchtimematrix, pitchdrummatrix, rhythmruler, pitchstaircase, tem
         var args = [];
         if (logo.blocks.blockList[blk].protoblock.args > 0) {
             for (var i = 1; i < logo.blocks.blockList[blk].protoblock.args + 1; i++) {
+                if (logo.blocks.blockList[blk].protoblock.dockTypes[i] === 'in' && logo.blocks.blockList[blk].connections[i] == null){
+                    console.log('skipping null inflow args');
+                } else {
                 args.push(logo.parseArg(logo, turtle, logo.blocks.blockList[blk].connections[i], blk, receivedArg));
+                }
             }
         }
 

--- a/js/logo.js
+++ b/js/logo.js
@@ -953,7 +953,7 @@ function Logo(pitchtimematrix, pitchdrummatrix, rhythmruler, pitchstaircase, tem
                 if (logo.blocks.blockList[blk].protoblock.dockTypes[i] === 'in' && logo.blocks.blockList[blk].connections[i] == null){
                     console.log('skipping null inflow args');
                 } else {
-                args.push(logo.parseArg(logo, turtle, logo.blocks.blockList[blk].connections[i], blk, receivedArg));
+                    args.push(logo.parseArg(logo, turtle, logo.blocks.blockList[blk].connections[i], blk, receivedArg));
                 }
             }
         }


### PR DESCRIPTION
Fixed @pikurasa's issue -- make it so that the stop button is hidden every time an error is reached.

Does not fix @Hrishi1999's issue; the stop button still momentarily appear nonetheless.

Fixes Issue: https://github.com/walterbender/musicblocks/issues/401