### PR TITLE
refactor rhythmruler code

### DIFF
--- a/css/activity.css
+++ b/css/activity.css
@@ -400,14 +400,14 @@ table {
     background: rgba(255, 255, 255, 0.85) !important;
 }
 
-#rulerBpdy {
+#rulerTableDiv {
     position: relative;
     border: 0 !important;
     background: rgba(255, 255, 255, 0.85) !important;
     width: 680px;
 }
 
-#drumDiv {
+#rulerButtonsDiv {
     position: relative;
     width: 400px;
     left: 0px;

--- a/css/activity.css
+++ b/css/activity.css
@@ -411,7 +411,6 @@ table {
 
 #rulerButtonsDiv {
     position: relative;
-    width: 456px;
     left: 0px;
     top: 0px;
     border: 0 !important;
@@ -423,15 +422,12 @@ table {
     left: 0px;
     top: 0px;
     right: 5em;
-    width: 675px;
-    height: 300px;
     overflow-y:auto;
     overflow-x:none;
     background: rgba(255, 255, 255, 0.85);
 }
 
 #innerdiv {
-    width: 600px;
     overflow-x:auto;
     margin-left: 53px;
 }

--- a/css/activity.css
+++ b/css/activity.css
@@ -350,7 +350,7 @@ table {
     left: 30%;
     border-style: solid;
     border: 0 !important;
-    background: rgba(255, 225, 255, 0.85);
+    background: rgba(255, 255, 255, 0.85);
     -webkit-user-select: none;
     overflow-x: scroll !important;
 }
@@ -361,7 +361,7 @@ table {
     left: 20%;
     border-style: solid;
     border: 0 !important;
-    background: rgba(255, 225, 255, 0.85);
+    background: rgba(255, 255, 255, 0.85);
     -webkit-user-select: none;
     overflow-x: scroll !important;
 }
@@ -372,7 +372,7 @@ table {
     left: 20%;
     border-style: solid;
     border: 0 !important;
-    background: rgba(255, 225, 255, 0.85);
+    background: rgba(255, 255, 255, 0.85);
     -webkit-user-select: none;
 }
 
@@ -382,7 +382,7 @@ table {
     left: 30%;
     border-style: solid;
     border: 0 !important;
-    background: rgba(255, 225, 255, 0.85);
+    background: rgba(255, 255, 255, 0.85);
     -webkit-user-select: none;
     overflow-x: scroll !important;
 }
@@ -393,25 +393,52 @@ table {
     left: 200px;
 }
 
-#rulerBody {
+#rulerDiv {
     position: absolute;
     top: 20%;
     left: 30%;
-    border-style: solid;
+    background: rgba(255, 255, 255, 0.85) !important;
+}
+
+#rulerBpdy {
+    position: relative;
     border: 0 !important;
-    background: rgba(255, 225, 255, 0.85);
-    -webkit-user-select: none;
-    overflow-x: scroll !important;
+    background: rgba(255, 255, 255, 0.85) !important;
+    width: 680px;
 }
 
 #drumDiv {
-    position: absolute;
-    top: 20%;
-    left: 26%;
-    border-style: solid;
+    position: relative;
+    width: 400px;
+    left: 0px;
+    top: 0px;
     border: 0 !important;
-    background: rgba(255, 225, 255, 0.85);
-    -webkit-user-select: none;
+    background: rgba(255, 255, 255, 0.85);
+}
+
+#outerdiv {
+    position: absolute;
+    left: 0px;
+    top: 55px;
+    right: 5em;
+    width: 675px;
+    height: 300px;
+    overflow-y:auto;
+    overflow-x:none;
+    background: rgba(255, 255, 255, 0.85);
+}
+
+#innerdiv {
+    width: 600px;
+    overflow-x:auto;
+    margin-left: 53px;
+}
+
+.headcol {
+    position:absolute;
+    left:2px;
+    top:auto;
+    vertical-align: middle;
 }
 
 #pitchstaircase {
@@ -420,7 +447,7 @@ table {
   left: 30%;
   border-style: solid;
   border: 0 !important;
-  background: rgba(255, 225, 255, 0.85);
+  background: rgba(255, 255, 255, 0.85);
   -webkit-user-select: none;
   overflow-y: scroll !important;
 }
@@ -432,7 +459,7 @@ table {
   left: 25%;
   border-style: solid;
   border: 0 !important;
-  background: rgba(255, 225, 255, 0.85);
+  background: rgba(255, 255, 255, 0.85);
   -webkit-user-select: none;
   overflow-y: scroll !important;
 }
@@ -443,7 +470,7 @@ table {
   left: 30%;
   border-style: solid;
   border: 0 !important;
-  background: rgba(255, 225, 255, 0.85);
+  background: rgba(255, 255, 255, 0.85);
   -webkit-user-select: none;
   overflow-y: scroll !important;
 }
@@ -454,7 +481,7 @@ table {
   left: 30%;
   border-style: solid;
   border: 0 !important;
-  background: rgba(255, 225, 255, 0.85);
+  background: rgba(255, 255, 255, 0.85);
   -webkit-user-select: none;
 }
 
@@ -474,7 +501,7 @@ table {
   left: 20%;
   border-style: solid;
   border: 0 !important;
-  background: rgba(255, 225, 255, 0.85);
+  background: rgba(255, 255, 255, 0.85);
   -webkit-user-select: none;
 }
 

--- a/css/activity.css
+++ b/css/activity.css
@@ -402,6 +402,8 @@ table {
 
 #rulerTableDiv {
     position: relative;
+    left: 0px;
+    top: 0px;
     border: 0 !important;
     background: rgba(255, 255, 255, 0.85) !important;
     width: 680px;
@@ -409,7 +411,7 @@ table {
 
 #rulerButtonsDiv {
     position: relative;
-    width: 400px;
+    width: 456px;
     left: 0px;
     top: 0px;
     border: 0 !important;
@@ -419,7 +421,7 @@ table {
 #outerdiv {
     position: absolute;
     left: 0px;
-    top: 55px;
+    top: 0px;
     right: 5em;
     width: 675px;
     height: 300px;

--- a/header-icons/grab.svg
+++ b/header-icons/grab.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#FFFFFF">
+  <!ENTITY stroke_color "#FFFFFF">
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+<path d="M11,18 Q13,16 15,19 L15,31 Q16,33 17,31 L17,7 Q19,5 21,7 L21,25 Q22,27 23,25 L23,7 Q25,5 27,7 L27,25 Q28,27 29,25 L29,7 Q31,5 33,7 L33,25 Q34,27 35,25 L35,12 Q37,10 39,12 L39,37 Q39,44 33,45 L17,45 Q11,45 11,37" style="fill:&fill_color;;stroke:&stroke_color;;stroke-width:.3"/></svg>

--- a/index.html
+++ b/index.html
@@ -333,8 +333,8 @@
     <div id="pitchdrummatrix" overflow-x="auto" ondrag="movePitchDrumMatrix(event)" onmouseup="movePitchDrumMatrix(event)"></div>
     <div id="dissectNumber"></div>
     <div id="rulerDiv" draggable="true">
-      <div id="drumDiv"></div>
-      <div id="rulerBody"></div>
+      <div id="rulerButtonsDiv"></div>
+      <div id="rulerTableDiv"></div>
     </div>
     <div id="pitchstaircase" style="visibility:hidden"></div>
     <div id="pitchSliderDiv" style="visibility:hidden"></div>

--- a/index.html
+++ b/index.html
@@ -331,7 +331,6 @@
 
     <div id="pitchtimematrix" overflow-x="auto" draggable="true" ondrag="moveMatrix(event)" onmouseup="if (isDragging) moveMatrix(event); isDragging = false;"></div>
     <div id="pitchdrummatrix" overflow-x="auto" ondrag="movePitchDrumMatrix(event)" onmouseup="movePitchDrumMatrix(event)"></div>
-    <div id="dissectNumber"></div>
     <div id="rulerDiv" draggable="true">
       <div id="rulerButtonsDiv"></div>
       <div id="rulerTableDiv"></div>

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
             }(document, 'script', 'facebook-jssdk'));
         } catch (e) {}
     -->
