### PR TITLE
Fixed #492; waitFor now gets connected with other blocks

### DIFF
--- a/js/protoblocks.js
+++ b/js/protoblocks.js
@@ -198,10 +198,10 @@ function ProtoBlock(name) {
     // E.g., wait for
     this.oneBooleanArgBlock = function() {
         this.args = 1;
-        this.size = 3;
-        this.dockTypes.push('in');
-        this.dockTypes.push('booleanin');
+        this.size = 2.6;
         this.dockTypes.push('out');
+        this.dockTypes.push('booleanin');
+        this.dockTypes.push('in');
         this.generator = this.oneBooleanArgBlockGenerator;
     };
 
@@ -213,7 +213,6 @@ function ProtoBlock(name) {
         svg.setSlot(true);
         svg.setBoolean(true);
         svg.setClampCount(0);
-        svg.setExpand(0, 0, 0, 0);
         if (this.fontsize) {
             svg.setFontSize(this.fontsize);
         }


### PR DESCRIPTION
1. dockTypes of waitFor were mismatched, they should've been placed in reverse order
2. waitFor size is not a standard one, it has been adjusted to make it looking well in clamps 