### PR TITLE
View bug fixed

### DIFF
--- a/js/basicblocks.js
+++ b/js/basicblocks.js
@@ -487,6 +487,7 @@ function initBasicProtoBlocks(palettes, blocks) {
     tempoBlock.palette = palettes.dict['widgets'];
     blocks.protoBlockDict['tempo'] = tempoBlock;
     tempoBlock.staticLabels.push(_('tempo'));
+    tempoBlock.extraWidth = 20;
     tempoBlock.adjustWidthToLabel();
     tempoBlock.stackClampZeroArgBlock();
 


### PR DESCRIPTION
Visual bug specific to tempo widget is fixed. On collapsing the widget, it wasn't showcased properly. Similar to #572 