### PR TITLE
add savebox support to MB; add save-block-artwork button

### DIFF
--- a/header-icons/fb-inactive.svg
+++ b/header-icons/fb-inactive.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="55"
+   height="55"
+   viewBox="0 0 55.000001 55.000001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="fb-inactive.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="19.111612"
+     inkscape:cy="18.67327"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     units="px"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1375"
+     inkscape:window-height="876"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="27.480552,60.951203"
+       orientation="1,0"
+       id="guide4984" />
+    <sodipodi:guide
+       position="-54.389464,27.490402"
+       orientation="0,1"
+       id="guide4986" />
+    <sodipodi:guide
+       position="-11.90625,48.398438"
+       orientation="0,1"
+       id="guide6503" />
+    <sodipodi:guide
+       position="-12.78125,6.8007814"
+       orientation="0,1"
+       id="guide6505" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-997.36216)"
+     style="display:none">
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4752"
+       width="55.077793"
+       height="39.222054"
+       x="0"
+       y="1005.1733"
+       rx="13.302688"
+       ry="9.5134344" />
+    <text
+       sodipodi:linespacing="125%"
+       id="text4758"
+       y="1032.217"
+       x="2.5664103"
+       style="font-style:normal;font-weight:normal;font-size:20.40717316px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="fill:#ffffff;fill-opacity:1"
+         y="1032.217"
+         x="2.5664103"
+         id="tspan4760"
+         sodipodi:role="line">.SVG</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2">
+    <path
+       style="fill:#888888;fill-opacity:1"
+       d="M 7.8982881,48.761523 C 7.2279305,48.529894 6.744349,48.085825 6.4368001,47.419449 l -0.1510167,-0.327211 0,-19.411174 0,-19.4111729 0.1809121,-0.3859535 C 6.6974772,7.391593 7.1690572,6.920013 7.6614018,6.6892306 l 0.3859535,-0.1809122 19.4111737,0 19.411174,0 0.385953,0.1809122 c 0.492345,0.2307824 0.963924,0.7023624 1.194706,1.194707 l 0.180912,0.3859535 0,19.4111729 0,19.411174 -0.153739,0.333366 c -0.209035,0.45327 -0.574872,0.884726 -0.923314,1.088927 -0.649602,0.380691 -0.491531,0.371627 -6.49432,0.372423 l -5.53879,7.32e-4 0,-8.198087 0,-8.198087 2.739421,0 c 2.550255,0 2.741879,-0.0082 2.774993,-0.118567 0.01957,-0.06521 0.06852,-0.392966 0.108796,-0.728343 0.09263,-0.771339 0.375802,-2.957099 0.546765,-4.22035 0.07207,-0.53252 0.131033,-1.058451 0.131033,-1.168736 l 0,-0.200518 -3.156133,0 -3.156134,0 0.02758,-2.557668 c 0.02385,-2.210619 0.04382,-2.607519 0.14723,-2.925056 0.272864,-0.837885 0.742911,-1.284328 1.631891,-1.549947 0.255294,-0.07628 0.881317,-0.111295 2.540729,-0.14211 l 2.201966,-0.04089 0.0177,-2.80759 c 0.0097,-1.544176 -0.0055,-2.830181 -0.03388,-2.85779 -0.167846,-0.163361 -4.482258,-0.363211 -5.697547,-0.263919 -2.2031,0.179998 -3.914545,0.906788 -5.202066,2.209135 -0.962532,0.973614 -1.536422,2.032958 -1.925304,3.553921 -0.255445,0.999077 -0.335397,2.234874 -0.336218,5.196887 l -6.05e-4,2.185028 -2.743988,0 -2.743988,0 0,3.218257 0,3.218258 2.743988,0 2.743988,0 0,8.198087 0,8.198087 -10.315362,-0.0022 C 8.8186316,48.883381 8.2312128,48.87656 7.8982881,48.761523 Z"
+       id="path4253"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/header-icons/save-block-artwork.svg
+++ b/header-icons/save-block-artwork.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg2"
+   viewBox="0 0 55.000001 55.000001"
+   height="55"
+   width="55">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-997.36216)"
+     id="layer1">
+    <rect
+       ry="9.5134344"
+       rx="13.302688"
+       y="1005.1733"
+       x="0"
+       height="39.222054"
+       width="55.077793"
+       id="rect4752"
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 13.055555,1023.7511 v -4.4444 a 4.444445,4.444445 0 0 1 4.44445,-4.4445 h 4.44444 v 2.2223 h 11.11111 v -2.2223 h 4.44445 a 4.444445,4.444445 0 0 1 4.44444,4.4445 v 4.4444 4.4445 a 4.444445,4.444445 0 0 1 -4.44444,4.4444 h -4.44445 -1.11111 v 2.2222 h -8.88889 v -2.2222 h -1.11111 -4.44444 a 4.444445,4.444445 0 0 1 -4.44445,-4.4444 z"
+       id="path75"
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/header-icons/save-block-artwork_backup.svg
+++ b/header-icons/save-block-artwork_backup.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="55"
+   height="55"
+   viewBox="0 0 55.000001 55.000001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="save-tb.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.0895363"
+     inkscape:cx="29.919413"
+     inkscape:cy="27.140128"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1375"
+     inkscape:window-height="876"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="27.480552,60.951203"
+       orientation="1,0"
+       id="guide4984" />
+    <sodipodi:guide
+       position="-54.389464,27.490402"
+       orientation="0,1"
+       id="guide4986" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-997.36216)">
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4752"
+       width="55.077793"
+       height="39.222054"
+       x="0"
+       y="1005.1733"
+       rx="13.302688"
+       ry="9.5134344" />
+    <text
+       sodipodi:linespacing="125%"
+       id="text4758"
+       y="1032.217"
+       x="9.7765932"
+       style="font-style:normal;font-weight:normal;font-size:20.40717316px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="fill:#ffffff;fill-opacity:1"
+         y="1032.217"
+         x="9.7765932"
+         id="tspan4760"
+         sodipodi:role="line">.TB</tspan></text>
+  </g>
+</svg>

