### PR TITLE
Fixed issue #852

### DIFF
--- a/css/activity.css
+++ b/css/activity.css
@@ -90,7 +90,7 @@ div.back:active {
 }
 
 .canvasHolder.hide {
-    transform: scale(0.24);
+    transform: scale(0.2375);
     top: 117px;
     left: 1%;
     width: 100vw;
@@ -169,12 +169,14 @@ nav ul li {
 .content {
     padding: 0px;
     margin: 0px;
+    display: flex;
+    flex-wrap: wrap;
 }
 
 .content li {
     display: block;
     list-style: none;
-    width: 24%;
+    width: 23.75%;
     float: left;
     padding-left: 1%;
 }
@@ -185,12 +187,12 @@ nav ul li {
 
 @media (max-width: 500px) {
     .content li {
-    width: 49%;
+    width: 48.5%;
     padding-left: 1%;
     }
     
     .canvasHolder.hide {
-    transform: scale(0.49);
+    transform: scale(0.485);
     }
     
     nav h1 {
@@ -226,6 +228,10 @@ nav ul li {
 .planet-content h2 {
     color: #212121;
     clear: both;
+}
+
+.projectname {
+    word-wrap: break-word;
 }
 
 img.icon {

--- a/js/samplesviewer.js
+++ b/js/samplesviewer.js
@@ -88,7 +88,7 @@ const LOCAL_PROJECT_TEMPLATE ='\
 const GLOBAL_PROJECT_TEMPLATE = '\
 <img class="thumbnail" src="{img}" /> \
 <div class="options"> \
-    <span>{title}</span><br/> \
+    <span class="projectname">{title}</span><br/> \
     <span class="shareurlspan"> \
     <img class="share icon" title="' + _('Share') + '" alt="' + _('Share') + '" src="header-icons/share.svg" /> \
     <div class="tooltiptriangle" id="plshareurltri_NUM_"></div> \


### PR DESCRIPTION
1. To fix the issue of thumbnail padding, I reduced the width of the thumbnails so that the total width of each row would sum to 99% - meaning that 1% padding would be left at the right of the thumbnails as empty space.

2. As project names have no spaces, they would not ordinarily wrap in a `<span>` - thus I set wordwrap to break-word to force the names to wrap even when no spaces are present. I changed the display attribute of the 'content' divs (local and global projects) to flexbox to prevent thumbnail names which wrap onto the next line from overly affecting the layout of the grid.