### PR TITLE
fixes #667: resizing palette container

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -986,7 +986,7 @@ function Palette(palettes, name) {
             return;
         }
 
-        var paletteWidth = MENUWIDTH + (this.columns * 160);
+        var paletteWidth = MENUWIDTH + this._getOverflowWidth();
         this.menuContainer.removeAllChildren();
 
         // Create the menu button
@@ -1011,14 +1011,23 @@ function Palette(palettes, name) {
 
     this._updateBlockMasks = function () {
         var h = Math.min(maxPaletteHeight(this.palettes.cellSize, this.palettes.scale), this.y);
+	var w = MENUWIDTH + this._getOverflowWidth();
         for (var i in this.protoContainers) {
             var s = new createjs.Shape();
-            s.graphics.r(0, 0, MENUWIDTH, h);
+            s.graphics.r(0, 0, w, h);
             s.x = this.background.x;
             s.y = this.background.y;
             this.protoContainers[i].mask = s;
         }
     };
+	
+    this._getOverflowWidth = function() {
+        var maxWidth = 0;
+        for(var i in this.protoList) {
+            maxWidth = Math.max(maxWidth, this.protoList[i].textWidth);
+        }
+        return (maxWidth  > 100 ? maxWidth - 30 : 0);
+    }
 
     this._updateBackground = function () {
         if (this.menuContainer == null) {
@@ -1043,8 +1052,8 @@ function Palette(palettes, name) {
         var h = maxPaletteHeight(this.palettes.cellSize, this.palettes.scale);
 
         var shape = new createjs.Shape();
-        shape.graphics.f('#949494').r(0, 0, MENUWIDTH, h).ef();
-        shape.width = MENUWIDTH;
+        shape.graphics.f('#949494').r(0, 0, MENUWIDTH + this._getOverflowWidth(), h).ef();
+        shape.width = MENUWIDTH + this._getOverflowWidth();
         shape.height = h;
         this.background.addChild(shape);
 
@@ -1495,7 +1504,7 @@ function Palette(palettes, name) {
         var palette = this;
         var locked = false;
         var trashcan = this.palettes.trashcan;
-        var paletteWidth = MENUWIDTH + (this.columns * 160);
+        var paletteWidth = MENUWIDTH + this._getOverflowWidth();
 
         this.menuContainer.on('click', function (event) {
             if (Math.round(event.stageX / palette.palettes.scale) > palette.menuContainer.x + paletteWidth - STANDARDBLOCKHEIGHT) {

--- a/js/protoblocks.js
+++ b/js/protoblocks.js
@@ -54,6 +54,8 @@ function ProtoBlock(name) {
     this.hidden = false;
     // Disabled: use inactive colors
     this.disabled = false;
+    //Stores the width of the text component
+    this.textWidth = 0;
 
     this.adjustWidthToLabel = function () {
         if (this.staticLabels.length === 0) {
@@ -63,6 +65,7 @@ function ProtoBlock(name) {
         var text = new createjs.Text(this.staticLabels[0], this.fontSize + 'px Sans', '#000000');
         c.addChild(text);
         var b = c.getBounds();
+        this.textWidth = b.width;
         this.extraWidth += Math.max(b.width - 30, 0);
     };
 


### PR DESCRIPTION
Resize palette container based on the components it has.
Tested the code on both Windows and Mac environments.