--- a/header-icons/save-png-inactive.svg
+++ b/header-icons/save-png-inactive.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg2"
+   viewBox="0 0 55.000001 55.000001"
+   height="55"
+   width="55">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-997.36216)"
+     id="layer1">
+    <rect
+       ry="9.5134344"
+       rx="13.302688"
+       y="1005.1733"
+       x="0"
+       height="39.222054"
+       width="55.077793"
+       id="rect4752"
+       style="fill:#888888;fill-opacity:1;stroke:none;stroke-width:15;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:20.40717316px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="2.5664103"
+       y="1032.217"
+       id="text4758"><tspan
+         id="tspan4760"
+         x="2.5664103"
+         y="1032.217"
+         style="fill:#ffffff;fill-opacity:1">.PNG</tspan></text>
+  </g>
+</svg>

--- a/header-icons/save-png.svg
+++ b/header-icons/save-png.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="55"
+   height="55"
+   viewBox="0 0 55.000001 55.000001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="save-png.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.0895363"
+     inkscape:cx="29.919413"
+     inkscape:cy="27.140128"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1375"
+     inkscape:window-height="876"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="27.480552,60.951203"
+       orientation="1,0"
+       id="guide4984" />
+    <sodipodi:guide
+       position="-54.389464,27.490402"
+       orientation="0,1"
+       id="guide4986" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-997.36216)">
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4752"
+       width="55.077793"
+       height="39.222054"
+       x="0"
+       y="1005.1733"
+       rx="13.302688"
+       ry="9.5134344" />
+    <text
+       sodipodi:linespacing="125%"
+       id="text4758"
+       y="1032.217"
+       x="2.5664103"
+       style="font-style:normal;font-weight:normal;font-size:20.40717316px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="fill:#ffffff;fill-opacity:1"
+         y="1032.217"
+         x="2.5664103"
+         id="tspan4760"
+         sodipodi:role="line">.PNG</tspan></text>
+  </g>
+</svg>

--- a/header-icons/save-svg.svg
+++ b/header-icons/save-svg.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="55"
+   height="55"
+   viewBox="0 0 55.000001 55.000001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="save-svg.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.0895363"
+     inkscape:cx="29.919413"
+     inkscape:cy="27.140128"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1375"
+     inkscape:window-height="876"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="27.480552,60.951203"
+       orientation="1,0"
+       id="guide4984" />
+    <sodipodi:guide
+       position="-54.389464,27.490402"
+       orientation="0,1"
+       id="guide4986" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-997.36216)">
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4752"
+       width="55.077793"
+       height="39.222054"
+       x="0"
+       y="1005.1733"
+       rx="13.302688"
+       ry="9.5134344" />
+    <text
+       sodipodi:linespacing="125%"
+       id="text4758"
+       y="1032.217"
+       x="2.5664103"
+       style="font-style:normal;font-weight:normal;font-size:20.40717316px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="fill:#ffffff;fill-opacity:1"
+         y="1032.217"
+         x="2.5664103"
+         id="tspan4760"
+         sodipodi:role="line">.SVG</tspan></text>
+  </g>
+</svg>

