### PR TITLE
Fixed #421; resolved logic error with 'rulerSelected'

### DIFF
--- a/js/rhythmruler.js
+++ b/js/rhythmruler.js
@@ -681,10 +681,10 @@ function RhythmRuler () {
 
                 var rulerTable = docById('rulerTable' + drum);
                 for (var j = 0; j < this._dissectHistory[i].length; j++) {
-                    this._rulerSelected = drum;
                     if (this._dissectHistory[i][0][j] == undefined) {
                         continue;
                     }
+                    this._rulerSelected = drum;
 
                     var cell = rulerTable.rows[0].cells[this._dissectHistory[i][0][j][0]];
                     if (cell != undefined) {


### PR DESCRIPTION
`this._rulerSelected` had unexisiting values after restoring session, because it was set before existance condition was checked and applied. The result while undo started to work after doing some another action is that another dissection was requiring an app to set proper `this._rulerSelected` value.