### PR TITLE
Fixed #451; require palette labels to be written with title case

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -742,7 +742,7 @@ function PopdownPalette(palettes) {
                                      alt="{' + _('popout') + '}" \
                                      title="{' + _('popout') + '}" /> \
                             </h2>',
-                           {i: icon, n: _(name)});
+                           {i: icon, n: toTitleCase(_(name))});
             html += '<ul>';
             this.models[name].update();
             
@@ -945,7 +945,7 @@ function Palette(palettes, name) {
         this.menuContainer.removeAllChildren();
 
         // Create the menu button
-        makePaletteBitmap(this, PALETTEHEADER.replace('fill_color', '#282828').replace('palette_label', _(this.name)).replace(/header_width/g, paletteWidth), this.name, __processHeader, null);
+        makePaletteBitmap(this, PALETTEHEADER.replace('fill_color', '#282828').replace('palette_label', toTitleCase(_(this.name))).replace(/header_width/g, paletteWidth), this.name, __processHeader, null);
     };
 
     this._getDownButtonY = function () {

--- a/js/utils.js
+++ b/js/utils.js
@@ -208,6 +208,14 @@ function _(text) {
     }
 };
 
+function toTitleCase(str) {
+    if (typeof str !== 'string')
+        return;
+    var tempStr = '';
+    if (str.length > 1)
+        tempStr = str.substring(1);
+    return str.toUpperCase()[0] + tempStr;
+}
 
 function processRawPluginData(rawData, palettes, blocks, errorMsg, evalFlowDict, evalArgDict, evalParameterDict, evalSetterDict, evalOnStartList, evalOnStopList) {
     // console.log(rawData);


### PR DESCRIPTION
Changing `turtledefs.js` would require us to change all PO files. Implemented workaround requires palette label to be always written with title case - if it is not, then first char of label gets automatically upper-ed. 

When this PR is merged, I will commit analogous changes to TBJS.

Preview:
![Preview of changes](http://i.imgur.com/F28osXY.png)