--- a/header-icons/save-tb.svg
+++ b/header-icons/save-tb.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="55"
+   height="55"
+   viewBox="0 0 55.000001 55.000001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="save-tb.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.0895363"
+     inkscape:cx="29.919413"
+     inkscape:cy="27.140128"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1375"
+     inkscape:window-height="876"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="27.480552,60.951203"
+       orientation="1,0"
+       id="guide4984" />
+    <sodipodi:guide
+       position="-54.389464,27.490402"
+       orientation="0,1"
+       id="guide4986" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-997.36216)">
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4752"
+       width="55.077793"
+       height="39.222054"
+       x="0"
+       y="1005.1733"
+       rx="13.302688"
+       ry="9.5134344" />
+    <text
+       sodipodi:linespacing="125%"
+       id="text4758"
+       y="1032.217"
+       x="9.7765932"
+       style="font-style:normal;font-weight:normal;font-size:20.40717316px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="fill:#ffffff;fill-opacity:1"
+         y="1032.217"
+         x="9.7765932"
+         id="tspan4760"
+         sodipodi:role="line">.TB</tspan></text>
+  </g>
+</svg>

--- a/header-icons/upload-planet.svg
+++ b/header-icons/upload-planet.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="55"
+   height="55"
+   viewBox="0 0 55.000001 55.000001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="upload-planet.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="6.4272727"
+     inkscape:cx="16.181921"
+     inkscape:cy="19.272827"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1375"
+     inkscape:window-height="876"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-997.36216)">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-opacity:1"
+       d="m 27.266613,1004.1792 c -11.41695,0 -20.6828813,9.2661 -20.6828813,20.683 0,11.417 9.2659313,20.6829 20.6828813,20.6829 11.41695,0 20.68288,-9.2659 20.68288,-20.6829 0,-11.4169 -9.26593,-20.683 -20.68288,-20.683 z m -2.068289,37.0845 c -8.169737,-1.0134 -14.478016,-7.9629 -14.478016,-16.4015 0,-1.2823 0.165463,-2.5027 0.43434,-3.7022 l 9.9071,9.9071 0,2.0683 c 0,2.2751 1.86146,4.1365 4.136576,4.1365 l 0,3.9918 z m 14.271188,-5.2534 c -0.537754,-1.6753 -2.068287,-2.8749 -3.929747,-2.8749 l -2.068288,0 0,-6.2049 c 0,-1.1376 -0.93073,-2.0683 -2.068288,-2.0683 l -12.409728,0 0,-4.1366 4.136576,0 c 1.137559,0 2.068287,-0.9307 2.068287,-2.0683 l 0,-4.1365 4.136577,0 c 2.275116,0 4.136576,-1.8615 4.136576,-4.1367 l 0,-0.8479 c 6.060083,2.4613 10.341441,8.3973 10.341441,15.326 0,4.302 -1.654631,8.2111 -4.343406,11.1481 z"
+       id="path4214" />
+  </g>
+</svg>

--- a/js/activity.js
+++ b/js/activity.js
@@ -55,7 +55,7 @@ if (lang.indexOf('-') !== -1) {
 }
 
 if (_THIS_IS_MUSIC_BLOCKS_) {
-    MYDEFINES = ["activity/sugarizer-compatibility", 'activity/platformstyle', 'easeljs-0.8.2.min', 'tweenjs-0.6.2.min', 'preloadjs-0.6.2.min', 'Tone.min', 'howler', 'p5.min', 'p5.sound.min', 'p5.dom.min', 'mespeak', 'Chart', 'activity/utils', 'activity/artwork', 'activity/status', 'activity/munsell', 'activity/trash', 'activity/boundary', 'activity/turtle', 'activity/palette', 'activity/protoblocks', 'activity/blocks', 'activity/block', 'activity/turtledefs', 'activity/logo', 'activity/clearbox', 'activity/utilitybox', 'activity/samplesviewer', 'activity/basicblocks', 'activity/blockfactory', 'activity/analytics', 'activity/modewidget', 'activity/soundsamples', 'activity/pitchtimematrix', 'activity/pitchdrummatrix', 'activity/rhythmruler', 'activity/pitchstaircase', 'activity/tempo', 'activity/pitchslider', 'activity/macros', 'activity/musicutils', 'activity/lilypond', 'prefixfree.min'];
+    MYDEFINES = ["activity/sugarizer-compatibility", 'activity/platformstyle', 'easeljs-0.8.2.min', 'tweenjs-0.6.2.min', 'preloadjs-0.6.2.min', 'Tone.min', 'howler', 'p5.min', 'p5.sound.min', 'p5.dom.min', 'mespeak', 'Chart', 'activity/utils', 'activity/artwork', 'activity/status', 'activity/munsell', 'activity/trash', 'activity/boundary', 'activity/turtle', 'activity/palette', 'activity/protoblocks', 'activity/blocks', 'activity/block', 'activity/turtledefs', 'activity/logo', 'activity/clearbox', 'activity/savebox', 'activity/utilitybox', 'activity/samplesviewer', 'activity/basicblocks', 'activity/blockfactory', 'activity/analytics', 'activity/modewidget', 'activity/soundsamples', 'activity/pitchtimematrix', 'activity/pitchdrummatrix', 'activity/rhythmruler', 'activity/pitchstaircase', 'activity/tempo', 'activity/pitchslider', 'activity/macros', 'activity/musicutils', 'activity/lilypond', 'prefixfree.min'];
 } else {
     MYDEFINES = ["activity/sugarizer-compatibility", 'activity/platformstyle', 'easeljs-0.8.2.min', 'tweenjs-0.6.2.min', 'preloadjs-0.6.2.min', 'howler', 'p5.min', 'p5.sound.min', 'p5.dom.min', 'mespeak', 'Chart', 'activity/utils', 'activity/artwork', 'activity/status', 'activity/munsell', 'activity/trash', 'activity/boundary', 'activity/turtle', 'activity/palette', 'activity/protoblocks', 'activity/blocks', 'activity/block', 'activity/turtledefs', 'activity/logo', 'activity/clearbox', 'activity/savebox', 'activity/utilitybox', 'activity/samplesviewer', 'activity/basicblocks', 'activity/blockfactory', 'activity/analytics', 'activity/macros', 'activity/musicutils', 'activity/lilypond', 'prefixfree.min'];
 }
