### PR TITLE
Fixes on device project thumbnail bug.

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
         <div id="labelDiv">
         </div>
 
-        <div id="ioDiv">
+        <div id="ioDiv" style="display:none">
           <input tabindex="-1" class="file" type="file" id="myMedia" accept="image/*">
           <input tabindex="-1" class="file" type="file" id="myOpenFile" accept=".ta, .tb">
           <input tabindex="-1" class="file" type="file" id="myOpenPlugin" accept=".json">


### PR DESCRIPTION
There are 4 input types shown in the place of on device project
thumbnail when opened a project from planet. They will be visible at the
bottom of thumbnail.
Problem : https://github.com/walterbender/musicblocks/issues/709