-    
+
     $(function() {
         $("#pitchtimematrix").draggable();
     });
@@ -81,57 +81,33 @@
     $(function() {
         $("#pitchdrummatrix").draggable();
     });
-        
+
     $(function() {
-        <!-- drag rhythm ruler when dragging drum play buttons -->
-        $('#drumDiv').draggable({
-            drag: function() {
-                jQuery('#rulerBody').css('top',jQuery(this).position().top);
-                jQuery('#rulerBody').css('left',jQuery(this).position().left + $(window).innerWidth/25);
-            },
-            stop: function(){
-                jQuery('#rulerBody').css('top',jQuery(this).position().top);                     
-                jQuery('#rulerBody').css('left',jQuery(this).position().left + $(window).innerWidth/25);                                        
-            }
-        });
+        $("#rulerDiv").draggable();
     });
-        
-    $(function() {
-        <!-- drag drum play buttons when dragging rhythm ruler -->
-        $('#rulerBody').draggable({
-            drag: function() {
-                jQuery('#drumDiv').css('top',jQuery(this).position().top);
-                jQuery('#drumDiv').css('left',jQuery(this).position().left - $(window).innerWidth/25);
-            },
-            stop: function(){
-                jQuery('#drumDiv').css('top',jQuery(this).position().top);                     
-                jQuery('#drumDiv').css('left',jQuery(this).position().left - $(window).innerWidth/25);                                        
-            }
-        });
-    });
-        
+
     $(function() {
         $('#pitchstaircase').draggable({
             drag: function() {
-                jQuery('#playPitch').css('top',jQuery(this).position().top);
-                jQuery('#playPitch').css('left',jQuery(this).position().left - $(window).innerWidth/25);
+                jQuery('#playPitch').css('top', jQuery(this).position().top);
+                jQuery('#playPitch').css('left', jQuery(this).position().left - $(window).innerWidth/25);
             },
             stop: function(){
-                jQuery('#playPitch').css('top',jQuery(this).position().top);                     
-                jQuery('#playPitch').css('left',jQuery(this).position().left - $(window).innerWidth/25);                                        
+                jQuery('#playPitch').css('top', jQuery(this).position().top);
+                jQuery('#playPitch').css('left', jQuery(this).position().left - $(window).innerWidth/25);
             }
         });
     });
-        
+
     $(function() {
         $('#playPitch').draggable({
             drag: function() {
-                jQuery('#pitchstaircase').css('top',jQuery(this).position().top);
-                jQuery('#pitchstaircase').css('left',jQuery(this).position().left + $(window).innerWidth/25);
+                jQuery('#pitchstaircase').css('top', jQuery(this).position().top);
+                jQuery('#pitchstaircase').css('left', jQuery(this).position().left + $(window).innerWidth/25);
             },
             stop: function(){
-                jQuery('#pitchstaircase').css('top',jQuery(this).position().top);                     
-                jQuery('#pitchstaircase').css('left',jQuery(this).position().left + $(window).innerWidth/25);                                        
+                jQuery('#pitchstaircase').css('top', jQuery(this).position().top);
+                jQuery('#pitchstaircase').css('left', jQuery(this).position().left + $(window).innerWidth/25);
             }
         });
     });
@@ -139,25 +115,25 @@
     $(function() {
         $('#tempoCanvas').draggable({
             drag: function() {
-                jQuery('#tempoDiv').css('left',jQuery(this).position().left);
-                jQuery('#tempoDiv').css('top',jQuery(this).position().top - $(window).innerWidth/30);
+                jQuery('#tempoDiv').css('left', jQuery(this).position().left);
+                jQuery('#tempoDiv').css('top', jQuery(this).position().top - $(window).innerWidth/30);
             },
             stop: function(){
-                jQuery('#tempoDiv').css('left',jQuery(this).position().left);                     
-                jQuery('#tempoDiv').css('top',jQuery(this).position().top - $(window).innerWidth/30);                                        
+                jQuery('#tempoDiv').css('left', jQuery(this).position().left);
+                jQuery('#tempoDiv').css('top', jQuery(this).position().top - $(window).innerWidth/30);
             }
         });
     });
-        
+
     $(function() {
         $('#tempoDiv').draggable({
             drag: function() {
-                jQuery('#tempoCanvas').css('left',jQuery(this).position().left);
-                jQuery('#tempoCanvas').css('top',jQuery(this).position().top + $(window).innerWidth/30);
+                jQuery('#tempoCanvas').css('left', jQuery(this).position().left);
+                jQuery('#tempoCanvas').css('top', jQuery(this).position().top + $(window).innerWidth/30);
             },
             stop: function(){
-                jQuery('#tempoCanvas').css('left',jQuery(this).position().left);                     
-                jQuery('#tempoCanvas').css('top',jQuery(this).position().top + $(window).innerWidth/30);                                        
+                jQuery('#tempoCanvas').css('left', jQuery(this).position().left);
+                jQuery('#tempoCanvas').css('top', jQuery(this).position().top + $(window).innerWidth/30);
             }
         });
     });
@@ -165,20 +141,20 @@
     $(function() {
         $('#pitchSliderDiv').draggable({
             drag: function() {
-                jQuery('#moveUpSliderDiv').css('left',jQuery(this).position().left);
-                jQuery('#moveUpSliderDiv').css('top',jQuery(this).position().top + $(window).innerWidth/4.4);
-                jQuery('#moveDownSliderDiv').css('left',jQuery(this).position().left);
-                jQuery('#moveDownSliderDiv').css('top',jQuery(this).position().top + $(window).innerWidth/3.8);
+                jQuery('#moveUpSliderDiv').css('left', jQuery(this).position().left);
+                jQuery('#moveUpSliderDiv').css('top', jQuery(this).position().top + $(window).innerWidth/4.4);
+                jQuery('#moveDownSliderDiv').css('left', jQuery(this).position().left);
+                jQuery('#moveDownSliderDiv').css('top', jQuery(this).position().top + $(window).innerWidth/3.8);
             },
             stop: function(){
-                jQuery('#moveUpSliderDiv').css('left',jQuery(this).position().left);                     
-                jQuery('#moveUpSliderDiv').css('top',jQuery(this).position().top + $(window).innerWidth/4.4);
-                jQuery('#moveDownSliderDiv').css('left',jQuery(this).position().left);                     
-                jQuery('#moveDownSliderDiv').css('top',jQuery(this).position().top + $(window).innerWidth/3.8);
+                jQuery('#moveUpSliderDiv').css('left', jQuery(this).position().left);
+                jQuery('#moveUpSliderDiv').css('top', jQuery(this).position().top + $(window).innerWidth/4.4);
+                jQuery('#moveDownSliderDiv').css('left', jQuery(this).position().left);
+                jQuery('#moveDownSliderDiv').css('top', jQuery(this).position().top + $(window).innerWidth/3.8);
             }
         });
     });
-        
+
     $(function() {
         $("#statusmatrix").draggable();
     });