@@ -120,9 +120,9 @@ define(MYDEFINES, function (compatibility) {
         var pasteContainer = null;
         var pasteImage = null;
         var chartBitmap = null;
-        if (_THIS_IS_TURTLE_BLOCKS_) {
+        // if (_THIS_IS_TURTLE_BLOCKS_) {
             var saveBox;
-        }
+        // }
 
         // Calculate the palette colors.
         for (var p in PALETTECOLORS) {
@@ -722,18 +722,17 @@ define(MYDEFINES, function (compatibility) {
                 .setRefreshCanvas(refreshCanvas)
                 .setClear(sendAllToTrash);
 
-            if (_THIS_IS_TURTLE_BLOCKS_) {
-                saveBox = new SaveBox();
-                saveBox
-                    .setCanvas(canvas)
-                    .setStage(stage)
-                    .setRefreshCanvas(refreshCanvas)
-                    .setSaveTB(doSaveTB)
-                    .setSaveSVG(doSaveSVG)
-                    .setSavePNG(doSavePNG)
-                    .setSavePlanet(doUploadToPlanet)
-                    .setSaveFB(doShareOnFacebook);
-            }
+            saveBox = new SaveBox();
+            saveBox
+                .setCanvas(canvas)
+                .setStage(stage)
+                .setRefreshCanvas(refreshCanvas)
+                .setSaveTB(doSaveTB)
+                .setSaveSVG(doSaveSVG)
+                .setSavePNG(doSavePNG)
+                .setSavePlanet(doUploadToPlanet)
+                // .setSaveFB(doShareOnFacebook)
+                .setSaveBlockArtwork(doSaveBlockArtwork);
 
             utilityBox = new UtilityBox();
             utilityBox
@@ -1192,12 +1191,12 @@ define(MYDEFINES, function (compatibility) {
 
             const BACKSPACE = 8;
             const TAB = 9;
-			/*
+                        /*
             if (event.keyCode === TAB || event.keyCode === BACKSPACE) {
                 // Prevent browser from grabbing TAB key
                 event.preventDefault();
             }
-			*/
+                        */
 
             const ESC = 27;
             const ALT = 18;
@@ -1681,13 +1680,13 @@ define(MYDEFINES, function (compatibility) {
         };
 
         function doSave() {
-            if (_THIS_IS_MUSIC_BLOCKS_) {
-                console.log('Saving .tb file');
-                var name = 'My Project';
-                download(name + '.tb', 'data:text/plain;charset=utf-8,' + prepareExport());
-            } else {
+            // if (_THIS_IS_MUSIC_BLOCKS_) {
+            //     console.log('Saving .tb file');
+            //     var name = 'My Project';
+            //     download(name + '.tb', 'data:text/plain;charset=utf-8,' + prepareExport());
+            // } else {
                 saveBox.init(turtleBlocksScale, saveButton.x - 27, saveButton.y - 97, _makeButton);
-            }
+            // }
         };
 
         function doSaveTB() {
@@ -1709,6 +1708,10 @@ define(MYDEFINES, function (compatibility) {
                 var svg = doSVG(logo.canvas, logo, logo.turtles, logo.canvas.width, logo.canvas.height, 1.0);
                 download(filename, 'data:image/svg+xml;utf8,' + svg, filename, '"width=' + logo.canvas.width + ', height=' + logo.canvas.height + '"');
             }
+        };
+
+        function doSaveBlockArtwork() {
+            _printBlockSVG();
         };
 
         function doSavePNG() {


### PR DESCRIPTION
The savebox panel is the same as the one already used in Turtle Blocks. The disabled save to Facebook button has been replaced by a button to save the block artwork (same as the Alt-B keyboard accelerator command).