### PR TITLE
Fixed #495; made removal of the only start block impossible

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3626,7 +3626,7 @@ function Blocks(canvas, stage, refreshCanvas, trashcan, updateStage, getStageSca
                 this.turtles.turtleList[turtle].trash = true;
                 this.turtles.turtleList[turtle].container.visible = false;
             } else {
-                this.errorMsg("You can't remove the only start block");
+                this.errorMsg("You must always have at least one start block");
                 console.log('null turtle');
                 return;
             }

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3616,8 +3616,8 @@ function Blocks(canvas, stage, refreshCanvas, trashcan, updateStage, getStageSca
         if (myBlock.name === 'start' || myBlock.name === 'drum') {
             turtle = myBlock.value;
             var turtleNotInTrash = 0;
-            for(var i = 0; i < this.turtles.turtleList.length; i++) {
-                if(!blocks.turtles.turtleList[i].trash) {
+            for (var i = 0; i < this.turtles.turtleList.length; i++) {
+                if (!this.turtles.turtleList[i].trash) {
                     turtleNotInTrash += 1;
                 }
             }
@@ -3626,7 +3626,9 @@ function Blocks(canvas, stage, refreshCanvas, trashcan, updateStage, getStageSca
                 this.turtles.turtleList[turtle].trash = true;
                 this.turtles.turtleList[turtle].container.visible = false;
             } else {
+                this.errorMsg("You can't remove the only start block");
                 console.log('null turtle');
+                return;
             }
         } else if (myBlock.name === 'action') {
             this.deleteActionBlock(myBlock);


### PR DESCRIPTION
removal of the only start block is now made impossible, user gets an error message after trying to perform such action

this is actually the fix of a logic error - function deteced no turtle will be left, but didn't stop proceeding