### PR TITLE
Collapsable name set

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -646,6 +646,7 @@ function Block(protoblock, blocks, overrideName) {
                     break;
                 case 'tempo':
                     myBlock.collapseText = new createjs.Text(_('tempo'), fontSize + 'px Sans', '#000000');
+                    break;
                 case 'modewidget':
                     myBlock.collapseText = new createjs.Text(_('mode'), fontSize + 'px Sans', '#000000');
                     break;


### PR DESCRIPTION
tempo widget now shows "tempo" after being collapsed instead of "mode"