### PR TITLE
Fixes visual bug specific to status block

### DIFF
--- a/js/basicblocks.js
+++ b/js/basicblocks.js
@@ -525,7 +525,7 @@ function initBasicProtoBlocks(palettes, blocks) {
     statusBlock.palette = palettes.dict['widgets'];
     blocks.protoBlockDict['status'] = statusBlock;
     statusBlock.staticLabels.push(_('status'));
-	statusBlock.extraWidth = 10;
+    statusBlock.extraWidth = 10;
     statusBlock.adjustWidthToLabel();
     statusBlock.stackClampZeroArgBlock();
 

--- a/js/basicblocks.js
+++ b/js/basicblocks.js
@@ -525,6 +525,7 @@ function initBasicProtoBlocks(palettes, blocks) {
     statusBlock.palette = palettes.dict['widgets'];
     blocks.protoBlockDict['status'] = statusBlock;
     statusBlock.staticLabels.push(_('status'));
+	statusBlock.extraWidth = 10;
     statusBlock.adjustWidthToLabel();
     statusBlock.stackClampZeroArgBlock();
 


### PR DESCRIPTION
Status block now doesn't get cut from right side. (See image)
(Issue : https://github.com/walterbender/musicblocks/issues/572)
![capture](https://cloud.githubusercontent.com/assets/16208722/23579538/b0734484-0115-11e7-80af-99d845862ee8.PNG)