@@ -355,9 +331,11 @@
 
     <div id="pitchtimematrix" overflow-x="auto" draggable="true" ondrag="moveMatrix(event)" onmouseup="if (isDragging) moveMatrix(event); isDragging = false;"></div>
     <div id="pitchdrummatrix" overflow-x="auto" ondrag="movePitchDrumMatrix(event)" onmouseup="movePitchDrumMatrix(event)"></div>
-    <div id="rulerBody" overflow-x="auto"></div>
     <div id="dissectNumber"></div>
-    <div id="drumDiv"></div>
+    <div id="rulerDiv" draggable="true">
+      <div id="drumDiv"></div>
+      <div id="rulerBody"></div>
+    </div>
     <div id="pitchstaircase" style="visibility:hidden"></div>
     <div id="pitchSliderDiv" style="visibility:hidden"></div>
     <div id="playPitch" style="visibility:hidden"></div>

--- a/js/activity.js
+++ b/js/activity.js
@@ -1510,7 +1510,7 @@ define(function (require) {
         function _doOpenSamples() {
             localStorage.setItem('isMatrixHidden', document.getElementById('pitchtimematrix').style.visibility);
             localStorage.setItem('isPitchDrumMatrixHidden', document.getElementById('pitchdrummatrix').style.visibility);
-            localStorage.setItem('isRhythmRulerHidden', document.getElementById('rulerBody').style.visibility);
+            localStorage.setItem('isRhythmRulerHidden', document.getElementById('rulerDiv').style.visibility);
             localStorage.setItem('isStatusHidden', document.getElementById('statusmatrix').style.visibility);
             localStorage.setItem('isModeWidgetHidden', document.getElementById('modewidget').style.visibility);
 
@@ -1524,9 +1524,10 @@ define(function (require) {
                 document.getElementById('pitchdrummatrix').style.border = 0;
             }
 
-            if(document.getElementById('rulerBody').style.visibility !== 'hidden') {
-                document.getElementById('rulerBody').style.visibility = 'hidden';
-                document.getElementById('rulerBody').style.border = 0;
+            if(document.getElementById('rulerDiv').style.visibility !== 'hidden') {
+                document.getElementById('rulerDiv').style.visibility = 'hidden';
+                document.getElementById('rulerTableDiv').style.visibility = 'hidden';
+                document.getElementById('rulerButtonsDiv').style.visibility = 'hidden';
             }
 
             if (document.getElementById('statusmatrix').style.visibility !== 'hidden') {

--- a/js/rhythmruler.js
+++ b/js/rhythmruler.js
@@ -18,6 +18,14 @@
 // rulerTableDiv is for the drum buttons (fixed first col) and the ruler cells
 
 function RhythmRuler () {
+    const BUTTONDIVWIDTH = 476;  // 8 buttons 476 = (55 + 4) * 8
+    const OUTERWINDOWWIDTH = 675;
+    const INNERWINDOWWIDTH = 600;
+    const RULERHEIGHT = 82;  // A little extra than we need for FF.
+    const BUTTONSIZE = 51;
+    const ICONSIZE = 32;
+    const BACKSPACE = 8;
+
     // There is one ruler per drum.
     this.Drums = [];
     // Rulers, one per drum, contain the subdivisions defined by rhythm blocks.
@@ -41,7 +49,7 @@ function RhythmRuler () {
     this._rulerPlaying = -1;
 
     this._noteWidth = function (noteValue) {
-        return Math.floor(EIGHTHNOTEWIDTH * (8 / noteValue) * this._cellScale * 3);
+        return Math.floor(EIGHTHNOTEWIDTH * (8 / noteValue) * 3);
     };
 
     this._calculateZebraStripes = function(rulerno) {
@@ -443,25 +451,25 @@ function RhythmRuler () {
         }
 
         var w = window.innerWidth;
-        this._cellScale = 1.0; //  w / 1200;
-        var iconSize = Math.floor(this._cellScale * 32);
+        this._cellScale = 1.0;
+        var iconSize = ICONSIZE;
 
         // The widget buttons
 	var widgetButtonsDiv = docById('rulerButtonsDiv');
         widgetButtonsDiv.style.display = 'inline';
         widgetButtonsDiv.style.visibility = 'visible';
-        // widgetButtonsDiv.style.border = 0;
+        widgetButtonsDiv.style.width = BUTTONDIVWIDTH;
         widgetButtonsDiv.innerHTML = '<table id="widgetButtonTable"></table>';
 
         var buttonTable = docById('widgetButtonTable');
-        // buttonTable.width = '456px';
+        // buttonTable.style.
         var header = buttonTable.createTHead();
         var row = header.insertRow(0);
 
         // For the button callbacks
         var that = this;
 
-        var cell = this._addButton(row, 'play-button.svg', iconSize, _('play all'));
+        var cell = this._addButton(row, 'play-button.svg', iconSize, _('play all'), '');
 
         cell.onclick=function() {
             if (that._playing) {
@@ -495,12 +503,12 @@ function RhythmRuler () {
             }
         };
 
-        var cell = this._addButton(row, 'export-chunk.svg', iconSize, _('save rhythms'));
+        var cell = this._addButton(row, 'export-chunk.svg', iconSize, _('save rhythms'), '');
         cell.onclick=function() {
             that._save(0);
         };
 
-        var cell = this._addButton(row, 'export-drums.svg', iconSize, _('save drum machine'));
+        var cell = this._addButton(row, 'export-drums.svg', iconSize, _('save drum machine'), '');
         cell.onclick=function() {
             that._saveDrumMachine(0);
         };
@@ -510,32 +518,31 @@ function RhythmRuler () {
         cell.innerHTML = '<input id="dissectNumber" style="-webkit-user-select: text;-moz-user-select: text;-ms-user-select: text;" class="dissectNumber" type="dussectNumber" value="' + 2 + '" />';
         cell.style.top = 0;
         cell.style.left = 0;
-        cell.style.width = "51px"; // Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
+        cell.style.width = BUTTONSIZE + 'px';
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
-        cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
+        cell.style.height = Math.floor(MATRIXBUTTONHEIGHT) + 'px';
         cell.style.backgroundColor = MATRIXBUTTONCOLOR;
         // FIXME: rough workaround for #508, investigate reasons why
         // the backspace press doesn't work by default
         var numberInput = docById('dissectNumber');
-        const BACKSPACE = 8;
         numberInput.addEventListener('keydown', function(event) {
             console.log(event.keyCode);
            if (event.keyCode === BACKSPACE)
                numberInput.value = numberInput.value.substring(0, numberInput.value.length-1);
         });
 
-        var cell = this._addButton(row, 'restore-button.svg', iconSize, _('undo'));
+        var cell = this._addButton(row, 'restore-button.svg', iconSize, _('undo'), '');
         cell.onclick=function() {
             that._undo();
         };
 
-        var cell = this._addButton(row, 'erase-button.svg', iconSize, _('clear'));
+        var cell = this._addButton(row, 'erase-button.svg', iconSize, _('clear'), '');
         cell.onclick=function() {
             that._clear();
         };
 
-        var cell = this._addButton(row, 'close-button.svg', iconSize, _('close'));
+        var cell = this._addButton(row, 'close-button.svg', iconSize, _('close'), '');
 
         cell.onclick=function() {
             // Save the new dissect history.
@@ -572,7 +579,7 @@ function RhythmRuler () {
             that._playingAll = false;
         };
 
-        var cell = this._addButton(row, 'grab.svg', iconSize, _('drag'));
+        var cell = this._addButton(row, 'grab.svg', iconSize, _('drag'), '');
 
         // The ruler table
 	var rulerTableDiv = docById('rulerTableDiv');
@@ -585,12 +592,26 @@ function RhythmRuler () {
 	// scroll horizontally.
         rulerTableDiv.innerHTML = '<div id="outerdiv"><div id="innerdiv"><table id="rhythmRulerTable"></table></div></div>';
 
+        var n = Math.max(Math.floor((window.innerHeight * 0.5) / 100), 2);
+        if (this.Rulers.length > n) {
+            docById('outerdiv').style.height = 82 * n + 'px';
+            var w = Math.max(Math.min(window.innerWidth, OUTERWINDOWWIDTH), BUTTONDIVWIDTH);
+            docById('outerdiv').style.width = w + 'px';
+        } else {
+            docById('outerdiv').style.height = 82 * this.Rulers.length + 'px';
+            var w = Math.max(Math.min(window.innerWidth, OUTERWINDOWWIDTH - 20), BUTTONDIVWIDTH);
+            docById('outerdiv').style.width = w + 'px';
+        }
+
+        var w = Math.max(Math.min(window.innerWidth, INNERWINDOWWIDTH), BUTTONDIVWIDTH - BUTTONSIZE);
+	docById('innerdiv').style.width = w + 'px';
+
         // Each row in the ruler table contains a play button in the
         // first column and a ruler table in the second column.
         var rhythmRulerTable = docById('rhythmRulerTable');
         for (var i = 0; i < this.Rulers.length; i++) {
             var rhythmRulerTableRow = rhythmRulerTable.insertRow();
-            var drumcell = this._addButton(rhythmRulerTableRow, 'play-button.svg', iconSize, _('play'));
+            var drumcell = this._addButton(rhythmRulerTableRow, 'play-button.svg', iconSize, _('play'), '<br>');
             drumcell.setAttribute('id', i);
             drumcell.className = "headcol";  // Position fixed when scrolling horizontally
 
@@ -598,7 +619,7 @@ function RhythmRuler () {
                 var id = Number(this.getAttribute('id'));
                 if (that._playing) {
                     if (that._rulerPlaying === id) {
-                        this.innerHTML = '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="' + _('play') + '" alt="' + _('play') + '" height="' + iconSize + '" width="' + iconSize + '" vertical-align="middle">&nbsp;&nbsp;';
+                        this.innerHTML = '<br>&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="' + _('play') + '" alt="' + _('play') + '" height="' + iconSize + '" width="' + iconSize + '" vertical-align="middle">&nbsp;&nbsp;';
                         that._playing = false;
                         that._playingOne = false;
                         that._playingAll = false;
@@ -619,7 +640,7 @@ function RhythmRuler () {
                         that._cellCounter = 0;
                         that._startingTime = null;
                         that._rulerPlaying = id;
-                        this.innerHTML = '&nbsp;&nbsp;<img src="header-icons/pause-button.svg" title="' + _('pause') + '" alt="' + _('pause') + '" height="' + iconSize + '" width="' + iconSize + '" vertical-align="middle">&nbsp;&nbsp;';
+                        this.innerHTML = '<br>&nbsp;&nbsp;<img src="header-icons/pause-button.svg" title="' + _('pause') + '" alt="' + _('pause') + '" height="' + iconSize + '" width="' + iconSize + '" vertical-align="middle">&nbsp;&nbsp;';
                         that._elapsedTimes[id] = 0;
                         that._playOne();
                     }
@@ -670,9 +691,9 @@ function RhythmRuler () {
             }
 
             // Match the play button height to the ruler height.
-            rhythmRulerTableRow.cells[0].style.width = '51px';
-            rhythmRulerTableRow.cells[0].style.minWidth = '51px';
-            rhythmRulerTableRow.cells[0].style.maxWidth = '51px';
+            rhythmRulerTableRow.cells[0].style.width = BUTTONSIZE + 'px';
+            rhythmRulerTableRow.cells[0].style.minWidth = BUTTONSIZE + 'px';
+            rhythmRulerTableRow.cells[0].style.maxWidth = BUTTONSIZE + 'px';
             rhythmRulerTableRow.cells[0].style.height = rulerRow.offsetHeight + 'px';
             rhythmRulerTableRow.cells[0].style.minHeight = rulerRow.offsetHeight + 'px';
             rhythmRulerTableRow.cells[0].style.maxHeight = rulerRow.offsetHeight + 'px';
@@ -705,10 +726,10 @@ function RhythmRuler () {
         }
     };
 
-    this._addButton = function(row, icon, iconSize, label) {
+    this._addButton = function(row, icon, iconSize, label, extras) {
         var cell = row.insertCell(-1);
-        cell.innerHTML = '&nbsp;&nbsp;<img src="header-icons/' + icon + '" title="' + label + '" alt="' + label + '" height="' + iconSize + '" width="' + iconSize + '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
-        cell.style.width = "51px";  // Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
+        cell.innerHTML = extras + '&nbsp;&nbsp;<img src="header-icons/' + icon + '" title="' + label + '" alt="' + label + '" height="' + iconSize + '" width="' + iconSize + '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+        cell.style.width = BUTTONSIZE + 'px';
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
         cell.style.height = cell.style.width; 

--- a/js/rhythmruler.js
+++ b/js/rhythmruler.js
@@ -14,6 +14,9 @@
 // notes.
 
 
+// drumDiv is for the widget buttons
+// rulerBody is for the drum buttons (fixed first col) and the ruler cells
+
 function RhythmRuler () {
     // There is one ruler per drum.
     this.Drums = [];
@@ -32,12 +35,13 @@ function RhythmRuler () {
     this._elapsedTimes = [];
     // Starting time from which we measure for sync.
     this._startingTime = null;
+
     this._offsets = [];
     this._rulerSelected = 0;
     this._rulerPlaying = -1;
 
     this._noteWidth = function (noteValue) {
-        return Math.floor(EIGHTHNOTEWIDTH * (8 / noteValue) * this._cellScale * 3) + 'px';
+        return Math.floor(EIGHTHNOTEWIDTH * (8 / noteValue) * this._cellScale * 3);
     };
 
     this._calculateZebraStripes = function(rulerno) {
@@ -84,6 +88,7 @@ function RhythmRuler () {
         docById('dissectNumber').value = inputNum;
 
         var cell = event.target;
+	// Does this work if there are more than 10 rulers?
         this._rulerSelected = cell.parentNode.id[5];
         this.__dissect(cell, inputNum, true);
     };
@@ -145,7 +150,7 @@ function RhythmRuler () {
         var newNoteValue = oldCellNoteValue/inputNum;
 
         var newCell = ruler.insertCell(newCellIndex);
-        newCell.style.width = this._noteWidth(newNoteValue);
+        newCell.style.width = this._noteWidth(newNoteValue) + 'px';
         newCell.style.minWidth = newCell.style.width;
         newCell.style.maxWidth = newCell.style.width;
         newCell.style.backgroundColor = MATRIXNOTECELLCOLOR;
@@ -430,83 +435,33 @@ function RhythmRuler () {
         console.log('init RhythmRuler');
         this._logo = logo;
 
-        docById('rulerBody').style.display = 'inline';
-        docById('rulerBody').style.visibility = 'visible';
-        docById('rulerBody').style.border = 2;
-
-        docById('drumDiv').style.display = 'inline';
-        docById('drumDiv').style.visibility = 'visible';
-        docById('drumDiv').style.border = 2;
-
-        var w = window.innerWidth;
-        this._cellScale = w / 1200;
-        var iconSize = Math.floor(this._cellScale * 24);
-
-        docById('rulerBody').innerHTML = '';
-        docById('drumDiv').innerHTML = '';
-
-        docById('rulerBody').style.width = Math.floor(w / 2) + 'px';
-        docById('rulerBody').style.overflowX = 'auto';
-
-        docById('drumDiv').style.width = Math.max(iconSize, Math.floor(w / 24)) + 'px';
-        docById('drumDiv').style.overflowX = 'auto';
-
-        // Remove the rhythm ruler before adding it again.
-        Element.prototype.remove = function() {
-            this.parentElement.removeChild(this);
-        };
-
-        NodeList.prototype.remove = HTMLCollection.prototype.remove = function() {
-            for (var i = 0, len = this.length; i < len; i++) {
-                if (this[i] && this[i].parentElement) {
-                    this[i].parentElement.removeChild(this[i]);
-                }
-            }
-        };
-
-        var that = this;
-        var table = docById('buttonTable');
-
-        if (table !== null) {
-            table.remove();
-        }
-
-        var table = docById('drum');
-
-        if (table !== null) {
-            table.remove();
-        }
-
         this._elapsedTimes = [];
         this._offsets = [];
         for (var i = 0; i < this.Rulers.length; i++) {
-            var rulertable = docById('rulerTable' + i);
-            var rulerdrum = docById('rulerdrum' + i);
             this._elapsedTimes.push(0);
             this._offsets.push(0);
         }
 
-        // The play all button
-        var x = document.createElement('TABLE');
-        x.setAttribute('id', 'drum');
-        x.style.textAlign = 'center';
-        x.style.borderCollapse = 'collapse';
-        x.cellSpacing = 0;
-        x.cellPadding = 0;
+        var w = window.innerWidth;
+        this._cellScale = 1.0; //  w / 1200;
+        var iconSize = Math.floor(this._cellScale * 24);
 
-        var drumDiv = docById('drumDiv');
-        drumDiv.style.paddingTop = 0 + 'px';
-        drumDiv.style.paddingLeft = 0 + 'px';
-        drumDiv.appendChild(x);
-        drumDivPosition = drumDiv.getBoundingClientRect();
+        // The widget buttons
+	var widgetButtonsDiv = docById('drumDiv');
+        widgetButtonsDiv.style.display = 'inline';
+        widgetButtonsDiv.style.visibility = 'visible';
+        widgetButtonsDiv.style.border = 0;
+        widgetButtonsDiv.innerHTML = '<table id="widgetButtonTable"></table>';
 
-        var table = docById('drum');
-        var row = table.insertRow(0);
-        row.setAttribute('id', 'playalldrums');
-        row.style.left = Math.floor(drumDivPosition.left) + 'px';
-        row.style.top = Math.floor(drumDivPosition.top) + 'px';
+        var buttonTable = docById('widgetButtonTable');
+        buttonTable.width = '400px';
+        var header = buttonTable.createTHead();
+        var row = header.insertRow(0);
 
-        var cell = this._addButton(row, -1, 'play-button.svg', iconSize, _('play all'));
+        // For the button callbacks
+        var that = this;
+
+        var cell = this._addButton(row, 'play-button.svg', iconSize, _('play all'));
 
         cell.onclick=function() {
             if (that._playing) {
@@ -540,44 +495,18 @@ function RhythmRuler () {
             }
         };
 
-        // Add rows for drum play buttons.
-        for (var i = 0; i < this.Rulers.length; i++) {
-            var row = table.insertRow(i + 1);
-            row.setAttribute('id', 'drum' + i);
-        }
-
-        // Add tool buttons to top row
-        var x = document.createElement('TABLE');
-        x.setAttribute('id', 'buttonTable');
-        x.style.textAlign = 'center';
-        x.style.borderCollapse = 'collapse';
-        x.cellSpacing = 0;
-        x.cellPadding = 0;
-
-        var rulerBodyDiv = docById('rulerBody');
-        rulerBodyDiv.style.paddingTop = 0 + 'px';
-        rulerBodyDiv.style.paddingLeft = 0 + 'px';
-        rulerBodyDiv.appendChild(x);
-        rulerBodyDivPosition = rulerBodyDiv.getBoundingClientRect();
-
-        var table = docById('buttonTable');
-        docById('buttonTable').innerHTML = '';
-
-        var header = table.createTHead();
-        var row = header.insertRow(0);
-
-        var cell = this._addButton(row, -1, 'export-chunk.svg', iconSize, _('save rhythms'));
+        var cell = this._addButton(row, 'export-chunk.svg', iconSize, _('save rhythms'));
         cell.onclick=function() {
             that._save(0);
         };
 
-        var cell = this._addButton(row, 1, 'export-drums.svg', iconSize, _('save drum machine'));
+        var cell = this._addButton(row, 'export-drums.svg', iconSize, _('save drum machine'));
         cell.onclick=function() {
             that._saveDrumMachine(0);
         };
 
         // An input for setting the dissect number
-        var cell = row.insertCell(2);
+        var cell = row.insertCell();
         cell.innerHTML = '<input id="dissectNumber" style="-webkit-user-select: text;-moz-user-select: text;-ms-user-select: text;" class="dissectNumber" type="dussectNumber" value="' + 2 + '" />';
         cell.style.top = 0;
         cell.style.left = 0;
@@ -595,17 +524,18 @@ function RhythmRuler () {
                numberInput.value = numberInput.value.substring(0, numberInput.value.length-1);
         });
         
-        var cell = this._addButton(row, 3, 'restore-button.svg', iconSize, _('undo'));
+        var cell = this._addButton(row, 'restore-button.svg', iconSize, _('undo'));
         cell.onclick=function() {
             that._undo();
         };
 
-        var cell = this._addButton(row, 4, 'erase-button.svg', iconSize, _('clear'));
+        var cell = this._addButton(row, 'erase-button.svg', iconSize, _('clear'));
         cell.onclick=function() {
             that._clear();
         };
 
-        var cell = this._addButton(row, 5, 'close-button.svg', iconSize, _('close'));
+        var cell = this._addButton(row, 'close-button.svg', iconSize, _('close'));
+
         cell.onclick=function() {
             // Save the new dissect history.
             var dissectHistory = [];
@@ -632,104 +562,120 @@ function RhythmRuler () {
 
             that._dissectHistory = JSON.parse(JSON.stringify(dissectHistory));
 
-            for (var i = 0; i < that.Rulers.length; i++) {
-                var rulertable = docById('rulerTable' + i);
-                var rulerdrum = docById('rulerdrum' + i);
-                if (rulertable !== null) {
-                    rulertable.remove();
-                }
-                if (rulerdrum !== null) {
-                    rulerdrum.remove();
-                }
-            }
+            rulerTableDiv.style.visibility = 'hidden';
+            widgetButtonsDiv.style.visibility = 'hidden';
+            docById('rulerDiv').style.visibility = 'hidden';
 
-            docById('rulerBody').style.visibility = 'hidden';
-            docById('drumDiv').style.visibility = 'hidden';
-            docById('rulerBody').style.border = 0;
-            docById('drumDiv').style.border = 0;
             that._playing = false;
             that._playingOne = false;
             that._playingAll = false;
         };
 
-        // Create a play button for each ruler
-        var table = docById('drum');
+        // The ruler table
+	var rulerTableDiv = docById('rulerBody');
+        rulerTableDiv.style.display = 'inline';
+        rulerTableDiv.style.visibility = 'visible';
+        rulerTableDiv.style.border = '2px';
+        rulerTableDiv.innerHTML = '';
+        // rulerTableDiv.style.width = Math.floor(w / 2) + 'px';
+	
+	// We use an outerdiv to scroll vertically and an innerdiv to
+	// scroll horizontally.
+        rulerTableDiv.innerHTML = '<div id="outerdiv"><div id="innerdiv"><table id="rhythmRulerTable"></table></div></div>';
+        // rulerTableDiv.style.background = "rgba(255, 255, 255, 0.85)";
+
+        // Each row in the ruler table contains a play button in the
+        // first column and a ruler table in the second column.
+        var rhythmRulerTable = docById('rhythmRulerTable');
         for (var i = 0; i < this.Rulers.length; i++) {
-            var row = table.rows[i + 1];
-            var drumcell = this._addButton(row, -1, 'play-button.svg', iconSize, _('play'));
+            var rhythmRulerTableRow = rhythmRulerTable.insertRow();
+            var drumcell = this._addButton(rhythmRulerTableRow, 'play-button.svg', iconSize, _('play'));
+            drumcell.setAttribute('id', i);
+            drumcell.className = "headcol";  // Position fixed when scrolling horizontally
+
             drumcell.onclick=function() {
+                var id = Number(this.getAttribute('id'));
                 if (that._playing) {
-                    if (this.parentNode.id[4] === that._rulerPlaying) {
+                    if (that._rulerPlaying === id) {
                         this.innerHTML = '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="' + _('play') + '" alt="' + _('play') + '" height="' + iconSize + '" width="' + iconSize + '" vertical-align="middle">&nbsp;&nbsp;';
                         that._playing = false;
                         that._playingOne = false;
                         that._playingAll = false;
                         that._rulerPlaying = -1;
                         that._startingTime = null;
-                        that._offsets[i] = 0;
-                        that._elapsedTimes[i] = 0;
-                        setTimeout(that._calculateZebraStripes(this.parentNode.id[4]),1000);
+                        that._offsets[id] = 0;
+                        that._elapsedTimes[id] = 0;
+                        setTimeout(that._calculateZebraStripes(id), 1000);
                     }
                 }
                 else {
                     if (that._playingOne === false) {
-                        that._rulerSelected = this.parentNode.id[4];
+                        that._rulerSelected = id;
                         that._logo.setTurtleDelay(0);
                         that._playing = true;
                         that._playingOne = true;
                         that._playingAll = false;
                         that._cellCounter = 0;
                         that._startingTime = null;
-                        that._rulerPlaying = this.parentNode.id[4];
+                        that._rulerPlaying = id;
                         this.innerHTML = '&nbsp;&nbsp;<img src="header-icons/pause-button.svg" title="' + _('pause') + '" alt="' + _('pause') + '" height="' + iconSize + '" width="' + iconSize + '" vertical-align="middle">&nbsp;&nbsp;';
-                        that._elapsedTimes[i] = 0;
+                        that._elapsedTimes[id] = 0;
                         that._playOne();
                     }
                 }
             };
 
+            var rulerCell = rhythmRulerTableRow.insertCell();
             // Create individual rulers as tables.
-            var rulerTable = document.createElement('TABLE');
-            rulerTable.setAttribute('id', 'rulerTable' + i);
-            rulerTable.style.textAlign = 'center';
-            rulerTable.style.borderCollapse = 'collapse';
-            rulerTable.cellSpacing = 0;
-            rulerTable.cellPadding = 0;
-            rulerBodyDiv.appendChild(rulerTable);
+            rulerCell.innerHTML = '<table id="rulerCellTable' + i + '"></table>';
 
-            var row = rulerTable.insertRow(-1);
-            row.style.left = Math.floor(rulerBodyDivPosition.left) + 'px';
-            row.style.top = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
-            row.setAttribute('id', 'ruler' + i);
-            for (var j = 0; j < that.Rulers[i][0].length; j++) {
-                var noteValue = that.Rulers[i][0][j];
-                var rulercell = row.insertCell(j);
-                rulercell.innerHTML = calcNoteValueToDisplay(noteValue, 1);
-                rulercell.style.width = that._noteWidth(noteValue);
-                rulercell.minWidth = rulercell.style.width;
-                rulercell.maxWidth = rulercell.style.width;
-                rulercell.style.lineHeight = 60 + ' % ';
+	    var rulerCellTable = docById('rulerCellTable' + i);
+            rulerCellTable.style.textAlign = 'center';
+            rulerCellTable.style.border = '0px';
+            rulerCellTable.style.borderCollapse = 'collapse';
+            rulerCellTable.cellSpacing = '0px';
+            rulerCellTable.cellPadding = '0px';
+            var rulerRow = rulerCellTable.insertRow();
+            rulerRow.setAttribute('id', 'ruler' + i);
+            for (var j = 0; j < this.Rulers[i][0].length; j++) {
+                var noteValue = this.Rulers[i][0][j];
+                var rulerSubCell = rulerRow.insertCell(-1);
+                rulerSubCell.innerHTML = calcNoteValueToDisplay(noteValue, 1);
+                rulerSubCell.style.width = this._noteWidth(noteValue) + 'px';
+                rulerSubCell.minWidth = rulerSubCell.style.width;
+                rulerSubCell.maxWidth = rulerSubCell.style.width;
+                rulerSubCell.style.border = '0px';
+                rulerSubCell.border = '0px';
+                rulerSubCell.padding = '0px';
+                rulerSubCell.style.padding = '0px';
+                rulerSubCell.style.lineHeight = 60 + ' % ';
                 if (i % 2 === 0) {
                     if (j % 2 === 0) {
-                        rulercell.style.backgroundColor = MATRIXNOTECELLCOLOR;
+                        rulerSubCell.style.backgroundColor = MATRIXNOTECELLCOLOR;
                     } else {
-                        rulercell.style.backgroundColor = MATRIXNOTECELLCOLORHOVER;
+                        rulerSubCell.style.backgroundColor = MATRIXNOTECELLCOLORHOVER;
                     }
                 } else {
                     if (j % 2 === 0) {
-                        rulercell.style.backgroundColor = MATRIXNOTECELLCOLORHOVER;
+                        rulerSubCell.style.backgroundColor = MATRIXNOTECELLCOLORHOVER;
                     } else {
-                        rulercell.style.backgroundColor = MATRIXNOTECELLCOLOR;
+                        rulerSubCell.style.backgroundColor = MATRIXNOTECELLCOLOR;
                     }
                 }
 
-                rulercell.addEventListener('click', function(event) {
+                rulerSubCell.addEventListener('click', function(event) {
                     that._dissectRuler(event);
                 });
             }
 
             // Match the play button height to the ruler height.
-            table.rows[i + 1].cells[0].style.height = row.offsetHeight + 'px';
+            rhythmRulerTableRow.cells[0].style.width = '51px';
+            rhythmRulerTableRow.cells[0].style.minWidth = '51px';
+            rhythmRulerTableRow.cells[0].style.maxWidth = '51px';
+            rhythmRulerTableRow.cells[0].style.height = rulerRow.offsetHeight + 'px';
+            rhythmRulerTableRow.cells[0].style.minHeight = rulerRow.offsetHeight + 'px';
+            rhythmRulerTableRow.cells[0].style.maxHeight = rulerRow.offsetHeight + 'px';
+            rhythmRulerTableRow.cells[0].style.verticalAlign = 'middle';
         }
 
         // Restore dissect history.
@@ -739,7 +685,7 @@ function RhythmRuler () {
                     continue;
                 }
 
-                var rulerTable = docById('rulerTable' + drum);
+                var rhythmRulerTableRow = docById('ruler' + drum);
                 for (var j = 0; j < this._dissectHistory[i][0].length; j++) {
                     if (this._dissectHistory[i][0][j] == undefined) {
                         continue;
@@ -747,7 +693,7 @@ function RhythmRuler () {
 
                     this._rulerSelected = drum;
 
-                    var cell = rulerTable.rows[0].cells[this._dissectHistory[i][0][j][0]];
+                    var cell = rhythmRulerTableRow.cells[this._dissectHistory[i][0][j][0]];
                     if (cell != undefined) {
                         this.__dissect(cell, this._dissectHistory[i][0][j][1], false);
                     } else {
@@ -758,13 +704,15 @@ function RhythmRuler () {
         }
     };
 
-    this._addButton = function(row, colIndex, icon, iconSize, label) {
-        var cell = row.insertCell();
-        cell.innerHTML = '&nbsp;&nbsp;<img src="header-icons/' + icon + '" title="' + label + '" alt="' + label + '" height="' + iconSize + '" width="' + iconSize + '" vertical-align="middle">&nbsp;&nbsp;';
+    this._addButton = function(row, icon, iconSize, label) {
+        var cell = row.insertCell(-1);
+        cell.innerHTML = '&nbsp;&nbsp;<img src="header-icons/' + icon + '" title="' + label + '" alt="' + label + '" height="' + iconSize + '" width="' + iconSize + '" -webkit-vertical-align="middle" vertical-align="middle" -webkit-align-content="center" align-content="center">&nbsp;&nbsp;';
         cell.style.width = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
-        cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
+        cell.style.height = cell.style.width; 
+        cell.style.minHeight = cell.style.height;
+        cell.style.maxHeight = cell.style.height;
         cell.style.backgroundColor = MATRIXBUTTONCOLOR;
 
         cell.onmouseover=function() {

--- a/js/rhythmruler.js
+++ b/js/rhythmruler.js
@@ -14,8 +14,8 @@
 // notes.
 
 
-// drumDiv is for the widget buttons
-// rulerBody is for the drum buttons (fixed first col) and the ruler cells
+// rulerButtonsDiv is for the widget buttons
+// rulerTableDiv is for the drum buttons (fixed first col) and the ruler cells
 
 function RhythmRuler () {
     // There is one ruler per drum.
@@ -224,7 +224,7 @@ function RhythmRuler () {
     };
 
     this.__loop = function(noteTime, notesCounter, rulerNo, colIndex) {
-        if (docById('rulerBody').style.visibility === 'hidden' || docById('drumDiv').style.visibility === 'hidden') {
+        if (docById('rulerDiv').style.visibility === 'hidden' || docById('rulerButtonsDiv').style.visibility === 'hidden' || docById('rulerTableDiv').style.visibility === 'hidden') {
             return;
         }
 
@@ -447,7 +447,7 @@ function RhythmRuler () {
         var iconSize = Math.floor(this._cellScale * 32);
 
         // The widget buttons
-	var widgetButtonsDiv = docById('drumDiv');
+	var widgetButtonsDiv = docById('rulerButtonsDiv');
         widgetButtonsDiv.style.display = 'inline';
         widgetButtonsDiv.style.visibility = 'visible';
         widgetButtonsDiv.style.border = 0;
@@ -572,17 +572,15 @@ function RhythmRuler () {
         };
 
         // The ruler table
-	var rulerTableDiv = docById('rulerBody');
+	var rulerTableDiv = docById('rulerTableDiv');
         rulerTableDiv.style.display = 'inline';
         rulerTableDiv.style.visibility = 'visible';
         rulerTableDiv.style.border = '2px';
         rulerTableDiv.innerHTML = '';
-        // rulerTableDiv.style.width = Math.floor(w / 2) + 'px';
 	
 	// We use an outerdiv to scroll vertically and an innerdiv to
 	// scroll horizontally.
         rulerTableDiv.innerHTML = '<div id="outerdiv"><div id="innerdiv"><table id="rhythmRulerTable"></table></div></div>';
-        // rulerTableDiv.style.background = "rgba(255, 255, 255, 0.85)";
 
         // Each row in the ruler table contains a play button in the
         // first column and a ruler table in the second column.

--- a/js/rhythmruler.js
+++ b/js/rhythmruler.js
@@ -96,7 +96,7 @@ function RhythmRuler () {
         docById('dissectNumber').value = inputNum;
 
         var cell = event.target;
-	// Does this work if there are more than 10 rulers?
+        // Does this work if there are more than 10 rulers?
         this._rulerSelected = cell.parentNode.id[5];
         this.__dissect(cell, inputNum, true);
     };
@@ -455,7 +455,7 @@ function RhythmRuler () {
         var iconSize = ICONSIZE;
 
         // The widget buttons
-	var widgetButtonsDiv = docById('rulerButtonsDiv');
+        var widgetButtonsDiv = docById('rulerButtonsDiv');
         widgetButtonsDiv.style.display = 'inline';
         widgetButtonsDiv.style.visibility = 'visible';
         widgetButtonsDiv.style.width = BUTTONDIVWIDTH;
@@ -527,7 +527,6 @@ function RhythmRuler () {
         // the backspace press doesn't work by default
         var numberInput = docById('dissectNumber');
         numberInput.addEventListener('keydown', function(event) {
-            console.log(event.keyCode);
            if (event.keyCode === BACKSPACE)
                numberInput.value = numberInput.value.substring(0, numberInput.value.length-1);
         });
@@ -582,14 +581,14 @@ function RhythmRuler () {
         var cell = this._addButton(row, 'grab.svg', iconSize, _('drag'), '');
 
         // The ruler table
-	var rulerTableDiv = docById('rulerTableDiv');
+        var rulerTableDiv = docById('rulerTableDiv');
         rulerTableDiv.style.display = 'inline';
         rulerTableDiv.style.visibility = 'visible';
         rulerTableDiv.style.border = '2px';
         rulerTableDiv.innerHTML = '';
-	
-	// We use an outerdiv to scroll vertically and an innerdiv to
-	// scroll horizontally.
+        
+        // We use an outerdiv to scroll vertically and an innerdiv to
+        // scroll horizontally.
         rulerTableDiv.innerHTML = '<div id="outerdiv"><div id="innerdiv"><table id="rhythmRulerTable"></table></div></div>';
 
         var n = Math.max(Math.floor((window.innerHeight * 0.5) / 100), 2);
@@ -604,7 +603,7 @@ function RhythmRuler () {
         }
 
         var w = Math.max(Math.min(window.innerWidth, INNERWINDOWWIDTH), BUTTONDIVWIDTH - BUTTONSIZE);
-	docById('innerdiv').style.width = w + 'px';
+        docById('innerdiv').style.width = w + 'px';
 
         // Each row in the ruler table contains a play button in the
         // first column and a ruler table in the second column.
@@ -651,7 +650,7 @@ function RhythmRuler () {
             // Create individual rulers as tables.
             rulerCell.innerHTML = '<table id="rulerCellTable' + i + '"></table>';
 
-	    var rulerCellTable = docById('rulerCellTable' + i);
+            var rulerCellTable = docById('rulerCellTable' + i);
             rulerCellTable.style.textAlign = 'center';
             rulerCellTable.style.border = '0px';
             rulerCellTable.style.borderCollapse = 'collapse';

--- a/js/rhythmruler.js
+++ b/js/rhythmruler.js
@@ -120,14 +120,19 @@ function RhythmRuler () {
         var tempwidth = this._noteWidth(newNoteValue);
         var tempwidthPixels = parseFloat(inputNum) * parseFloat(tempwidth) + 'px';
         var difference = parseFloat(this._noteWidth(noteValue)) - parseFloat(inputNum) * parseFloat(tempwidth);
-        var newCellWidth = parseFloat(this._noteWidth(newNoteValue)) + parseFloat(difference) / inputNum + 'px';
+        var newCellWidth = parseFloat(this._noteWidth(newNoteValue)) + parseFloat(difference) / inputNum;
         noteValues.splice(newCellIndex, 1);
 
         for (var i = 0; i < inputNum; i++) {
             var newCell = ruler.insertCell(newCellIndex+i);
             noteValues.splice(newCellIndex + i, 0, newNoteValue);
-            newCell.innerHTML = calcNoteValueToDisplay(newNoteValue, 1);
-            newCell.style.width = newCellWidth;
+            if (newCellWidth > 10) {
+                newCell.innerHTML = calcNoteValueToDisplay(newNoteValue, 1);
+            } else {
+                newCell.innerHTML = '';
+            }
+
+            newCell.style.width = newCellWidth + 'px';
             newCell.style.minWidth = newCell.style.width;
             newCell.style.maxWidth = newCell.style.width;
             newCell.addEventListener('click', function(event) {

--- a/js/rhythmruler.js
+++ b/js/rhythmruler.js
@@ -444,7 +444,7 @@ function RhythmRuler () {
 
         var w = window.innerWidth;
         this._cellScale = 1.0; //  w / 1200;
-        var iconSize = Math.floor(this._cellScale * 24);
+        var iconSize = Math.floor(this._cellScale * 32);
 
         // The widget buttons
 	var widgetButtonsDiv = docById('drumDiv');

--- a/js/rhythmruler.js
+++ b/js/rhythmruler.js
@@ -79,7 +79,7 @@ function RhythmRuler () {
         }
 
         var inputNum = docById('dissectNumber').value;
-        if (isNaN(inputNum)) {
+        if (inputNum === '' || isNaN(inputNum)) {
             inputNum = 2;
         } else {
             inputNum = Math.abs(Math.floor(inputNum));
@@ -450,11 +450,11 @@ function RhythmRuler () {
 	var widgetButtonsDiv = docById('rulerButtonsDiv');
         widgetButtonsDiv.style.display = 'inline';
         widgetButtonsDiv.style.visibility = 'visible';
-        widgetButtonsDiv.style.border = 0;
+        // widgetButtonsDiv.style.border = 0;
         widgetButtonsDiv.innerHTML = '<table id="widgetButtonTable"></table>';
 
         var buttonTable = docById('widgetButtonTable');
-        buttonTable.width = '400px';
+        // buttonTable.width = '456px';
         var header = buttonTable.createTHead();
         var row = header.insertRow(0);
 
@@ -510,7 +510,7 @@ function RhythmRuler () {
         cell.innerHTML = '<input id="dissectNumber" style="-webkit-user-select: text;-moz-user-select: text;-ms-user-select: text;" class="dissectNumber" type="dussectNumber" value="' + 2 + '" />';
         cell.style.top = 0;
         cell.style.left = 0;
-        cell.style.width = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
+        cell.style.width = "51px"; // Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
         cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
@@ -520,10 +520,11 @@ function RhythmRuler () {
         var numberInput = docById('dissectNumber');
         const BACKSPACE = 8;
         numberInput.addEventListener('keydown', function(event) {
+            console.log(event.keyCode);
            if (event.keyCode === BACKSPACE)
                numberInput.value = numberInput.value.substring(0, numberInput.value.length-1);
         });
-        
+
         var cell = this._addButton(row, 'restore-button.svg', iconSize, _('undo'));
         cell.onclick=function() {
             that._undo();
@@ -570,6 +571,8 @@ function RhythmRuler () {
             that._playingOne = false;
             that._playingAll = false;
         };
+
+        var cell = this._addButton(row, 'grab.svg', iconSize, _('drag'));
 
         // The ruler table
 	var rulerTableDiv = docById('rulerTableDiv');
@@ -704,8 +707,8 @@ function RhythmRuler () {
 
     this._addButton = function(row, icon, iconSize, label) {
         var cell = row.insertCell(-1);
-        cell.innerHTML = '&nbsp;&nbsp;<img src="header-icons/' + icon + '" title="' + label + '" alt="' + label + '" height="' + iconSize + '" width="' + iconSize + '" -webkit-vertical-align="middle" vertical-align="middle" -webkit-align-content="center" align-content="center">&nbsp;&nbsp;';
-        cell.style.width = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
+        cell.innerHTML = '&nbsp;&nbsp;<img src="header-icons/' + icon + '" title="' + label + '" alt="' + label + '" height="' + iconSize + '" width="' + iconSize + '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+        cell.style.width = "51px";  // Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
         cell.style.height = cell.style.width; 

--- a/js/rhythmruler.js
+++ b/js/rhythmruler.js
@@ -138,6 +138,9 @@ function RhythmRuler () {
     };
 
     this._undo = function() {
+        this._logo.synth.stop();
+        this._startingTime = null;
+
         if (this._undoList.length === 0) {
             return;
         }
@@ -169,7 +172,6 @@ function RhythmRuler () {
 
         var that = this;
         newCell.addEventListener('click', function(event) {
-            console.log('adding DISSECT event too');
             that._dissectRuler(event);
         });
 
@@ -243,6 +245,7 @@ function RhythmRuler () {
         var drum = this._logo.blocks.blockList[drumblockno].value;
 
         var that = this;
+
         setTimeout(function() {
             var ruler = docById('ruler' + rulerNo);
             if (ruler == null) {
@@ -453,6 +456,8 @@ function RhythmRuler () {
         var w = window.innerWidth;
         this._cellScale = 1.0;
         var iconSize = ICONSIZE;
+
+        docById('rulerDiv').style.visibility = 'visible';
 
         // The widget buttons
         var widgetButtonsDiv = docById('rulerButtonsDiv');

--- a/js/samplesviewer.js
+++ b/js/samplesviewer.js
@@ -487,7 +487,9 @@ function PlanetView(model, controller) {
             document.getElementById('pitchtimematrix').style.visibility = localStorage.getItem('isMatrixHidden');
             document.getElementById('statusmatrix').style.visibility = localStorage.getItem('isStatusHidden');
             document.getElementById('pitchdrummatrix').style.visibility = localStorage.getItem('isPitchDrumMatrixHidden');
-            document.getElementById('rulerBody').style.visibility = localStorage.getItem('isRhythmRulerHidden'); 
+            document.getElementById('rulerDiv').style.visibility = localStorage.getItem('isRhythmRulerHidden'); 
+            document.getElementById('rulerButtonsDiv').style.visibility = localStorage.getItem('isRhythmRulerHidden'); 
+            document.getElementById('rulerTableDiv').style.visibility = localStorage.getItem('isRhythmRulerHidden'); 
             document.getElementById('modewidget').style.visibility = localStorage.getItem('isModeWidgetHidden');
 
             if (ele.attributes.current.value === 'true') {


### PR DESCRIPTION
Fixes #586 (First Row in Rhythm Ruler should always be visible | scrolling) by changing the underlying structure of the divs and tables.

rulerDiv contains two children:
drumDiv (to hold the widget buttons) and
rulerBody (to hold a table of buttons and rulers)

The first column of the table in rulerBody is fix when horizontal scrolling is active.
The entire table scrolls vertically when needed.

Up to four rulers are visible at any one time.

The sizes of the various elements are by-in-large defined in activity.css.

