### PR TITLE
Making Guide Images Relevant

### DIFF
--- a/guide/fibonacci3.svg
+++ b/guide/fibonacci3.svg
@@ -5,13 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   viewBox="0 0 918 1169.1241"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="840.40088"
+   height="857.84308"
    version="1.1"
-   width="918"
-   height="1169.1241"
-   id="svg2">
+   id="svg10338"
+   sodipodi:docname="fibonacci3.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata157">
+     id="metadata10344">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -23,1658 +26,1566 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs155" />
-  <text
-     x="426"
-     y="116.39079"
-     id="text3033"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="528"
-       y="138.89079"
-       id="tspan3035" />
-  </text>
-  <text
-     x="444"
-     y="181.35439"
-     id="text3107"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="538"
-       y="203.85439"
-       id="tspan3109" />
-  </text>
-  <text
-     x="426"
-     y="200.39079"
-     id="text3033-0"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="528"
-       y="222.89079"
-       id="tspan3035-1" />
-  </text>
-  <text
-     x="426"
-     y="284.39078"
-     id="text3033-1"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="528"
-       y="306.89075"
-       id="tspan3035-8" />
-  </text>
-  <text
-     x="426"
-     y="368.39075"
-     id="text3033-0-9"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="528"
-       y="390.89075"
-       id="tspan3035-1-5" />
-  </text>
-  <text
-     x="-148.55554"
-     y="95.820213"
-     id="text3033-19"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="-46.555557"
-       y="118.32022"
-       id="tspan3035-6" />
-  </text>
-  <text
-     x="-148.55554"
-     y="179.82022"
-     id="text3033-0-93"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="-46.555557"
-       y="202.32021"
-       id="tspan3035-1-3" />
-  </text>
-  <text
-     x="-148.55554"
-     y="263.82019"
-     id="text3033-1-6"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="-46.555557"
-       y="286.32019"
-       id="tspan3035-8-9" />
-  </text>
-  <text
-     x="-148.55554"
-     y="347.82019"
-     id="text3033-0-9-1"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="-46.555557"
-       y="370.32019"
-       id="tspan3035-1-5-0" />
-  </text>
+     id="defs10342" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview10340"
+     showgrid="false"
+     inkscape:zoom="0.41581259"
+     inkscape:cx="456.35451"
+     inkscape:cy="553.95506"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg10338" />
   <g
-     transform="translate(510,222.56205)"
-     id="g3570">
-    <path
-       d="M 17,17 V 9 c 0,-4.1887902 3.81121,-8 8,-8 h 8 20 60 8 c 4.18879,0 8,3.8112098 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 160 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 H 113 53 33 25 c -4.18879,0 -8,-3.81121 -8,-8 V 193 25 23 H 5 v 6 H 1 V 13 h 4 v 6 h 12 z"
-       id="path3155"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text3157"
-       style="font-size:28px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="110"
-         y="49"
-         id="tspan3159">+</tspan>
-    </text>
-    <text
-       id="text3161"
-       style="font-size:18.66666603px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="110"
-         y="21.5"
-         id="tspan3163" />
-    </text>
-    <text
-       id="text3165"
-       style="font-size:18.66666603px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="110"
-         y="63.5"
-         id="tspan3167" />
-    </text>
+     transform="translate(1,0.42153745)"
+     id="g9462">
+    <g
+       transform="scale(1.5)"
+       id="g9460">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 126 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9450"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9454">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan9452">action</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9458">
+        <tspan
+           x="60.333332"
+           y="5.25"
+           id="tspan9456" />
+      </text>
+    </g>
   </g>
   <g
-     transform="translate(74)"
-     id="g4742">
+     transform="translate(95.5,9.4215375)"
+     id="g9472">
     <g
-       id="g3579"
-       transform="translate(322,42.56203)">
+       transform="scale(1.5)"
+       id="g9470">
       <path
-         style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path21-8-0"
-         d="M 131,97.000022 H 251 V 137.00002 H 131 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9464"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-         id="text23-0-5"
-         y="98.000031"
-         x="165">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9468">
         <tspan
-           id="tspan25-7-2"
-           y="124.00002"
-           x="185">1</tspan>
+           x="13.333333"
+           y="13.833333"
+           id="tspan9466">fib</tspan>
       </text>
     </g>
+  </g>
+  <g
+     transform="translate(0,398.42154)"
+     id="g9482">
     <g
-       id="g3213"
-       transform="translate(296,54.562052)">
+       transform="scale(1.5)"
+       id="g9480">
       <path
-         style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path21-3"
-         d="M 1,17 V 9 A 8,8 0 0 1 9,1 h 8 V 5 H 37 V 1 h 18 8 a 8,8 0 0 1 8,8 v 8 18 A 16,16 0 0 0 55,51 16,16 0 0 0 71,67 v 8 a 8,8 0 0 1 -8,8 h -8 -2 v 4 H 37 V 83 H 35 27 A 10,10 0 0 0 17,93 v 8 8 8 a 10,10 0 0 0 10,10 h 8 v 4 h 20 v -4 h 16 v 24 8 a 8,8 0 0 1 -8,8 h -8 -2 v 4 H 37 v -4 h -2 -8 a 10,10 0 0 0 -10,10 v 8 8 8 a 10,10 0 0 0 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 a 8,8 0 0 1 -8,8 H 55 37 35 v 4 H 19 v -4 H 17 9 a 8,8 0 0 1 -8,-8 v -8 z" />
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 231 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9474"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:sans-serif;text-anchor:start;fill:#000000"
-         id="text23-00">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9478">
         <tspan
-           id="tspan25-13"
-           y="35.5"
-           x="8">if</tspan>
-      </text>
-      <text
-         style="font-size:13.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
-         id="text27">
-        <tspan
-           id="tspan29"
-           y="78"
-           x="64">then</tspan>
-      </text>
-      <text
-         style="font-size:13.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
-         id="text31">
-        <tspan
-           id="tspan33"
-           y="162"
-           x="64">else</tspan>
+           x="5.3333335"
+           y="21.5"
+           id="tspan9476">start</tspan>
       </text>
     </g>
+  </g>
+  <g
+     transform="translate(13.5,501.92154)"
+     id="g9496">
     <g
-       id="g3243-4"
-       transform="translate(-2,0.56204994)">
+       transform="scale(1.5)"
+       id="g9494">
       <path
-         style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path3027-4-2"
-         d="m 281,29 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 l 10,-12 10,12 h 18 70 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -70 -2 v 4 h -16 v -4 h -2 -8 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 C 298.07773,57.780133 297,60.382006 297,63 v 8 218 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 C 301.78013,305.92227 304.38201,307 307,307 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18878 -3.93628,9.01593 -8,8 h -8 -18 l -10,12 -10,-12 h -8 c -4.18879,0 -8,-3.81122 -8,-8 v -8 z" />
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 147 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9484"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-         id="text3029-4-3"
-         y="-1.7447453"
-         x="280.72675">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9488">
         <tspan
-           id="tspan3031-5-7"
-           y="41.255257"
-           x="288.72675">action</tspan>
-      </text>
-    </g>
-    <g
-       id="g3802"
-       transform="translate(3.26968,0.56204994)">
-      <path
-         style="fill:#5DC1BC;fill-opacity:1;stroke:#5AA4AF;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path21-2-7"
-         d="m 417.73032,13 h 120 v 40 h -120 V 37 35 h -12 v 6 h -4 V 25 h 4 v 6 h 12 v -2 z" />
-      <text
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-         id="text23-2-3"
-         y="12"
-         x="442.73032">
-        <tspan
-           id="tspan25-1-3"
-           y="38"
-           x="462.73032">fib</tspan>
-      </text>
-    </g>
-    <g
-       id="g4-8"
-       transform="matrix(2,0,0,2,438,43.823736)">
-      <filter
-         style="color-interpolation-filters:sRGB"
-         id="dropshadow-7"
-         height="1.3">
-        <feGaussianBlur
-           id="feGaussianBlur7-8"
-           stdDeviation="3"
-           in="SourceAlpha" />
-        <feOffset
-           id="feOffset9-9"
-           result="offsetblur"
-           dy="2"
-           dx="2" />
-        <feComponentTransfer
-           id="feComponentTransfer11-4">
-          <feFuncA
-             id="feFuncA13-0"
-             slope="0.2"
-             type="linear" />
-        </feComponentTransfer>
-        <feMerge
-           id="feMerge15-1">
-          <feMergeNode
-             id="feMergeNode17-7" />
-          <feMergeNode
-             id="feMergeNode19-5"
-             in="SourceGraphic" />
-        </feMerge>
-      </filter>
-      <path
-         style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-         id="path21-31"
-         d="m 8.5,13.869157 v -4 c 0,-2.0943951 1.905605,-4 4,-4 h 4 10 40 4 v 20 h -4 -40 -10 -4 c -2.094395,0 -4,-1.905605 -4,-4 v -4 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z" />
-      <text
-         style="font-size:10px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text23-5"
-         y="6">
-        <tspan
-           id="tspan25-4"
-           y="19"
-           x="65">arg 1</tspan>
+           x="5.3333335"
+           y="15.25"
+           id="tspan9486">repeat</tspan>
       </text>
       <text
-         style="font-size:6.66666651px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text27-0">
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9492">
         <tspan
-           id="tspan29-8"
+           x="45.333332"
            y="11.25"
-           x="65" />
+           id="tspan9490" />
       </text>
     </g>
+  </g>
+  <g
+     transform="translate(85.5,501.92154)"
+     id="g9506">
     <g
-       id="g3480"
-       transform="translate(314,138.56205)">
+       transform="scale(1.5)"
+       id="g9504">
       <path
-         style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path3066"
-         d="M 1,17 V 9 A 8,8 0 0 1 9,1 h 8 V 5 H 37 V 1 h 84 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -84 -2 v 4 H 19 V 41 H 17 9 A 8,8 0 0 1 1,33 v -8 z" />
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9498"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text3068">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9502">
         <tspan
-           id="tspan3070"
-           y="28"
-           x="118">return</tspan>
-      </text>
-      <text
-         style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text3072">
-        <tspan
-           id="tspan3074"
-           y="22.5"
-           x="118" />
+           x="13.333333"
+           y="13.833333"
+           id="tspan9500">6</tspan>
       </text>
     </g>
+  </g>
+  <g
+     transform="translate(473.5,231.72154)"
+     id="g9520">
     <g
-       id="g3280"
-       transform="translate(352,54.56205)">
-      <g
-         style="fill:#d8d100;fill-opacity:1;stroke:#a19a00;stroke-opacity:1"
-         id="g3179"
-         transform="matrix(2,0,0,2,0,-32)">
-        <path
-           style="fill:#d8d100;fill-opacity:1;stroke:#a19a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path3181"
-           d="m 0.5,41.25 c 0,-3.665191 3.3348086,-6.75 7,-6.75 h 1 v -10 c 0,-4.18879 3.81121,-8 8,-8 h 34 v 8 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 8 h -30 -11 -1 v -1 -8 h -1 c -3.6651914,0 -7,-2.584809 -7,-6.25 z" />
-      </g>
-      <text
-         style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000;fill-opacity:1"
-         id="text3183">
-        <tspan
-           style="fill:#000000;fill-opacity:1"
-           id="tspan3185"
-           y="49"
-           x="82">&lt;</tspan>
-      </text>
-    </g>
-    <g
-       id="g3480-5"
-       transform="translate(314,222.56205)">
+       transform="scale(1.5)"
+       id="g9518">
       <path
-         style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path3066-9"
-         d="M 1,17 V 9 A 8,8 0 0 1 9,1 h 8 V 5 H 37 V 1 h 84 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -84 -2 v 4 H 19 V 41 H 17 9 A 8,8 0 0 1 1,33 v -8 z" />
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 126 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9508"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text3068-6">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9512">
         <tspan
-           id="tspan3070-9"
-           y="28"
-           x="118">return</tspan>
+           x="5.3333335"
+           y="15.25"
+           id="tspan9510">semi-tone transpose</tspan>
       </text>
       <text
-         style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text3072-4">
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9516">
         <tspan
-           id="tspan3074-1"
-           y="22.5"
-           x="118" />
-      </text>
-    </g>
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-8-00"
-       d="m 455.18928,97.562056 h 120 v 39.999994 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0-7"
-       y="99.096405"
-       x="487.18927">
-      <tspan
-         id="tspan25-7-3"
-         y="125.09639"
-         x="507.18927">2</tspan>
-    </text>
-  </g>
-  <g
-     transform="translate(662,264.56205)"
-     id="g3923-8">
-    <path
-       d="M 17,17 V 9 a 8,8 0 0 1 8,-8 h 8 20 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 H 113 53 33 25 A 8,8 0 0 1 17,75 V 67 25 23 H 5 v 6 H 1 V 13 h 4 v 6 h 12 z"
-       id="path3798-4"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text3800-3"
-       style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000">
-      <tspan
-         x="110"
-         y="49"
-         id="tspan3802-6">–</tspan>
-    </text>
-    <text
-       id="text3804-3"
-       style="font-size:18.66666603px;font-family:sans-serif;text-anchor:end;fill:#000000">
-      <tspan
-         x="110"
-         y="21.5"
-         id="tspan3806-1" />
-    </text>
-    <text
-       id="text3808-5"
-       style="font-size:18.66666603px;font-family:sans-serif;text-anchor:end;fill:#000000">
-      <tspan
-         x="110"
-         y="63.5"
-         id="tspan3810-0" />
-    </text>
-  </g>
-  <g
-     transform="matrix(2,0,0,2,776,253.82374)"
-     id="g4-8-4-3">
-    <filter
-       height="1.3"
-       id="dropshadow-7-6-3"
-       style="color-interpolation-filters:sRGB">
-      <feGaussianBlur
-         in="SourceAlpha"
-         stdDeviation="3"
-         id="feGaussianBlur7-8-6-6" />
-      <feOffset
-         dx="2"
-         dy="2"
-         result="offsetblur"
-         id="feOffset9-9-3-9" />
-      <feComponentTransfer
-         id="feComponentTransfer11-4-4-9">
-        <feFuncA
-           type="linear"
-           slope="0.2"
-           id="feFuncA13-0-7-1" />
-      </feComponentTransfer>
-      <feMerge
-         id="feMerge15-1-9-3">
-        <feMergeNode
-           id="feMergeNode17-7-4-9" />
-        <feMergeNode
-           in="SourceGraphic"
-           id="feMergeNode19-5-9-0" />
-      </feMerge>
-    </filter>
-    <path
-       d="m 8.5,13.869157 v -4 c 0,-2.0943951 1.905605,-4 4,-4 h 4 10 40 4 v 20 h -4 -40 -10 -4 c -2.094395,0 -4,-1.905605 -4,-4 v -4 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
-       id="path21-31-9-0"
-       style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:1;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       y="6"
-       id="text23-5-1-8"
-       style="font-size:10px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="65"
-         y="19"
-         id="tspan25-4-4-9">arg 1</tspan>
-    </text>
-    <text
-       id="text27-0-0-1"
-       style="font-size:6.66666651px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="65"
-         y="11.25"
-         id="tspan29-8-9-4" />
-    </text>
-  </g>
-  <g
-     transform="translate(-15.23618,248.39289)"
-     id="g4279">
-    <path
-       d="m 808.23618,59.169159 h 120 v 40.000004 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-       id="path21-8-2-1"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="840.23621"
-       y="60.16917"
-       id="text23-0-1-0"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="860.23621"
-         y="86.169151"
-         id="tspan25-7-0-5">1</tspan>
-    </text>
-  </g>
-  <g
-     transform="translate(624,222.56205)"
-     id="g3258-8">
-    <path
-       d="M 17,17 V 9 c 0,-4.1887902 3.81121,-8 8,-8 h 8 20 18 64 8 c 4.18879,0 8,3.8112098 8,8 v 8 8 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -64 -8 c -2.617994,0 -5.219867,1.077731 -7.071068,2.928932 C 54.077731,45.780133 53,48.382006 53,51 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,2.617994 1.077731,47.21987 2.928932,49.07107 C 57.780133,125.92227 60.460173,127.63496 63,127 h 8 16 v 12 12 8 c 0,4.18879 -3.81121,8 -8,8 H 71 53 33 25 c -4.18879,0 -8,-3.81121 -8,-8 V 151 25 23 H 5 v 6 H 1 V 13 h 4 v 6 h 12 z"
-       id="path21-5-6"
-       style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="48"
-       id="text23-3-1"
-       style="font-size:20px;font-family:sans-serif;text-anchor:start;fill:#000000">
-      <tspan
-         x="66"
-         y="30.5"
-         id="tspan25-77-8">fib</tspan>
-    </text>
-  </g>
-  <g
-     transform="translate(662,432.56205)"
-     id="g3923-8-9">
-    <path
-       d="M 17,17 V 9 a 8,8 0 0 1 8,-8 h 8 20 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 H 113 53 33 25 A 8,8 0 0 1 17,75 V 67 25 23 H 5 v 6 H 1 V 13 h 4 v 6 h 12 z"
-       id="path3798-4-4"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text3800-3-2"
-       style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000">
-      <tspan
-         x="110"
-         y="49"
-         id="tspan3802-6-2">–</tspan>
-    </text>
-    <text
-       id="text3804-3-3"
-       style="font-size:18.66666603px;font-family:sans-serif;text-anchor:end;fill:#000000">
-      <tspan
-         x="110"
-         y="21.5"
-         id="tspan3806-1-5" />
-    </text>
-    <text
-       id="text3808-5-4"
-       style="font-size:18.66666603px;font-family:sans-serif;text-anchor:end;fill:#000000">
-      <tspan
-         x="110"
-         y="63.5"
-         id="tspan3810-0-3" />
-    </text>
-  </g>
-  <g
-     transform="matrix(2,0,0,2,776,421.82374)"
-     id="g4-8-4-3-6">
-    <filter
-       height="1.3"
-       id="dropshadow-7-6-3-6"
-       style="color-interpolation-filters:sRGB">
-      <feGaussianBlur
-         in="SourceAlpha"
-         stdDeviation="3"
-         id="feGaussianBlur7-8-6-6-0" />
-      <feOffset
-         dx="2"
-         dy="2"
-         result="offsetblur"
-         id="feOffset9-9-3-9-8" />
-      <feComponentTransfer
-         id="feComponentTransfer11-4-4-9-8">
-        <feFuncA
-           type="linear"
-           slope="0.2"
-           id="feFuncA13-0-7-1-5" />
-      </feComponentTransfer>
-      <feMerge
-         id="feMerge15-1-9-3-2">
-        <feMergeNode
-           id="feMergeNode17-7-4-9-6" />
-        <feMergeNode
-           in="SourceGraphic"
-           id="feMergeNode19-5-9-0-3" />
-      </feMerge>
-    </filter>
-    <path
-       d="m 8.5,13.869157 v -4 c 0,-2.0943951 1.905605,-4 4,-4 h 4 10 40 4 v 20 h -4 -40 -10 -4 c -2.094395,0 -4,-1.905605 -4,-4 v -4 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
-       id="path21-31-9-0-8"
-       style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:1;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       y="6"
-       id="text23-5-1-8-0"
-       style="font-size:10px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="65"
-         y="19"
-         id="tspan25-4-4-9-3">arg 1</tspan>
-    </text>
-    <text
-       id="text27-0-0-1-5"
-       style="font-size:6.66666651px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="65"
-         y="11.25"
-         id="tspan29-8-9-4-8" />
-    </text>
-  </g>
-  <g
-     transform="translate(-15.23618,416.39289)"
-     id="g4279-7">
-    <path
-       d="m 808.23618,59.169159 h 120 v 40.000004 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-       id="path21-8-2-1-0"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="840.23621"
-       y="60.16917"
-       id="text23-0-1-0-1"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="860.23621"
-         y="86.169151"
-         id="tspan25-7-0-5-2">2</tspan>
-    </text>
-  </g>
-  <g
-     transform="translate(624,390.56207)"
-     id="g3258-8-5">
-    <path
-       d="M 17,17 V 9 c 0,-4.1887902 3.81121,-8 8,-8 h 8 20 18 64 8 c 4.18879,0 8,3.8112098 8,8 v 8 8 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -64 -8 c -2.617994,0 -5.219867,1.077731 -7.071068,2.928932 C 54.077731,45.780133 53,48.382006 53,51 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,2.617994 1.077731,47.21987 2.928932,49.07107 C 57.780133,125.92227 60.460173,127.63496 63,127 h 8 16 v 12 12 8 c 0,4.18879 -3.81121,8 -8,8 H 71 53 33 25 c -4.18879,0 -8,-3.81121 -8,-8 V 151 25 23 H 5 v 6 H 1 V 13 h 4 v 6 h 12 z"
-       id="path21-5-6-0"
-       style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="48"
-       id="text23-3-1-5"
-       style="font-size:20px;font-family:sans-serif;text-anchor:start;fill:#000000">
-      <tspan
-         x="66"
-         y="30.5"
-         id="tspan25-77-8-6">fib</tspan>
-    </text>
-  </g>
-  <text
-     x="75.546478"
-     y="69.393471"
-     id="text3033-7"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="177.54648"
-       y="91.893471"
-       id="tspan3035-4" />
-  </text>
-  <text
-     x="93.546478"
-     y="134.35707"
-     id="text3107-1"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="187.54648"
-       y="156.85707"
-       id="tspan3109-0" />
-  </text>
-  <text
-     x="75.546478"
-     y="153.39348"
-     id="text3033-0-8"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="177.54648"
-       y="175.89348"
-       id="tspan3035-1-6" />
-  </text>
-  <text
-     x="75.546478"
-     y="237.39348"
-     id="text3033-1-1"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="177.54648"
-       y="259.89346"
-       id="tspan3035-8-8" />
-  </text>
-  <text
-     x="75.546478"
-     y="321.39346"
-     id="text3033-0-9-9"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="177.54648"
-       y="343.89346"
-       id="tspan3035-1-5-3" />
-  </text>
-  <g
-     id="g4915"
-     transform="translate(500.45352,434.76658)">
-    <path
-       style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3027"
-       d="m -111.45352,109.35751 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 68 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -68 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-       id="text3029"
-       y="92.357513"
-       x="-112.45352">
-      <tspan
-         id="tspan3031"
-         y="120.35752"
-         x="-10.45352">forward</tspan>
-    </text>
-  </g>
-  <g
-     id="g4910"
-     transform="translate(500.45352,434.76658)">
-    <path
-       style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3101"
-       d="m -111.45352,151.35751 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-       id="text3103"
-       y="134.35751"
-       x="-112.45352">
-      <tspan
-         id="tspan3105"
-         y="162.35751"
-         x="-18.45352">right</tspan>
-    </text>
-  </g>
-  <g
-     id="g4905"
-     transform="translate(500.45352,434.76658)">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-7"
-       d="m 2.54648,135.35751 h 120.00001 v 40 H 2.54648 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-1"
-       y="136.1561"
-       x="26.397158">
-      <tspan
-         id="tspan25-0"
-         y="162.1561"
-         x="46.397125">90</tspan>
-    </text>
-  </g>
-  <g
-     id="g4925"
-     transform="translate(500.45352,434.76658)">
-    <path
-       style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3035"
-       d="m -129.45352,67.3575 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 h -16 v -4 h -2 -8 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 -1.8512,1.851201 -2.92893,4.453078 -2.92893,7.071068 v 8 50 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.18879,0 -8,-3.81121 -8,-8 v -8 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text3037"
-       y="50.357498"
-       x="-130.45352">
-      <tspan
-         id="tspan3039"
-         y="80.857498"
-         x="-122.45352">repeat</tspan>
-    </text>
-  </g>
-  <g
-     id="g4930"
-     transform="translate(500.45352,434.20455)">
-    <path
-       style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3027-4"
-       d="m -147.45352,25.3575 v -8 c 0,-4.18879 3.81121,-8.0000002 8,-8.0000002 h 8 l 10,-12 10,12 h 18 70 8 c 4.18879,0 8,3.8112102 8,8.0000002 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -70 -2 v 4 h -16 v -4 h -2 -8 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 -1.8512,1.851201 -2.92893,4.453074 -2.92893,7.071068 v 8 596 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53125,2.29397 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18878 -3.93628,9.01593 -8,8 h -8 -18 l -10,12 -10,-12 h -8 c -4.18879,0 -8,-3.81122 -8,-8 v -8 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text3029-4"
-       y="-5.3872457"
-       x="-147.72679">
-      <tspan
-         id="tspan3031-5"
-         y="37.612755"
-         x="-139.72679">action</tspan>
-    </text>
-  </g>
-  <g
-     id="g4900"
-     transform="translate(500.45352,434.76658)">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-8"
-       d="m -17.45352,51.35751 h 120 v 40 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0"
-       y="52.35751"
-       x="14.54648">
-      <tspan
-         id="tspan25-7"
-         y="78.357506"
-         x="34.546478">4</tspan>
-    </text>
-  </g>
-  <g
-     id="g5972"
-     transform="translate(720,196.56158)">
-    <g
-       id="g4-8-2"
-       transform="matrix(2,0,0,2,-252,487.82419)">
-      <filter
-         id="dropshadow-7-8"
-         height="1.3"
-         style="color-interpolation-filters:sRGB">
-        <feGaussianBlur
-           id="feGaussianBlur7-8-4"
-           stdDeviation="3"
-           in="SourceAlpha" />
-        <feOffset
-           id="feOffset9-9-3"
-           result="offsetblur"
-           dy="2"
-           dx="2" />
-        <feComponentTransfer
-           id="feComponentTransfer11-4-08">
-          <feFuncA
-             id="feFuncA13-0-1"
-             slope="0.2"
-             type="linear" />
-        </feComponentTransfer>
-        <feMerge
-           id="feMerge15-1-0">
-          <feMergeNode
-             id="feMergeNode17-7-4" />
-          <feMergeNode
-             id="feMergeNode19-5-7"
-             in="SourceGraphic" />
-        </feMerge>
-      </filter>
-      <path
-         style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-         id="path21-31-0"
-         d="m 8.5,13.869157 v -4 c 0,-2.0943951 1.905605,-4 4,-4 h 4 10 40 4 v 20 h -4 -40 -10 -4 c -2.094395,0 -4,-1.905605 -4,-4 v -4 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z" />
-      <text
-         style="font-size:10px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text23-5-1"
-         y="6">
-        <tspan
-           id="tspan25-4-9"
-           y="19"
-           x="65">arg 1</tspan>
-      </text>
-      <text
-         style="font-size:6.66666651px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text27-0-2">
-        <tspan
-           id="tspan29-8-3"
+           x="105.93392"
            y="11.25"
-           x="65" />
+           id="tspan9514" />
       </text>
     </g>
+  </g>
+  <g
+     transform="translate(13.5,438.92154)"
+     id="g9686">
     <g
-       id="g3497"
-       transform="translate(-386,150.5625)">
+       transform="scale(1.5)"
+       id="g9684">
       <path
-         style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path21-7-6"
-         d="m 151,307.00001 h 120.00001 v 40 H 151 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 32.792969 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9670"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-         id="text23-1-2"
-         y="307.79861"
-         x="174.85069">
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9674">
         <tspan
-           id="tspan25-0-1"
-           y="333.79858"
-           x="194.85066">90</tspan>
+           x="49.126301"
+           y="24"
+           id="tspan9672">store in</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9678">
+        <tspan
+           x="49.126301"
+           y="11.25"
+           id="tspan9676">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9682">
+        <tspan
+           x="49.126301"
+           y="32.25"
+           id="tspan9680">value</tspan>
       </text>
     </g>
+  </g>
+  <g
+     transform="translate(91.18945,438.92154)"
+     id="g9696">
     <g
-       id="g3585"
-       transform="translate(-350,456.5625)">
+       transform="scale(1.5)"
+       id="g9694">
       <path
-         style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path3194"
-         d="M 1,17 V 9 A 8,8 0 0 1 9,1 h 8 V 5 H 37 V 1 h 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 H 97 37 35 v 4 H 19 V 83 H 17 9 A 8,8 0 0 1 1,75 V 67 25 Z" />
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9688"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text3196">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9692">
         <tspan
-           id="tspan3198"
-           y="49"
-           x="94">arc</tspan>
-      </text>
-      <text
-         style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text3200">
-        <tspan
-           id="tspan3202"
-           y="22.5"
-           x="94">angle</tspan>
-      </text>
-      <text
-         style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text3204">
-        <tspan
-           id="tspan3206"
-           y="64.5"
-           x="94">radius</tspan>
+           x="13.333333"
+           y="13.833333"
+           id="tspan9690">box</tspan>
       </text>
     </g>
   </g>
   <g
-     id="g4920"
-     transform="translate(500.45352,434.20455)">
-    <path
-       style="fill:#5DC1BC;fill-opacity:1;stroke:#5AA4AF;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-2"
-       d="m -5.45352,9.3574998 h 120 V 49.3575 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-2"
-       y="8.3575001"
-       x="1.5464799">
-      <tspan
-         id="tspan25-1"
-         y="34.357498"
-         x="21.54648">square</tspan>
-    </text>
-  </g>
-  <g
-     transform="matrix(2,0,0,2,494,516.38577)"
-     id="g4-8-5">
-    <filter
-       style="color-interpolation-filters:sRGB"
-       height="1.3"
-       id="dropshadow-7-1">
-      <feGaussianBlur
-         in="SourceAlpha"
-         stdDeviation="3"
-         id="feGaussianBlur7-8-1" />
-      <feOffset
-         dx="2"
-         dy="2"
-         result="offsetblur"
-         id="feOffset9-9-5" />
-      <feComponentTransfer
-         id="feComponentTransfer11-4-0">
-        <feFuncA
-           type="linear"
-           slope="0.2"
-           id="feFuncA13-0-4" />
-      </feComponentTransfer>
-      <feMerge
-         id="feMerge15-1-3">
-        <feMergeNode
-           id="feMergeNode17-7-9" />
-        <feMergeNode
-           in="SourceGraphic"
-           id="feMergeNode19-5-9" />
-      </feMerge>
-    </filter>
-    <path
-       d="m 8.5,13.869157 v -4 c 0,-2.0943951 1.905605,-4 4,-4 h 4 10 40 4 v 20 h -4 -40 -10 -4 c -2.094395,0 -4,-1.905605 -4,-4 v -4 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
-       id="path21-31-6"
-       style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:1;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       y="6"
-       id="text23-5-3"
-       style="font-size:10px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="65"
-         y="19"
-         id="tspan25-4-4">arg 1</tspan>
-    </text>
-    <text
-       id="text27-0-8"
-       style="font-size:6.66666651px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="65"
-         y="11.25"
-         id="tspan29-8-0" />
-    </text>
-  </g>
-  <text
-     x="967.30768"
-     y="-2.5918002"
-     id="text3033-3"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1069.3076"
-       y="19.908199"
-       id="tspan3035-0" />
-  </text>
-  <text
-     x="967.30768"
-     y="81.408203"
-     id="text3033-0-2"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1069.3076"
-       y="103.9082"
-       id="tspan3035-1-66" />
-  </text>
-  <text
-     x="967.30768"
-     y="165.4082"
-     id="text3033-1-2"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1069.3076"
-       y="187.9082"
-       id="tspan3035-8-3" />
-  </text>
-  <text
-     x="967.30768"
-     y="249.4082"
-     id="text3033-0-9-93"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1069.3076"
-       y="271.9082"
-       id="tspan3035-1-5-2" />
-  </text>
-  <text
-     x="1062"
-     y="365.52155"
-     id="text3033-37"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1164"
-       y="388.02155"
-       id="tspan3035-17" />
-  </text>
-  <text
-     x="1080"
-     y="430.48514"
-     id="text3107-2"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1174"
-       y="452.98514"
-       id="tspan3109-1" />
-  </text>
-  <text
-     x="1062"
-     y="449.52155"
-     id="text3033-0-6"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1164"
-       y="472.02155"
-       id="tspan3035-1-33" />
-  </text>
-  <text
-     x="1062"
-     y="533.52155"
-     id="text3033-1-4"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1164"
-       y="556.02155"
-       id="tspan3035-8-1" />
-  </text>
-  <text
-     x="1062"
-     y="617.52155"
-     id="text3033-0-9-2"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1164"
-       y="640.02155"
-       id="tspan3035-1-5-5" />
-  </text>
-  <path
-     d="m 19,156.1241 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 H 55 v -4 h -2 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 C 36.07773,184.90423 35,187.50611 35,190.1241 v 8 302 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.93628,9.01593 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.18879,0 -8,-3.81121 -8,-8 v -8 z"
-     id="path3035-6"
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="17.999989"
-     y="139.1241"
-     id="text3037-6"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="25.999989"
-       y="169.6241"
-       id="tspan3039-8">repeat</tspan>
-  </text>
-  <path
-     d="m 131,140.12411 h 120.00001 v 40 H 131 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-8-9"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="160.99998"
-     y="141.12411"
-     id="text23-0-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="180.99998"
-       y="167.1241"
-       id="tspan25-7-6">6</tspan>
-  </text>
-  <path
-     d="m 1,29.56205 v -8 c 0,-4.18879 3.8112098,-8 8,-8 h 8 l 10,-12 10,12 h 18 60 8 c 4.18879,0 8,3.81121 8,8 v 8 8 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -60 -2 v 4 H 37 v -4 h -2 -8 c -2.617994,0 -5.219867,1.077731 -7.071068,2.928932 C 18.077731,58.342183 17,60.944056 17,63.56205 v 8 470 8 c 0,2.61799 1.077731,5.21987 2.928932,7.07107 1.851201,1.8512 4.53124,3.56389 7.071068,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.936277,9.01593 -8,8 H 55 37 l -10,12 -10,-12 H 9 c -4.1887902,0 -8,-3.81121 -8,-8 v -8 z"
-     id="path3660-8"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="0.56204998"
-     id="text3662-6"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="8"
-       y="43.56205"
-       id="tspan3664-1">start</tspan>
-  </text>
-  <path
-     d="m 149,98.1241 h 120 v 40 H 149 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-57"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="176"
-     y="97.124092"
-     id="text23-6"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="196"
-       y="123.12412"
-       id="tspan25-42">0</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-1"
-     d="m 19,72.1241 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 76 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -76 -2 v 4 H 37 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 -42 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text23-8"
-     x="18"
-     y="55.124096">
-    <tspan
-       id="tspan25-1-4"
-       y="104.12409"
-       x="128">store in</tspan>
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text27-4"
-     x="18"
-     y="57.124096">
-    <tspan
-       id="tspan29-2"
-       y="79.624092"
-       x="128">name</tspan>
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text31-1"
-     x="18"
-     y="59.124096">
-    <tspan
-       id="tspan33-6"
-       y="123.62409"
-       x="128">value</tspan>
-  </text>
-  <path
-     d="m 149,56.1241 h 120 v 40 H 149 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-5-7"
-     style="fill:#5DC1BC;fill-opacity:1;stroke:#5AA4AF;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="166"
-     y="55.124096"
-     id="text23-5-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="186"
-       y="81.124092"
-       id="tspan25-9">box</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-0"
-     d="m 151,476.10901 h 120 v 40 H 151 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-10"
-     y="475.10901"
-     x="183.99998">
-    <tspan
-       id="tspan25-6"
-       y="501.10904"
-       x="203.99998">1</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3172-5"
-     d="m 151,434.10901 h 120 v 40 H 151 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     y="433.10901"
-     x="134"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3174-8">
-    <tspan
-       id="tspan3176-1"
-       y="459.10901"
-       x="154">box</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124"
-     d="m 37,450.1241 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 -42 z" />
-  <text
-     y="433.12411"
-     x="36"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3126">
-    <tspan
-       id="tspan3128"
-       y="482.12411"
-       x="130">add</tspan>
-  </text>
-  <text
-     y="435.12411"
-     x="36"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3130">
-    <tspan
-       id="tspan3132"
-       y="457.62411"
-       x="130">to</tspan>
-  </text>
-  <text
-     y="437.12411"
-     x="36"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3134">
-    <tspan
-       id="tspan3136"
-       y="501.62411"
-       x="130">value</tspan>
-  </text>
-  <path
-     d="m 37,198.1241 v -8 c 0,-4.41828 3.581722,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.41828,0 8,3.58172 8,8 v 8 8 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -40 -8 c -5.522847,0 -10,4.47715 -10,10 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 134 c 0,5.52285 4.642051,11.33949 10,10 h 8 16 v 12 12 8 c 0,4.41828 -3.58172,8 -8,8 H 91 73 71 v 4 H 55 v -4 h -2 -8 c -4.418278,0 -8,-3.58172 -8,-8 v -8 z"
-     id="path3062"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="181.1241"
-     x="36"
-     id="text3064"
-     style="font-size:20px;font-family:sans-serif;text-anchor:start;fill:#000000">
-    <tspan
-       x="44"
-       y="211.6241"
-       id="tspan3066">square</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3114"
-     d="m 75,240.12408 v -8 c 0,-4.41828 3.581722,-8 8,-8 h 8 20 60 8 c 4.41828,0 8,3.58172 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 118 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41828 -3.71364,9.07159 -8,8 h -8 -60 -20 -8 c -4.418278,0 -8,-3.58172 -8,-8 v -8 -126 -2 H 63 v 6 h -4 v -16 h 4 v 6 h 12 z" />
-  <text
-     y="223.12408"
-     x="58"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3116">
-    <tspan
-       id="tspan3118"
-       y="272.12408"
-       x="168">×</tspan>
-  </text>
-  <text
-     y="223.12408"
-     x="58"
-     style="font-size:18.66666603px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3120">
-    <tspan
-       id="tspan3122"
-       y="244.62408"
-       x="168" />
-  </text>
-  <text
-     y="223.12408"
-     x="58"
-     style="font-size:18.66666603px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3124">
-    <tspan
-       id="tspan3126"
-       y="286.62408"
-       x="168" />
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-5"
-     d="m 189,240.1241 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 20 18 64 8 c 4.18879,0 8,3.81121 8,8 v 8 8 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -64 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45308 -2.92893,7.07107 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.45308,2.92893 7.07107,2.92893 h 8 16 v 12 12 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -18 -20 -8 c -4.18879,0 -8,-3.81121 -8,-8 v -8 -84 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 z" />
-  <text
-     y="223.1241"
-     style="font-size:20px;font-family:sans-serif;text-anchor:start;fill:#000000"
-     id="text23-3"
-     x="218">
-    <tspan
-       id="tspan25-77"
-       y="253.6241"
-       x="236">fib</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3172-5-1"
-     d="m 227,266.1241 h 120 v 40 H 227 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     y="265.12411"
-     x="210"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3174-8-1">
-    <tspan
-       id="tspan3176-1-3"
-       y="291.12411"
-       x="230">box</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21"
-     d="m 189,350.12408 h 120 v 40 H 189 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     y="349.12408"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23"
-     x="214">
-    <tspan
-       id="tspan25"
-       y="375.12408"
-       x="234">20</tspan>
-  </text>
-  <flowRoot
-     xml:space="preserve"
-     id="flowRoot4622"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><flowRegion
-       id="flowRegion4624"><rect
-         id="rect4626"
-         width="320.46744"
-         height="182.71428"
-         x="673.45996"
-         y="575.88477" /></flowRegion><flowPara
-       id="flowPara4628" /></flowRoot>  <text
-     x="1370.5294"
-     y="540.94934"
-     id="text3033-05"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1472.5294"
-       y="563.44934"
-       id="tspan3035-9" />
-  </text>
-  <text
-     x="1388.5294"
-     y="605.91296"
-     id="text3107-5"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1482.5294"
-       y="628.41296"
-       id="tspan3109-3" />
-  </text>
-  <text
-     x="1370.5294"
-     y="624.94934"
-     id="text3033-0-5"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1472.5294"
-       y="647.44934"
-       id="tspan3035-1-8" />
-  </text>
-  <text
-     x="1370.5294"
-     y="708.94934"
-     id="text3033-1-46"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1472.5294"
-       y="731.44934"
-       id="tspan3035-8-2" />
-  </text>
-  <text
-     x="1370.5294"
-     y="792.94934"
-     id="text3033-0-9-934"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1472.5294"
-       y="815.44934"
-       id="tspan3035-1-5-7" />
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5"
-     d="m 601,754.12408 v -8 a 8,8 0 0 1 8,-8 h 8 20 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -20 -8 a 8,8 0 0 1 -8,-8 v -8 -42 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 z" />
-  <text
-     x="576"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0"
-     y="737.12408">
-    <tspan
-       id="tspan3802-6-2-5"
-       y="786.12408"
-       x="686">/</tspan>
-  </text>
-  <text
-     style="font-size:18.66666603px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3804-3-3-6"
-     x="584"
-     y="737.12408">
-    <tspan
-       id="tspan3806-1-5-4"
-       y="758.62408"
-       x="694" />
-  </text>
-  <text
-     style="font-size:18.66666603px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3808-5-4-3"
-     x="584"
-     y="737.12408">
-    <tspan
-       id="tspan3810-0-3-9"
-       y="800.62408"
-       x="694" />
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-31-9-0-8-7"
-     d="m 715,754.12408 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 20 80 8 v 40 h -8 -80 -20 -8 c -4.18879,0 -8,-3.81121 -8,-8 v -8 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text23-5-1-8-0-7"
-     y="738.38574"
-     x="698">
-    <tspan
-       id="tspan25-4-4-9-3-0"
-       y="764.38574"
-       x="828">arg 1</tspan>
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text27-0-0-1-5-7"
-     x="698"
-     y="726.38574">
-    <tspan
-       id="tspan29-8-9-4-8-9"
-       y="748.88574"
-       x="828" />
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-2-1-0-6"
-     d="m 715,780.12408 h 120 v 40 H 715 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-1-0-1-0"
-     y="781.12408"
-     x="747">
-    <tspan
-       id="tspan25-7-0-5-2-5"
-       y="807.12408"
-       x="767">20</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-7"
-     d="m 389,796.12408 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.18879,0 8,3.81121 8,8 v 8 8 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 h -16 v -4 h -2 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45308 -2.92893,7.07107 v 8 176.00002 8 c 0,2.618 1.07773,5.2199 2.92893,7.0711 1.8512,1.8512 4.53124,3.5638 7.07107,2.9289 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.1888 -3.93628,9.0159 -8,8 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.18879,0 -8,-3.8112 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-0"
-     x="388"
-     y="779.12408">
-    <tspan
-       id="tspan3039-7"
-       y="809.62408"
-       x="396">no clock</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-23"
-     d="m 371,754.12408 v -8 c 0,-4.18879 3.8112,-8 8,-8 h 8 v 4 h 20 v -4 h 18 158 8 c 4.1888,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.8112,8 -8,8 h -8 -158 -2 v 4 h -16 v -4 h -2 -8 c -2.618,0 -5.2199,1.07774 -7.0711,2.92894 -1.8512,1.8512 -2.9289,4.45307 -2.9289,7.07106 v 8 8 260.00002 c 0,2.618 1.0777,5.2198 2.9289,7.0711 1.8512,1.8512 4.5313,2.2939 7.0711,2.9289 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.1888 -3.9363,6.9841 -8,8 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.1888,0 -8,-3.8112 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-1"
-     x="370"
-     y="737.12415">
-    <tspan
-       id="tspan3039-7-3"
-       y="767.62415"
-       x="378">adjust transposition</tspan>
-  </text>
-  <path
-     d="m 425,922.12414 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -5.99999 h -8 v 19.99999 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 -42 z"
-     id="path3194-36-6"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196-75-2"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="424"
-     y="905.12415">
-    <tspan
-       x="518"
-       y="954.12415"
-       id="tspan3198-3-1">pitch</tspan>
-  </text>
-  <text
-     id="text3200-5-7"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="424"
-     y="907.12415">
-    <tspan
-       x="518"
-       y="929.62415"
-       id="tspan3202-6-8">name</tspan>
-  </text>
-  <text
-     id="text3204-2-5"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="424"
-     y="909.12415">
-    <tspan
-       x="518"
-       y="973.62415"
-       id="tspan3206-9-7">octave</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-1-4"
-     d="m 539,906.12414 h 120 v 40.00001 H 539 v -16.00001 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     x="568"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-2-2-1"
-     y="905.12415">
-    <tspan
-       id="tspan25-70-8"
-       y="931.12415"
-       x="588">re</tspan>
-  </text>
-  <path
-     d="m 539,948.12414 h 120 v 40 H 539 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-9-5"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-3-2-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="574"
-     y="947.12415">
-    <tspan
-       x="594"
-       y="973.12415"
-       id="tspan25-8-6-7">4</tspan>
-  </text>
-  <path
-     d="m 407,838.12416 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18 60 8 c 4.41828,0 9.07159,3.71364 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41827 -3.58172,8 -8,8 h -8 -60 -2 v 4 h -16 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,9.99999 v 8 92.00001 7.99999 c 0,5.52285 4.64205,11.3395 10,10 h 8 v 4 h 20 v -4 h 16 v 11.99995 12 8 c 0,4.4183 -3.71365,9.0716 -8,8 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.41828,0 -8,-3.5817 -8,-8 v -8 z"
-     id="path3035-0-5"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-6-3"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="819.12415"
-     x="404">
-    <tspan
-       x="412"
-       y="849.62415"
-       id="tspan3039-2-8">note value</tspan>
-  </text>
-  <path
-     d="m 653,864.12416 h 120 v 40 H 653 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-1-1-6-3"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-8-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="680"
-     y="863.12415">
-    <tspan
-       x="700"
-       y="889.12415"
-       id="tspan25-8-5-7-8">16</tspan>
-  </text>
-  <path
-     d="m 539,838.12416 v -8 a 8,8 0 0 1 8,-8 h 8 20 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -20 -8 a 8,8 0 0 1 -8,-8 v -8 -42 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 z"
-     id="path3798-4-4-5-2-64"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="821.12415"
-     id="text3800-3-2-0-0-33"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     x="514">
-    <tspan
-       x="624"
-       y="870.12415"
-       id="tspan3802-6-2-5-2-3">/</tspan>
-  </text>
-  <g
-     transform="translate(406,779.12416)"
-     id="g5147-3-8">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-8-2-1-0-6-7-6"
-       d="M 247,43 H 367 V 83 H 247 V 67 65 h -12 v 6 h -4 V 55 h 4 v 6 h 12 v -2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0-1-0-1-0-5-0"
-       y="44"
-       x="279">
-      <tspan
-         id="tspan25-7-0-5-2-5-9-4"
-         y="70.000031"
-         x="299">1</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-2-8"
-     d="m 425,880.12416 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 60 8 c 4.41828,0 8,3.58172 8,8 v 8 8 8 c 0,4.41828 -3.71364,6.92841 -8,8 h -8 -60 -2 v 4 h -16 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 0 z" />
-  <text
-     id="text6137-2-8"
-     y="891.04724"
-     x="506.823"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="891.04724"
-       x="506.823"
-       id="tspan6139-8-8">↓</tspan></text>
-  <g
-     transform="matrix(1.185185,0,0,1.185185,-90.19436,-22.222455)"
-     id="g4634">
-    <path
-       style="fill:#ffc1c1;fill-opacity:1;stroke:#ff0000;stroke-width:0.37087584px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4725"
-       d="m 167.00762,39.539118 c 0,0 -0.46531,-0.370876 -0.74175,-0.370876 -0.55287,0 -1.09256,0.350814 -1.4835,0.741752 -0.58641,0.586406 -0.62773,1.552489 -1.11263,2.225255 -0.30668,0.425495 -0.68713,0.805948 -1.11263,1.112627 -0.67276,0.484903 -1.63885,0.526222 -2.22525,1.112628 -0.39094,0.390937 -0.74175,0.930634 -0.74175,1.483503 0,0.552869 0.43649,1.312961 0.74175,1.483503 0.96247,0.537721 0.31028,0.240518 0.74175,0.741752 0,0 -0.38587,1.22419 -0.37088,1.854379 0.0165,1.238632 0.45294,2.480604 0.74176,2.967007 0.18935,0.318895 1.34328,1.657344 2.22525,2.225255 0.88807,0.571841 1.97446,0.763668 3.02812,0.8376 1.13698,0.07978 2.21652,-0.132168 3.21565,-0.680635 0.61304,-0.336524 1.12013,-0.71383 1.54462,-1.269593 0.60499,-0.792083 1.22769,-1.632821 1.48351,-2.59613 0.15865,-0.597419 0.0755,-1.240885 0,-1.85438 -0.0623,-0.505901 -0.47178,-0.983869 -0.37088,-1.483503 0.12236,-0.605895 0.86033,-0.919212 1.11263,-1.483503 0.2573,-0.575467 0.62589,-1.277899 0.37087,-1.854379 -0.29162,-0.659231 -1.24525,-0.727152 -1.85438,-1.112628 -0.37665,-0.238358 -0.78107,-0.443829 -1.11262,-0.741752 -0.71819,-0.645351 -1.2767,-1.451586 -1.85438,-2.225255 -0.26668,-0.357158 -0.38752,-0.842067 -0.74175,-1.112627 -0.31068,-0.237297 -0.73215,-0.460695 -1.11263,-0.370876 -0.17016,0.04017 -0.37088,0.370876 -0.37088,0.370876" />
-    <path
-       d="m 172.57866,47.803117 c 0,0 0.54294,2.128427 0.37128,3.183536 -0.18671,1.147562 -0.64302,2.34396 -1.48511,3.183536 -0.76475,0.762463 -1.18949,1.049013 -2.22767,1.414905 -0.47858,0.168668 -1.84456,0.353726 -2.4159,0.353726 -0.57135,0 -1.93733,-0.185059 -2.41591,-0.353727 -1.03818,-0.365892 -1.46292,-0.652441 -2.22766,-1.414904 -0.84209,-0.839576 -1.29841,-2.035975 -1.48512,-3.183536 -0.17166,-1.055109 0.37128,-3.183536 0.37128,-3.183536 m 4.82661,-2.122358 c 0,0 -1.52881,1.745204 -2.59894,2.122358 -0.69643,0.245448 -1.5584,0.30646 -2.22767,0 -0.71423,-0.327051 -1.32906,-1.028431 -1.48511,-1.768631 -0.17743,-0.841581 0.2073,-1.529325 0.91624,-2.050581 0.76674,-0.563756 1.70542,-0.616723 2.42526,-1.132956 0.93281,-0.668963 1.08012,-1.998936 1.85639,-2.829809 0.52688,-0.563939 2.04463,-1.414905 2.04463,-1.414905 0,0 1.51774,0.850966 2.04462,1.414905 0.77627,0.830873 0.92358,2.160847 1.85639,2.82981 0.71984,0.516232 1.68334,0.54353 2.45008,1.085677 0.71847,0.508023 1.06885,1.256279 0.89142,2.097859 -0.15605,0.740201 -0.77087,1.44158 -1.48511,1.768631 -0.66927,0.30646 -1.53123,0.245448 -2.22767,0 -1.07013,-0.377153 -2.59894,-2.122357 -2.59894,-2.122357"
-       id="path4505-6"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     transform="translate(91.18945,470.42154)"
+     id="g9706">
     <g
-       id="g4565"
-       transform="matrix(0.37127797,0,0,0.35372622,176.72956,39.358074)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+       transform="scale(1.5)"
+       id="g9704">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9698"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9702">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9700">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(121,72.421537)"
+     id="g9716">
+    <g
+       transform="scale(1.5)"
+       id="g9714">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9708"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9712">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9710">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(460,2.2215375)"
+     id="g9730">
+    <g
+       transform="scale(1.5)"
+       id="g9728">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 294 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9718"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9722">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan9720">action</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9726">
+        <tspan
+           x="60.333332"
+           y="5.25"
+           id="tspan9724" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(554.5,11.221537)"
+     id="g9740">
+    <g
+       transform="scale(1.5)"
+       id="g9738">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9732"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9736">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9734">square</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(473.5,42.721537)"
+     id="g9754">
+    <g
+       transform="scale(1.5)"
+       id="g9752">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9742"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9746">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan9744">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9750">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan9748" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(545.5,42.721537)"
+     id="g9764">
+    <g
+       transform="scale(1.5)"
+       id="g9762">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9756"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9760">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9758">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(487,74.221537)"
+     id="g9778">
+    <g
+       transform="scale(1.5)"
+       id="g9776">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 33.344727 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#9ddd5f;fill-opacity:1;stroke:#003e00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9766"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9770">
+        <tspan
+           x="49.678059"
+           y="13.5"
+           id="tspan9768">forward</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9774">
+        <tspan
+           x="49.678059"
+           y="11.25"
+           id="tspan9772" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(565.51709,74.221537)"
+     id="g9788">
+    <g
+       transform="scale(1.5)"
+       id="g9786">
+      <path
+         d="m 8.5,0.5 h 70 v 20 h -70 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9780"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9784">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9782">arg 1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(487,105.72154)"
+     id="g9802">
+    <g
+       transform="scale(1.5)"
+       id="g9800">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#9ddd5f;fill-opacity:1;stroke:#003e00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9790"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9794">
+        <tspan
+           x="46.333332"
+           y="13.5"
+           id="tspan9792">right</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9798">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan9796" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(560.5,105.72154)"
+     id="g9812">
+    <g
+       transform="scale(1.5)"
+       id="g9810">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9804"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9808">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9806">90</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(473.5,168.72154)"
+     id="g9830">
+    <g
+       transform="scale(1.5)"
+       id="g9828">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#9ddd5f;fill-opacity:1;stroke:#003e00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9814"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9818">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan9816">arc</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9822">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan9820">angle</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9826">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan9824">radius</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(547,168.72154)"
+     id="g9840">
+    <g
+       transform="scale(1.5)"
+       id="g9838">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9832"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9836">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9834">90</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(547,200.22154)"
+     id="g9850">
+    <g
+       transform="scale(1.5)"
+       id="g9848">
+      <path
+         d="m 8.5,0.5 h 70 v 20 h -70 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9842"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9846">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9844">arg 1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(721.90088,231.72154)"
+     id="g9860">
+    <g
+       transform="scale(1.5)"
+       id="g9858">
+      <path
+         d="m 8.5,0.5 h 70 v 20 h -70 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9852"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9856">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9854">arg 1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(636.40088,231.72154)"
+     id="g9878">
+    <g
+       transform="scale(1.5)"
+       id="g9876">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9862"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9866">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan9864">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9870">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan9868" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9874">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan9872" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(721.90088,263.22154)"
+     id="g9888">
+    <g
+       transform="scale(1.5)"
+       id="g9886">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9880"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9884">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9882">20</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(487,263.22154)"
+     id="g9898">
+    <g
+       transform="scale(1.5)"
+       id="g9896">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 16.68457 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 84 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9890"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9894">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan9892">no clock</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(500.5,294.72154)"
+     id="g9912">
+    <g
+       transform="scale(1.5)"
+       id="g9910">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9900"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9904">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan9902">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9908">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan9906" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(596.72119,294.72154)"
+     id="g9930">
+    <g
+       transform="scale(1.5)"
+       id="g9928">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9914"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9918">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan9916">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9922">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan9920" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9926">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan9924" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(682.22119,294.72154)"
+     id="g9940">
+    <g
+       transform="scale(1.5)"
+       id="g9938">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9932"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9936">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9934">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(682.22119,326.22154)"
+     id="g9950">
+    <g
+       transform="scale(1.5)"
+       id="g9948">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9942"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9946">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9944">16</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(514,326.22154)"
+     id="g9960">
+    <g
+       transform="scale(1.5)"
+       id="g9958">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9952"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9956">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan9954">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(514,357.72154)"
+     id="g9978">
+    <g
+       transform="scale(1.5)"
+       id="g9976">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9962"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9966">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan9964">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9970">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan9968">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9974">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan9972">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(587.5,357.72154)"
+     id="g9988">
+    <g
+       transform="scale(1.5)"
+       id="g9986">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9980"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9984">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9982">re</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(587.5,389.22154)"
+     id="g9998">
+    <g
+       transform="scale(1.5)"
+       id="g9996">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9990"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9994">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9992">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(14.5,40.921537)"
+     id="g10016">
+    <g
+       transform="scale(1.5)"
+       id="g10014">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 4 a 4,4 90 0 1 4,4 v 4 9 a 8,8 90 0 0 -8,8 8,8 90 0 0 8,8 v 4 a 4,4 90 0 1 -4,4 h -4 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 12 4 a 4,4 90 0 1 -4,4 h -4 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10000"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10004">
+        <tspan
+           x="5.3333335"
+           y="18.583334"
+           id="tspan10002">if</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10008">
+        <tspan
+           x="30.666666"
+           y="37.833332"
+           id="tspan10006">then</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10012">
+        <tspan
+           x="30.666666"
+           y="79.833336"
+           id="tspan10010">else</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(56.5,40.921537)"
+     id="g10028">
+    <g
+       transform="scale(1.5)"
+       id="g10026">
       <g
-         id="g4553"
-         transform="translate(0,-1)"
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1">
+         transform="translate(0,-16)"
+         id="g10020">
         <path
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664"
-           id="path3411-7"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285"
-           id="path3413-5"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           d="m 0.5,41.5 a 7,7 90 0 1 7,-7 h 1 v -10 a 8,8 90 0 1 8,-8 h 34 v 8 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 8 h -30 -12 v -8 -1 h -1 a 7,7 90 0 1 -7,-7 z"
+           style="fill:#f2ec4d;fill-opacity:1;stroke:#4f4c00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+           id="path10018"
+           inkscape:connector-curvature="0" />
       </g>
-      <g
-         id="g4557"
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1">
-        <path
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658"
-           id="path3411-3"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075"
-           id="path3413-56"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10024">
+        <tspan
+           x="37.666668"
+           y="25.666666"
+           id="tspan10022">&lt;</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(121,40.921537)"
+     id="g10038">
     <g
-       id="g4636"
-       transform="matrix(0.37127797,0,0,0.35372622,176.92563,38.650622)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <ellipse
-         cx="-30.836912"
-         cy="14.612609"
-         id="circle3409-2"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <ellipse
-         cx="-23.593306"
-         cy="14.699166"
-         id="ellipse4229-9"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       transform="scale(1.5)"
+       id="g10036">
+      <path
+         d="m 8.5,0.5 h 70 v 20 h -70 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10030"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10034">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10032">arg 1</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(28,103.92154)"
+     id="g10052">
     <g
-       id="g4632"
-       transform="matrix(0.37127797,0,0,0.35372622,176.96142,38.650622)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+       transform="scale(1.5)"
+       id="g10050">
       <path
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25"
-         id="path4303-1"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25"
-         id="path4303-1-2"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10040"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10044">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan10042">return</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10048">
+        <tspan
+           x="56.333332"
+           y="11.25"
+           id="tspan10046" />
+      </text>
     </g>
-    <path
-       d="m 167.72688,38.606235 c -0.51355,0.487351 -0.73647,0.882428 -0.91229,0.882428 -0.24578,0 -0.47204,-0.395077 -0.91229,-0.882428 -0.36084,-0.399437 0.40844,-0.882428 0.91229,-0.882428 0.50385,0 1.3103,0.504726 0.91229,0.882428 z"
-       id="path4227-7"
-       style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.80251253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4653"
-       d="m 167.04984,55.935948 c 0,0 0.26819,1.158553 2.03989,1.361113 1.77169,0.202559 4.37064,-1.401457 5.48447,-3.523814 1.11384,-2.122358 0.8911,-4.261654 1.11384,-6.720799" />
+  </g>
+  <g
+     transform="translate(116.5,103.92154)"
+     id="g10062">
+    <g
+       transform="scale(1.5)"
+       id="g10060">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10054"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10058">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10056">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(28,166.92154)"
+     id="g10076">
+    <g
+       transform="scale(1.5)"
+       id="g10074">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10064"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10068">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan10066">return</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10072">
+        <tspan
+           x="56.333332"
+           y="11.25"
+           id="tspan10070" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(116.5,166.92154)"
+     id="g10094">
+    <g
+       transform="scale(1.5)"
+       id="g10092">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 42 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -42 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10078"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10082">
+        <tspan
+           x="54.333332"
+           y="44.799999"
+           id="tspan10080">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10086">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan10084" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10090">
+        <tspan
+           x="54.333332"
+           y="73.75"
+           id="tspan10088" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(28,198.42154)"
+     id="g10104">
+    <g
+       transform="scale(1.5)"
+       id="g10102">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10096"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10100">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan10098">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(202,166.92154)"
+     id="g10114">
+    <g
+       transform="scale(1.5)"
+       id="g10112">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 9 29.467773 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 35.5 h -4 a 5,5 90 0 0 -5,5 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 21 4 a 5,5 90 0 0 5,5 h 4 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -63 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10106"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10110">
+        <tspan
+           x="12"
+           y="15.25"
+           id="tspan10108">calculate</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(300.20166,166.92154)"
+     id="g10124">
+    <g
+       transform="scale(1.5)"
+       id="g10122">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10116"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10120">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10118">fib</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(316,198.42154)"
+     id="g10134">
+    <g
+       transform="scale(1.5)"
+       id="g10132">
+      <path
+         d="m 8.5,0.5 h 70 v 20 h -70 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10126"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10130">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10128">arg 1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(230.5,198.42154)"
+     id="g10152">
+    <g
+       transform="scale(1.5)"
+       id="g10150">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10136"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10140">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan10138">–</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10144">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan10142" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10148">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan10146" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(316,229.92154)"
+     id="g10162">
+    <g
+       transform="scale(1.5)"
+       id="g10160">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10154"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10158">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10156">-1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(202,261.42154)"
+     id="g10172">
+    <g
+       transform="scale(1.5)"
+       id="g10170">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 9 29.467773 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 35.5 h -4 a 5,5 90 0 0 -5,5 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 21 4 a 5,5 90 0 0 5,5 h 4 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -63 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10164"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10168">
+        <tspan
+           x="12"
+           y="15.25"
+           id="tspan10166">calculate</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(300.20166,261.42154)"
+     id="g10182">
+    <g
+       transform="scale(1.5)"
+       id="g10180">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10174"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10178">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10176">fib</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(230.5,292.92154)"
+     id="g10200">
+    <g
+       transform="scale(1.5)"
+       id="g10198">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10184"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10188">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan10186">–</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10192">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan10190" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10196">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan10194" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(316,324.42154)"
+     id="g10210">
+    <g
+       transform="scale(1.5)"
+       id="g10208">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10202"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10206">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10204">-2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(316,292.92154)"
+     id="g10220">
+    <g
+       transform="scale(1.5)"
+       id="g10218">
+      <path
+         d="m 8.5,0.5 h 70 v 20 h -70 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10212"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10216">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10214">arg 1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,533.42154)"
+     id="g10230">
+    <g
+       transform="scale(1.5)"
+       id="g10228">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -4 a 5,5 90 0 0 -5,5 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 63 4 a 5,5 90 0 0 5,5 h 4 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10222"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10226">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan10224">do</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(99,533.42154)"
+     id="g10240">
+    <g
+       transform="scale(1.5)"
+       id="g10238">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10232"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10236">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10234">square</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(43.5,564.92154)"
+     id="g10258">
+    <g
+       transform="scale(1.5)"
+       id="g10256">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 42 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -42 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10242"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10246">
+        <tspan
+           x="54.333332"
+           y="44.799999"
+           id="tspan10244">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10250">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan10248" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10254">
+        <tspan
+           x="54.333332"
+           y="73.75"
+           id="tspan10252" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(129,659.42154)"
+     id="g10268">
+    <g
+       transform="scale(1.5)"
+       id="g10266">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10260"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10264">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10262">20</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(129,564.92154)"
+     id="g10278">
+    <g
+       transform="scale(1.5)"
+       id="g10276">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 9 29.467773 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 35.5 h -4 a 5,5 90 0 0 -5,5 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 5,5 90 0 0 5,5 h 4 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -42 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10270"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10274">
+        <tspan
+           x="12"
+           y="15.25"
+           id="tspan10272">calculate</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(227.20166,564.92154)"
+     id="g10288">
+    <g
+       transform="scale(1.5)"
+       id="g10286">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10280"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10284">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10282">fib</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(157.5,596.42154)"
+     id="g10298">
+    <g
+       transform="scale(1.5)"
+       id="g10296">
+      <path
+         d="m 8.5,0.5 h 80 v 20 h -80 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10290"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10294">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10292">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,722.42154)"
+     id="g10316">
+    <g
+       transform="scale(1.5)"
+       id="g10314">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10300"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10304">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan10302">add</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10308">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan10306">to</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text10312">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan10310">value</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,722.42154)"
+     id="g10326">
+    <g
+       transform="scale(1.5)"
+       id="g10324">
+      <path
+         d="m 8.5,0.5 h 80 v 20 h -80 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10318"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10322">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10320">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,753.92154)"
+     id="g10336">
+    <g
+       transform="scale(1.5)"
+       id="g10334">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path10328"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text10332">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan10330">1</tspan>
+      </text>
+    </g>
   </g>
 </svg>

--- a/guide/graphics1.svg
+++ b/guide/graphics1.svg
@@ -5,13 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="671.90088"
+   height="522.84308"
    version="1.1"
-   width="806"
-   height="697.12408"
-   id="svg3641"
-   viewBox="0 0 806 697.12408">
+   id="svg8422"
+   sodipodi:docname="graphics1.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata3670">
+     id="metadata8428">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -23,767 +26,1012 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3668" />
-  <path
-     d="m 1,29.56205 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 L 27,1.5620499 37,13.56205 h 18 70 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -70 -2 v 4 H 37 v -4 h -2 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 C 18.07773,58.34218 17,60.94405 17,63.56205 v 8 384 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.531247,2.29397 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18878 -3.93628,9.01593 -8,8 H 55 37 l -10,12 -10,-12 H 9 c -4.18879,0 -8,-3.81122 -8,-8 v -8 z"
-     id="path3027-4"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="-0.055397034"
-     y="-1.7267047"
-     id="text3029-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="7.944603"
-       y="41.273296"
-       id="tspan3031-5">action</tspan>
-  </text>
-  <path
-     d="m 143,13.56205 h 120 v 40 H 143 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-2-0"
-     style="fill:#5DC1BC;fill-opacity:1;stroke:#5AA4AF;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="149.21786"
-     y="12.018046"
-     id="text23-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="169.21786"
-       y="38.018032"
-       id="tspan25-1">chunk</tspan>
-  </text>
-  <path
-     d="m 401,29.56205 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 l 10,-12 10,12 h 18 60 8 c 4.18879,0 8,3.81121 8,8 v 8 8 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -60 -2 v 4 h -16 v -4 h -2 -8 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 C 418.07773,58.342183 417,60.944056 417,63.56205 v 8 8 554 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,2.29397 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.93628,6.98407 -8,8 h -8 -18 l -10,12 -10,-12 h -8 c -4.18879,0 -8,-3.81121 -8,-8 v -8 z"
-     id="path3660"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3662"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="400"
-     y="0.56205004">
-    <tspan
-       x="408"
-       y="43.56205"
-       id="tspan3664">start</tspan>
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3095"
-     x="324"
-     y="475.12411">
-    <tspan
-       id="tspan3097"
-       y="497.62411"
-       x="434" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3107"
-     x="324"
-     y="265.12411">
-    <tspan
-       id="tspan3109"
-       y="287.62411"
-       x="418" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033"
-     x="324"
-     y="223.1241">
-    <tspan
-       id="tspan3035"
-       y="245.6241"
-       x="426" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3317"
-     x="306"
-     y="55.1241">
-    <tspan
-       id="tspan3319"
-       y="77.6241"
-       x="448" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3095-2"
-     x="324"
-     y="433.12411">
-    <tspan
-       id="tspan3097-4"
-       y="455.62411"
-       x="434" />
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3027"
-     d="m 37,238.1241 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 68 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -68 -2 v 4 H 55 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3029"
-     x="36"
-     y="221.12408">
-    <tspan
-       id="tspan3031"
-       y="249.12408"
-       x="138">forward</tspan>
-  </text>
-  <path
-     d="m 159,222.12411 h 120 v 40 H 159 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-72-7-7-1"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-5-5-0-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="194"
-     y="221.12411">
-    <tspan
-       x="214"
-       y="247.12411"
-       id="tspan25-8-7-0-3-3">10</tspan>
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3058"
-     d="m 473,324.1241 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 80 8 a 8,8 0 0 1 8,8 v 8 8 8 a 8,8 0 0 1 -8,8 h -8 -80 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3060"
-     x="472"
-     y="307.12411">
-    <tspan
-       id="tspan3062"
-       y="335.12411"
-       x="586">chunk</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3089"
-     d="m 455,450.1241 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 76 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -76 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3091"
-     x="454"
-     y="433.12411">
-    <tspan
-       id="tspan3093"
-       y="461.12411"
-       x="564">add 1 to</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124"
-     d="m 455,492.1241 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 -42 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3126"
-     x="454"
-     y="475.12408">
-    <tspan
-       id="tspan3128"
-       y="524.12408"
-       x="548">add</tspan>
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3130"
-     x="454"
-     y="477.12408">
-    <tspan
-       id="tspan3132"
-       y="499.62408"
-       x="548">to</tspan>
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3134"
-     x="454"
-     y="479.12408">
-    <tspan
-       id="tspan3136"
-       y="543.62408"
-       x="548">value</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3172"
-     d="m 685,266.1241 h 120 v 40 H 685 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3174"
-     x="668"
-     y="265.12411">
-    <tspan
-       id="tspan3176"
-       y="291.12411"
-       x="688">box</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21"
-     d="m 437,156.12408 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 76 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -76 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 -42 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text23"
-     x="436"
-     y="139.12408">
-    <tspan
-       id="tspan25"
-       y="188.12408"
-       x="546">store in</tspan>
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text27"
-     x="436"
-     y="141.12408">
-    <tspan
-       id="tspan29"
-       y="163.62408"
-       x="546">name</tspan>
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text31"
-     x="436"
-     y="143.12408">
-    <tspan
-       id="tspan33"
-       y="207.62408"
-       x="546">value</tspan>
-  </text>
-  <path
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3090"
-     d="m 585,434.1241 h 140 v 40 H 585 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3092"
-     x="568"
-     y="433.12411">
-    <tspan
-       id="tspan3094"
-       y="459.12411"
-       x="588">color</tspan>
-  </text>
-  <path
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3027-7"
-     d="m 569,476.1241 h 156 v 40 H 569 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3029-8"
-     x="552"
-     y="475.12408">
-    <tspan
-       id="tspan3031-1"
-       y="501.12408"
-       x="572">pen size</tspan>
-  </text>
-  <path
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3311"
-     d="m 437,114.1241 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 108 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -108 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3313"
-     x="436"
-     y="97.1241">
-    <tspan
-       id="tspan3315"
-       y="125.1241"
-       x="578">set pen size</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-8"
-     d="m 455,282.1241 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 158 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -158 -2 v 4 h -16 v -4 h -2 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45308 -2.92893,7.07107 v 8 8 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.45308,2.92893 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.18879,0 -8,-3.81121 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-9"
-     x="454"
-     y="265.12411">
-    <tspan
-       id="tspan3039-2"
-       y="295.62411"
-       x="462">adjust transposition</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3089-6"
-     d="m 455,408.1241 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 76 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -76 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3091-9"
-     x="454"
-     y="391.12411">
-    <tspan
-       id="tspan3093-6"
-       y="419.12411"
-       x="564">add 1 to</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3172-8"
-     d="m 585,392.1241 h 120 v 40 H 585 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3174-5"
-     x="568"
-     y="391.12411">
-    <tspan
-       id="tspan3176-0"
-       y="417.12411"
-       x="588">box</tspan>
-  </text>
-  <path
-     d="m 567,140.12409 h 120 v 39.99999 H 567 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-2-0-6"
-     style="fill:#5DC1BC;fill-opacity:1;stroke:#5AA4AF;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="573.2179"
-     y="138.20615"
-     id="text23-2-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="593.2179"
-       y="164.20613"
-       id="tspan25-1-8">box</tspan>
-  </text>
-  <path
-     d="m 567,182.12408 h 120 v 40 H 567 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-72-7"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-5-5"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="602"
-     y="180.75015">
-    <tspan
-       x="622"
-       y="206.75015"
-       id="tspan25-8-7-0">0</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035"
-     d="m 437,240.1241 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.41828,0 8,3.58172 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -40 -2 v 4 h -16 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,10 v 8 260 8 c 0,5.52285 4.47715,10 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037"
-     x="436"
-     y="223.1241">
-    <tspan
-       id="tspan3039"
-       y="253.6241"
-       x="444">repeat</tspan>
-  </text>
-  <path
-     d="m 549,224.12411 h 120 v 40 H 549 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-72-7-7"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-5-5-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="584"
-     y="223.12411">
-    <tspan
-       x="604"
-       y="249.12411"
-       id="tspan25-8-7-0-3">24</tspan>
-  </text>
-  <path
-     d="M 599,98.124108 H 719 V 138.12411 H 599 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-72-7-7-4"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-5-5-0-8"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="634"
-     y="97.124107">
-    <tspan
-       x="654"
-       y="123.12411"
-       id="tspan25-8-7-0-3-9">50</tspan>
-  </text>
-  <path
-     d="m 569,518.12411 h 120 v 40 H 569 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-72-7-7-0"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-5-5-0-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="604"
-     y="517.12408">
-    <tspan
-       x="624"
-       y="543.12408"
-       id="tspan25-8-7-0-3-4">-2</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3101"
-     d="m 37,406.1241 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3103"
-     x="36"
-     y="389.12415">
-    <tspan
-       id="tspan3105"
-       y="417.12415"
-       x="130">right</tspan>
-  </text>
-  <path
-     d="m 151,390.12411 h 120 v 40 H 151 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-72-7-7-8"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-5-5-0-93"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="186"
-     y="389.12415">
-    <tspan
-       x="206"
-       y="415.12415"
-       id="tspan25-8-7-0-3-6">3</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-1"
-     d="m 419,72.12408 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.41828,0 8,3.58172 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -40 -2 v 4 h -16 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,10 v 8 470 8 c 0,5.52285 4.64205,8.66051 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-6"
-     x="418"
-     y="55.124081">
-    <tspan
-       id="tspan3039-26"
-       y="85.624077"
-       x="426">repeat</tspan>
-  </text>
-  <path
-     d="m 531,56.12409 h 120 v 40 H 531 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-72-7-7-13"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-5-5-0-82"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="566"
-     y="55.124096">
-    <tspan
-       x="586"
-       y="81.124092"
-       id="tspan25-8-7-0-3-8">5</tspan>
-  </text>
-  <path
-     d="m 19,322.12408 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 H 73.000003 133 h 8 c 4.41828,0 9.07159,3.71364 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41827 -3.58172,8 -8,8 h -8 -59.999997 -2 v 4 H 55 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,10 v 8 50.00001 7.99999 c 0,5.52285 4.64205,11.3395 10,10 h 8 v 4 h 20.000003 v -4 h 16 v 12 12 8 c 0,4.41828 -3.71365,9.0716 -8,8 h -8 H 55 53 v 4 H 37 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 z"
-     id="path3035-0"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-6-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="303.12408"
-     x="15.999998">
-    <tspan
-       x="23.999998"
-       y="333.62411"
-       id="tspan3039-2-1">note value</tspan>
-  </text>
+     id="defs8426" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="751"
+     id="namedview8424"
+     showgrid="false"
+     inkscape:zoom="0.2079063"
+     inkscape:cx="572"
+     inkscape:cy="261.42154"
+     inkscape:window-x="0"
+     inkscape:window-y="282"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8422" />
   <g
-     transform="translate(18,347.12408)"
-     id="g5152-6">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-6-1-1"
-       d="m 247,1.000003 h 120 v 40 H 247 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       y="4.7314452e-06"
-       x="282"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-9-82-8">
-      <tspan
-         id="tspan25-8-5-7"
-         y="26.000004"
-         x="302">8</tspan>
-    </text>
-  </g>
-  <g
-     transform="translate(18,305.12408)"
-     id="g5157-9">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3798-4-4-5-2"
-       d="M 133,17 V 9 a 8,8 0 0 1 8,-8 h 8 20 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -20 -8 a 8,8 0 0 1 -8,-8 V 67 25 23 h -12 v 6 h -4 V 13 h 4 v 6 h 12 z" />
-    <text
-       x="108"
-       style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-       id="text3800-3-2-0-0"
-       y="-2.2888184e-05">
-      <tspan
-         id="tspan3802-6-2-5-2"
-         y="49"
-         x="218">/</tspan>
-    </text>
+     transform="translate(13.5,42.921537)"
+     id="g7960">
     <g
-       id="g5147-3"
-       transform="translate(0,-42)">
+       transform="scale(1.5)"
+       id="g7958">
       <path
-         d="M 247,43 H 367 V 83 H 247 V 67 65 h -12 v 6 h -4 V 55 h 4 v 6 h 12 v -2 z"
-         id="path21-8-2-1-0-6-7"
-         style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7948"
+         inkscape:connector-curvature="0" />
       <text
-         x="279"
-         y="44"
-         id="text23-0-1-0-1-0-5"
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7952">
         <tspan
-           x="299"
-           y="70.000031"
-           id="tspan25-7-0-5-2-5-9">1</tspan>
+           x="5.3333335"
+           y="15.25"
+           id="tspan7950">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7956">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan7954" />
       </text>
     </g>
   </g>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-2"
-     d="m 37,364.12409 v -8 c 0,-4.41828 3.58172,-8.00001 8,-8.00001 h 8 v 4.00001 h 20.000003 v -4.00001 H 133 h 8 c 4.41828,0 8,3.58173 8,8.00001 v 8 8 8 c 0,4.41828 -3.71364,6.92841 -8,8 h -8 -59.999997 -2 v 4 H 55 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 0 z" />
-  <text
-     id="text6137-2"
-     y="375.04718"
-     x="118.823"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="375.04718"
-       x="118.823"
-       id="tspan6139-8">↓</tspan></text>
-  <path
-     d="m 37,154.12407 v -7.99999 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 60 8 a 8,8 0 0 1 8,8 v 7.99999 h -8 v -5.99999 h -8 v 19.99999 h 8 v -6 h 8 v 34 h -8 v -5.99999 h -8 v 19.99999 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 -42 z"
-     id="path3194-2"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196-5"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="36"
-     y="137.12408">
-    <tspan
-       x="130"
-       y="186.12411"
-       id="tspan3198-4">pitch</tspan>
-  </text>
-  <text
-     id="text3200-7"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="36"
-     y="139.12408">
-    <tspan
-       x="130"
-       y="161.62408"
-       id="tspan3202-4">note</tspan>
-  </text>
-  <text
-     id="text3204-43"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="36"
-     y="141.12408">
-    <tspan
-       x="130"
-       y="205.62411"
-       id="tspan3206-07">octave</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8"
-     d="m 151,138.12408 h 120 v 40 H 151 v -16.00001 -2 h -12 v 6 h -4 v -15.99999 h 4 v 5.99999 h 12 v -2 z" />
-  <text
-     x="176"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-68"
-     y="137.12408">
-    <tspan
-       id="tspan25-84"
-       y="163.12408"
-       x="196">sol</tspan>
-  </text>
-  <path
-     d="m 151,180.12407 h 120 v 40 H 151 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-3"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="186"
-     y="179.12411">
-    <tspan
-       x="206"
-       y="205.12411"
-       id="tspan25-8-4">4</tspan>
-  </text>
-  <path
-     d="m 19,70.12409 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18 60 8 c 4.41828,0 9.07159,3.71364 8,8 v 8 h -8 v -6 h -8 V 84.1241 h 8 v -6 h 8 v 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,9.99999 v 8 134 7.99999 c 0,5.52285 4.64205,11.3395 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.41828 -3.71364,9.0716 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 z"
-     id="path3035-9"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="51.124107"
-     x="16">
-    <tspan
-       x="24"
-       y="81.624107"
-       id="tspan3039-06">note value</tspan>
-  </text>
   <g
-     transform="translate(18,95.1241)"
-     id="g5152">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-6-1-8"
-       d="m 247,1.000003 h 120 v 40 H 247 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       y="4.7314452e-06"
-       x="280"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-9-82-9">
-      <tspan
-         id="tspan25-8-5-2"
-         y="26.000004"
-         x="300">4</tspan>
-    </text>
-  </g>
-  <g
-     transform="translate(18,53.12409)"
-     id="g5157">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3798-4-4-5"
-       d="M 133,17 V 9 a 8,8 0 0 1 8,-8 h 8 20 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -20 -8 a 8,8 0 0 1 -8,-8 V 67 25 23 h -12 v 6 h -4 V 13 h 4 v 6 h 12 z" />
-    <text
-       x="108"
-       style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-       id="text3800-3-2-0"
-       y="-2.2888184e-05">
-      <tspan
-         id="tspan3802-6-2-5"
-         y="49"
-         x="218">/</tspan>
-    </text>
+     transform="translate(109.72119,42.921537)"
+     id="g7978">
     <g
-       id="g5147"
-       transform="translate(0,-42)">
+       transform="scale(1.5)"
+       id="g7976">
       <path
-         d="M 247,43 H 367 V 83 H 247 V 67 65 h -12 v 6 h -4 V 55 h 4 v 6 h 12 v -2 z"
-         id="path21-8-2-1-0-6"
-         style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7962"
+         inkscape:connector-curvature="0" />
       <text
-         x="279"
-         y="44"
-         id="text23-0-1-0-1-0"
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7966">
         <tspan
-           x="299"
-           y="70.000031"
-           id="tspan25-7-0-5-2-5">1</tspan>
+           x="54.333332"
+           y="23.799999"
+           id="tspan7964">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7970">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7968" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7974">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7972" />
       </text>
     </g>
   </g>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-27"
-     d="m 37,112.1241 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 60 8 c 4.41828,0 8,3.58172 8,8 v 8 8 8 c 0,4.41828 -3.71364,6.92841 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 0 z" />
-  <text
-     id="text6137"
-     y="123.04721"
-     x="118.823"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="123.04721"
-       x="118.823"
-       id="tspan6139">↓</tspan></text>
   <g
-     transform="matrix(1.185185,0,0,1.185185,308.09629,-22.532107)"
-     id="g4634">
-    <path
-       style="fill:#ffc1c1;fill-opacity:1;stroke:#ff0000;stroke-width:0.37087584px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4725"
-       d="m 167.00762,39.539118 c 0,0 -0.46531,-0.370876 -0.74175,-0.370876 -0.55287,0 -1.09256,0.350814 -1.4835,0.741752 -0.58641,0.586406 -0.62773,1.552489 -1.11263,2.225255 -0.30668,0.425495 -0.68713,0.805948 -1.11263,1.112627 -0.67276,0.484903 -1.63885,0.526222 -2.22525,1.112628 -0.39094,0.390937 -0.74175,0.930634 -0.74175,1.483503 0,0.552869 0.43649,1.312961 0.74175,1.483503 0.96247,0.537721 0.31028,0.240518 0.74175,0.741752 0,0 -0.38587,1.22419 -0.37088,1.854379 0.0165,1.238632 0.45294,2.480604 0.74176,2.967007 0.18935,0.318895 1.34328,1.657344 2.22525,2.225255 0.88807,0.571841 1.97446,0.763668 3.02812,0.8376 1.13698,0.07978 2.21652,-0.132168 3.21565,-0.680635 0.61304,-0.336524 1.12013,-0.71383 1.54462,-1.269593 0.60499,-0.792083 1.22769,-1.632821 1.48351,-2.59613 0.15865,-0.597419 0.0755,-1.240885 0,-1.85438 -0.0623,-0.505901 -0.47178,-0.983869 -0.37088,-1.483503 0.12236,-0.605895 0.86033,-0.919212 1.11263,-1.483503 0.2573,-0.575467 0.62589,-1.277899 0.37087,-1.854379 -0.29162,-0.659231 -1.24525,-0.727152 -1.85438,-1.112628 -0.37665,-0.238358 -0.78107,-0.443829 -1.11262,-0.741752 -0.71819,-0.645351 -1.2767,-1.451586 -1.85438,-2.225255 -0.26668,-0.357158 -0.38752,-0.842067 -0.74175,-1.112627 -0.31068,-0.237297 -0.73215,-0.460695 -1.11263,-0.370876 -0.17016,0.04017 -0.37088,0.370876 -0.37088,0.370876" />
-    <path
-       d="m 172.57866,47.803117 c 0,0 0.54294,2.128427 0.37128,3.183536 -0.18671,1.147562 -0.64302,2.34396 -1.48511,3.183536 -0.76475,0.762463 -1.18949,1.049013 -2.22767,1.414905 -0.47858,0.168668 -1.84456,0.353726 -2.4159,0.353726 -0.57135,0 -1.93733,-0.185059 -2.41591,-0.353727 -1.03818,-0.365892 -1.46292,-0.652441 -2.22766,-1.414904 -0.84209,-0.839576 -1.29841,-2.035975 -1.48512,-3.183536 -0.17166,-1.055109 0.37128,-3.183536 0.37128,-3.183536 m 4.82661,-2.122358 c 0,0 -1.52881,1.745204 -2.59894,2.122358 -0.69643,0.245448 -1.5584,0.30646 -2.22767,0 -0.71423,-0.327051 -1.32906,-1.028431 -1.48511,-1.768631 -0.17743,-0.841581 0.2073,-1.529325 0.91624,-2.050581 0.76674,-0.563756 1.70542,-0.616723 2.42526,-1.132956 0.93281,-0.668963 1.08012,-1.998936 1.85639,-2.829809 0.52688,-0.563939 2.04463,-1.414905 2.04463,-1.414905 0,0 1.51774,0.850966 2.04462,1.414905 0.77627,0.830873 0.92358,2.160847 1.85639,2.82981 0.71984,0.516232 1.68334,0.54353 2.45008,1.085677 0.71847,0.508023 1.06885,1.256279 0.89142,2.097859 -0.15605,0.740201 -0.77087,1.44158 -1.48511,1.768631 -0.66927,0.30646 -1.53123,0.245448 -2.22767,0 -1.07013,-0.377153 -2.59894,-2.122357 -2.59894,-2.122357"
-       id="path4505-6"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     transform="translate(195.22119,42.921537)"
+     id="g7988">
     <g
-       id="g4565"
-       transform="matrix(0.37127797,0,0,0.35372622,176.72956,39.358074)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <g
-         id="g4553"
-         transform="translate(0,-1)"
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1">
-        <path
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664"
-           id="path3411-7"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285"
-           id="path3413-5"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <g
-         id="g4557"
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1">
-        <path
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658"
-           id="path3411-3"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075"
-           id="path3413-56"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </g>
-    <g
-       id="g4636"
-       transform="matrix(0.37127797,0,0,0.35372622,176.92563,38.650622)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <ellipse
-         cx="-30.836912"
-         cy="14.612609"
-         id="circle3409-2"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <ellipse
-         cx="-23.593306"
-         cy="14.699166"
-         id="ellipse4229-9"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="g4632"
-       transform="matrix(0.37127797,0,0,0.35372622,176.96142,38.650622)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+       transform="scale(1.5)"
+       id="g7986">
       <path
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25"
-         id="path4303-1"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25"
-         id="path4303-1-2"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7980"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7984">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7982">1</tspan>
+      </text>
     </g>
-    <path
-       d="m 167.72688,38.606235 c -0.51355,0.487351 -0.73647,0.882428 -0.91229,0.882428 -0.24578,0 -0.47204,-0.395077 -0.91229,-0.882428 -0.36084,-0.399437 0.40844,-0.882428 0.91229,-0.882428 0.50385,0 1.3103,0.504726 0.91229,0.882428 z"
-       id="path4227-7"
-       style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.80251253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4653"
-       d="m 167.04984,55.935948 c 0,0 0.26819,1.158553 2.03989,1.361113 1.77169,0.202559 4.37064,-1.401457 5.48447,-3.523814 1.11384,-2.122358 0.8911,-4.261654 1.11384,-6.720799" />
+  </g>
+  <g
+     transform="translate(195.22119,74.421537)"
+     id="g7998">
+    <g
+       transform="scale(1.5)"
+       id="g7996">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7990"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7994">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7992">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,74.421537)"
+     id="g8008">
+    <g
+       transform="scale(1.5)"
+       id="g8006">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8000"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8004">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan8002">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(0,2.4215375)"
+     id="g8022">
+    <g
+       transform="scale(1.5)"
+       id="g8020">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 189 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8010"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8014">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan8012">action</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8018">
+        <tspan
+           x="60.333332"
+           y="5.25"
+           id="tspan8016" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(94.5,11.421537)"
+     id="g8032">
+    <g
+       transform="scale(1.5)"
+       id="g8030">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8024"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8028">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8026">chunk</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(335,0.42153745)"
+     id="g8042">
+    <g
+       transform="scale(1.5)"
+       id="g8040">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 273 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8034"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8038">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan8036">start</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(348.5,40.921537)"
+     id="g8056">
+    <g
+       transform="scale(1.5)"
+       id="g8054">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 231 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8044"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8048">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan8046">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8052">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan8050" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(420.5,40.921537)"
+     id="g8066">
+    <g
+       transform="scale(1.5)"
+       id="g8064">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8058"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8062">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8060">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(389,229.92154)"
+     id="g8076">
+    <g
+       transform="scale(1.5)"
+       id="g8074">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8068"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8072">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan8070">chunk</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(375.5,198.42154)"
+     id="g8090">
+    <g
+       transform="scale(1.5)"
+       id="g8088">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8078"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8082">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan8080">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8086">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan8084" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(362,166.92154)"
+     id="g8104">
+    <g
+       transform="scale(1.5)"
+       id="g8102">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 126 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8092"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8096">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan8094">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8100">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan8098" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(434,166.92154)"
+     id="g8114">
+    <g
+       transform="scale(1.5)"
+       id="g8112">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8106"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8110">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8108">24</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,105.92154)"
+     id="g8132">
+    <g
+       transform="scale(1.5)"
+       id="g8130">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8116"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8120">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan8118">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8124">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan8122">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8128">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan8126">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,105.92154)"
+     id="g8142">
+    <g
+       transform="scale(1.5)"
+       id="g8140">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8134"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8138">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8136">sol</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,137.42154)"
+     id="g8152">
+    <g
+       transform="scale(1.5)"
+       id="g8150">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8144"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8148">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8146">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,168.92154)"
+     id="g8166">
+    <g
+       transform="scale(1.5)"
+       id="g8164">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 33.344727 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#9ddd5f;fill-opacity:1;stroke:#003e00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8154"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8158">
+        <tspan
+           x="49.678059"
+           y="13.5"
+           id="tspan8156">forward</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8162">
+        <tspan
+           x="49.678059"
+           y="11.25"
+           id="tspan8160" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(105.51709,168.92154)"
+     id="g8176">
+    <g
+       transform="scale(1.5)"
+       id="g8174">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8168"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8172">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8170">10</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,231.92154)"
+     id="g8190">
+    <g
+       transform="scale(1.5)"
+       id="g8188">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8178"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8182">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan8180">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8186">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan8184" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(109.72119,231.92154)"
+     id="g8208">
+    <g
+       transform="scale(1.5)"
+       id="g8206">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8192"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8196">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan8194">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8200">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan8198" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8204">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan8202" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,231.92154)"
+     id="g8218">
+    <g
+       transform="scale(1.5)"
+       id="g8216">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8210"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8214">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8212">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,263.42154)"
+     id="g8228">
+    <g
+       transform="scale(1.5)"
+       id="g8226">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8220"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8224">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8222">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,263.42154)"
+     id="g8238">
+    <g
+       transform="scale(1.5)"
+       id="g8236">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8230"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8234">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan8232">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,294.92154)"
+     id="g8252">
+    <g
+       transform="scale(1.5)"
+       id="g8250">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#9ddd5f;fill-opacity:1;stroke:#003e00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8240"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8244">
+        <tspan
+           x="46.333332"
+           y="13.5"
+           id="tspan8242">right</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8248">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan8246" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,294.92154)"
+     id="g8262">
+    <g
+       transform="scale(1.5)"
+       id="g8260">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8254"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8258">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8256">3</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(538.40088,198.42154)"
+     id="g8272">
+    <g
+       transform="scale(1.5)"
+       id="g8270">
+      <path
+         d="m 8.5,0.5 h 80 v 20 h -80 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8264"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8268">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8266">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(362,72.421537)"
+     id="g8286">
+    <g
+       transform="scale(1.5)"
+       id="g8284">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 53.364258 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8274"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8278">
+        <tspan
+           x="69.697594"
+           y="13.5"
+           id="tspan8276">set pen size</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8282">
+        <tspan
+           x="69.697594"
+           y="11.25"
+           id="tspan8280" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(470.54639,72.421537)"
+     id="g8296">
+    <g
+       transform="scale(1.5)"
+       id="g8294">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8288"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8292">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8290">50</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(362,103.92154)"
+     id="g8314">
+    <g
+       transform="scale(1.5)"
+       id="g8312">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 32.792969 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8298"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8302">
+        <tspan
+           x="49.126301"
+           y="24"
+           id="tspan8300">store in</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8306">
+        <tspan
+           x="49.126301"
+           y="11.25"
+           id="tspan8304">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8310">
+        <tspan
+           x="49.126301"
+           y="32.25"
+           id="tspan8308">value</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(439.68945,103.92154)"
+     id="g8324">
+    <g
+       transform="scale(1.5)"
+       id="g8322">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8316"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8320">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8318">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(439.68945,135.42154)"
+     id="g8334">
+    <g
+       transform="scale(1.5)"
+       id="g8332">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8326"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8330">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8328">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(375.5,292.92154)"
+     id="g8348">
+    <g
+       transform="scale(1.5)"
+       id="g8346">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 36.142578 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8336"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8340">
+        <tspan
+           x="52.47591"
+           y="13.5"
+           id="tspan8338">add 1 to</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8344">
+        <tspan
+           x="52.47591"
+           y="11.25"
+           id="tspan8342" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(458.21387,292.92154)"
+     id="g8358">
+    <g
+       transform="scale(1.5)"
+       id="g8356">
+      <path
+         d="m 8.5,0.5 h 80 v 20 h -80 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8350"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8354">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8352">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(375.5,324.42154)"
+     id="g8372">
+    <g
+       transform="scale(1.5)"
+       id="g8370">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 36.142578 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8360"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8364">
+        <tspan
+           x="52.47591"
+           y="13.5"
+           id="tspan8362">add 1 to</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8368">
+        <tspan
+           x="52.47591"
+           y="11.25"
+           id="tspan8366" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(375.5,355.92154)"
+     id="g8390">
+    <g
+       transform="scale(1.5)"
+       id="g8388">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8374"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8378">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan8376">add</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8382">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan8380">to</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8386">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan8384">value</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(449,355.92154)"
+     id="g8400">
+    <g
+       transform="scale(1.5)"
+       id="g8398">
+      <path
+         d="m 8.5,0.5 h 77.246094 v 20 H 8.5 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8392"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8396">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8394">pen size</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(458.21387,324.42154)"
+     id="g8410">
+    <g
+       transform="scale(1.5)"
+       id="g8408">
+      <path
+         d="m 8.5,0.5 h 70 v 20 h -70 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8402"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8406">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8404">color</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(449,387.42154)"
+     id="g8420">
+    <g
+       transform="scale(1.5)"
+       id="g8418">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8412"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8416">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8414">-2</tspan>
+      </text>
+    </g>
   </g>
 </svg>

--- a/guide/lilypond1.svg
+++ b/guide/lilypond1.svg
@@ -5,15 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="639.38788"
+   height="813.34308"
    version="1.1"
-   id="svg4075"
-   viewBox="0 0 708.00002 1075.124"
-   height="303.42389mm"
-   width="199.81334mm">
-  <defs
-     id="defs4077" />
+   id="svg1394"
+   sodipodi:docname="lilypond1.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata4080">
+     id="metadata1400">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,1096 +25,1413 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <text
-     x="-8.0000305"
-     y="274.67804"
-     id="text3033"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="93.999969"
-       y="297.17804"
-       id="tspan3035" />
-  </text>
-  <text
-     x="9.9999695"
-     y="339.6416"
-     id="text3107"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="103.99997"
-       y="362.1416"
-       id="tspan3109" />
-  </text>
-  <text
-     x="-8.0000305"
-     y="358.67804"
-     id="text3033-0"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="93.999969"
-       y="381.17804"
-       id="tspan3035-1" />
-  </text>
-  <text
-     x="-8.0000305"
-     y="442.67798"
-     id="text3033-1"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="93.999969"
-       y="465.17798"
-       id="tspan3035-8" />
-  </text>
-  <text
-     x="-8.0000305"
-     y="526.67798"
-     id="text3033-0-9"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="93.999969"
-       y="549.17798"
-       id="tspan3035-1-5" />
-  </text>
-  <path
-     d="m 0.99996948,29.56205 0,-8 c 0,-4.18879 3.81120982,-8 8.00000002,-8 l 7.9999995,0 10,-12.0000001 10,12.0000001 18,0 60.000001,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 0,8 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -60.000001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.617994,0 -5.219867,1.077731 -7.071068,2.928932 -1.851201,1.851201 -2.928932,4.453074 -2.928932,7.071068 l 0,8 0,931.99995 0,8 c 0,2.618 1.077731,5.2199 2.928932,7.0711 1.851201,1.8512 4.53124,3.5639 7.071068,2.9289 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.936277,9.016 -8,8 l -8,0 -18,0 -10,12 -10,-12 -7.9999995,0 c -4.1887902,0 -8.00000002,-3.8112 -8.00000002,-8 l 0,-8 z"
-     id="path3660-4"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="0.56204998"
-     x="-3.0515161e-05"
-     id="text3662-8"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="7.9999695"
-       y="43.56205"
-       id="tspan3664-5">start</tspan>
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3058"
-     d="m 18.99997,155.20367 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 80,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z" />
-  <text
-     y="138.20367"
-     x="17.999969"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3060">
-    <tspan
-       id="tspan3062"
-       y="166.20367"
-       x="131.99997">action</tspan>
-  </text>
-  <path
-     d="m 286.99997,223.56205 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 10,-12 10,12 18,0 70,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -70,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45307 -2.92893,7.07107 l 0,8 0,632.00003 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53125,2.29397 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18878 -3.93628,9.01593 -8,8 l -8,0 -18,0 -10,12 -10,-12 -8,0 c -4.18879,0 -8,-3.81122 -8,-8 l 0,-8 z"
-     id="path3027-4"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="285.94458"
-     y="192.2733"
-     id="text3029-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="293.94458"
-       y="235.2733"
-       id="tspan3031-5">action</tspan>
-  </text>
-  <path
-     d="m 428.99997,207.56205 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-2-0"
-     style="fill:#5DC1BC;fill-opacity:1;stroke:#5AA4AF;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="435.21783"
-     y="206.01805"
-     id="text23-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="455.21783"
-       y="232.01804"
-       id="tspan25-1">action</tspan>
-  </text>
-  <path
-     d="m 322.99997,307.56205 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 40,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.85121 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,172.00001 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z"
-     id="path3035-7"
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="321.99997"
-     y="290.56204"
-     id="text3037-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="329.99997"
-       y="321.06204"
-       id="tspan3039-4">repeat</tspan>
-  </text>
-  <path
-     d="m 434.99997,291.56206 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8-61"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="464.99997"
-     y="292.56207"
-     id="text23-0-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="484.99997"
-       y="318.56207"
-       id="tspan25-7-0">4</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-23"
-     d="m 304.99997,265.20366 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 158,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -158,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,8 0,548.00002 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,2.29397 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-1"
-     x="303.99997"
-     y="246.20367">
-    <tspan
-       id="tspan3039-7-3"
-       y="276.70367"
-       x="311.99997">adjust transposition</tspan>
-  </text>
-  <path
-     d="m 322.99994,597.20371 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 40,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.85121 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,174.00001 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z"
-     id="path3035-7-4"
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="321.99994"
-     y="580.20374"
-     id="text3037-9-22"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="329.99994"
-       y="610.70374"
-       id="tspan3039-4-6">repeat</tspan>
-  </text>
-  <path
-     d="m 434.99994,581.20372 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8-61-4"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="464.99994"
-     y="582.20374"
-     id="text23-0-4-6"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="484.99994"
-       y="608.20374"
-       id="tspan25-7-0-3">2</tspan>
-  </text>
-  <path
-     d="m 18.99992,71.20371 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 76,0 8,0 a 8,8 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8,8 0 0 1 -8,8 l -8,0 -76,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path21"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="54.203709"
-     x="17.99992"
-     id="text23"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="127.99992"
-       y="103.20371"
-       id="tspan25">store in</tspan>
-  </text>
-  <text
-     y="56.203709"
-     x="17.99992"
-     id="text27"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="127.99992"
-       y="78.703712"
-       id="tspan29">name</tspan>
-  </text>
-  <text
-     y="58.203709"
-     x="17.99992"
-     id="text31"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="127.99992"
-       y="122.70371"
-       id="tspan33">value</tspan>
-  </text>
-  <path
-     style="fill:#5dc1bc;fill-opacity:1;stroke:#5aa4af;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-2-0-6"
-     d="m 148.99992,55.266204 h 120 v 40 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-2-0"
-     y="53.285755"
-     x="155.21779">
-    <tspan
-       id="tspan25-1-8"
-       y="79.285744"
-       x="175.21779">box</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-72-7"
-     d="m 148.99991,97.4537 h 120 v 40 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     y="95.829781"
-     x="183.99991"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-5-5">
-    <tspan
-       id="tspan25-8-7-0"
-       y="121.82978"
-       x="203.99991">0</tspan>
-  </text>
-  <path
-     d="m 132.99998,307.2037 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path3172"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="306.2037"
-     x="115.99998"
-     id="text3174"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="135.99998"
-       y="332.2037"
-       id="tspan3176">box</tspan>
-  </text>
-  <path
-     d="m 18.99997,323.2037 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60,0 8,0 a 8,8 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8,8 0 0 1 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3124"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="306.2037"
-     x="17.999969"
-     id="text3126"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="111.99997"
-       y="355.2037"
-       id="tspan3128">add</tspan>
-  </text>
-  <text
-     y="308.2037"
-     x="17.999969"
-     id="text3130"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="111.99997"
-       y="330.7037"
-       id="tspan3132">to</tspan>
-  </text>
-  <text
-     y="310.2037"
-     x="17.999969"
-     id="text3134"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="111.99997"
-       y="374.7037"
-       id="tspan3136">value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-72-7-7-0"
-     d="m 132.99998,349.2037 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     y="348.2037"
-     x="167.99998"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-5-5-0-2">
-    <tspan
-       id="tspan25-8-7-0-3-4"
-       y="374.2037"
-       x="187.99998">2</tspan>
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3058-23"
-     d="m 19.00005,407.20373 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 19.999998,0 0,-4 80.000002,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80.000002,0 -1.999998,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z" />
-  <text
-     y="390.20374"
-     x="18.000034"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3060-40">
-    <tspan
-       id="tspan3062-0"
-       y="418.20374"
-       x="132.00005">action</tspan>
-  </text>
-  <path
-     d="m 132.99998,181.20368 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path3172-5"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="180.20367"
-     x="115.99998"
-     id="text3174-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="135.99998"
-       y="206.20367"
-       id="tspan3176-5">box</tspan>
-  </text>
-  <path
-     d="m 18.99997,197.20368 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60,0 8,0 a 8,8 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8,8 0 0 1 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3124-2"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="180.20367"
-     x="17.999969"
-     id="text3126-7"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="111.99997"
-       y="229.20367"
-       id="tspan3128-1">add</tspan>
-  </text>
-  <text
-     y="182.20367"
-     x="17.999969"
-     id="text3130-2"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="111.99997"
-       y="204.70367"
-       id="tspan3132-9">to</tspan>
-  </text>
-  <text
-     y="184.20367"
-     x="17.999969"
-     id="text3134-4"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="111.99997"
-       y="248.70367"
-       id="tspan3136-5">value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-72-7-7-0-3"
-     d="m 132.99998,223.20368 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     y="222.20367"
-     x="167.99998"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-5-5-0-2-9">
-    <tspan
-       id="tspan25-8-7-0-3-4-9"
-       y="248.20367"
-       x="187.99998">7</tspan>
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3058-23-7"
-     d="m 19.00005,281.20371 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 19.999998,0 0,-4 80.000002,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80.000002,0 -1.999998,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z" />
-  <text
-     y="264.20374"
-     x="18.000034"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3060-40-0">
-    <tspan
-       id="tspan3062-0-1"
-       y="292.20374"
-       x="132.00005">action</tspan>
-  </text>
-  <path
-     d="m 18.99996,449.20369 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 40,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.85121 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,92.00001 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.85119 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z"
-     id="path3035"
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="18.468781"
-     y="431.884"
-     id="text3037"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="26.468781"
-       y="462.38397"
-       id="tspan3039">repeat</tspan>
-  </text>
-  <path
-     d="m 131.46878,432.88399 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="161.46878"
-     y="433.884"
-     id="text23-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="181.46878"
-       y="459.884"
-       id="tspan25-7">2</tspan>
-  </text>
+  <defs
+     id="defs1398" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="683"
+     inkscape:window-height="480"
+     id="namedview1396"
+     showgrid="false"
+     inkscape:zoom="0.2079063"
+     inkscape:cx="564.66667"
+     inkscape:cy="542.92154"
+     inkscape:window-x="0"
+     inkscape:window-y="282"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1394" />
   <g
-     transform="translate(133.99998,474.20367)"
-     id="g6016-8">
-    <path
-       style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3172-0"
-       d="m 17,1 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text3174-9">
-      <tspan
-         id="tspan3176-6"
-         y="26"
-         x="20">box</tspan>
-    </text>
-  </g>
-  <path
-     d="m 36.99997,491.20367 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60,0 8,0 a 8,8 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8,8 0 0 1 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3124-6"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="474.20367"
-     x="35.999969"
-     id="text3126-9"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="129.99997"
-       y="523.20367"
-       id="tspan3128-8">add</tspan>
-  </text>
-  <text
-     y="476.20367"
-     x="35.999969"
-     id="text3130-8"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="129.99997"
-       y="498.70367"
-       id="tspan3132-4">to</tspan>
-  </text>
-  <text
-     y="478.20367"
-     x="35.999969"
-     id="text3134-0"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="129.99997"
-       y="542.70367"
-       id="tspan3136-4">value</tspan>
-  </text>
-  <g
-     transform="translate(-147.83638,571.02791)"
-     id="g3710-3-3-1-29-0">
-    <path
-       d="m 298.83636,-53.824242 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-6-72-7-7-0-2"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text23-9-5-5-0-2-3"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       x="333.83636"
-       y="-54.824242">
-      <tspan
-         x="353.83636"
-         y="-28.824242"
-         id="tspan25-8-7-0-3-4-3">-2</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3058-23-2"
-     d="m 37.00005,575.2037 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 19.999998,0 0,-4 80.000002,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80.000002,0 -1.999998,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z" />
-  <text
-     y="558.20374"
-     x="36.000034"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3060-40-7">
-    <tspan
-       id="tspan3062-0-17"
-       y="586.20374"
-       x="150.00005">action</tspan>
-  </text>
-  <path
-     d="m 18.99996,785.20371 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 40,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.85121 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,92 0,8 c 0,2.61799 1.07773,5.21988 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12.00001 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z"
-     id="path3035-18"
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="18.468781"
-     y="767.88403"
-     id="text3037-5"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="26.468781"
-       y="798.38397"
-       id="tspan3039-00">repeat</tspan>
-  </text>
-  <path
-     d="m 131.46878,768.88401 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8-6"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="161.46878"
-     y="769.88403"
-     id="text23-0-5"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="181.46878"
-       y="795.88403"
-       id="tspan25-7-5">2</tspan>
-  </text>
-  <g
-     transform="translate(133.99998,810.20369)"
-     id="g6016-8-7">
-    <path
-       style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3172-0-0"
-       d="m 17,1 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text3174-9-3">
-      <tspan
-         id="tspan3176-6-1"
-         y="26"
-         x="20">box</tspan>
-    </text>
-  </g>
-  <path
-     d="m 36.99997,827.20369 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60,0 8,0 a 8,8 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8,8 0 0 1 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3124-6-2"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="810.20367"
-     x="35.999969"
-     id="text3126-9-9"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="129.99997"
-       y="859.20367"
-       id="tspan3128-8-9">add</tspan>
-  </text>
-  <text
-     y="812.20367"
-     x="35.999969"
-     id="text3130-8-8"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="129.99997"
-       y="834.70367"
-       id="tspan3132-4-9">to</tspan>
-  </text>
-  <text
-     y="814.20367"
-     x="35.999969"
-     id="text3134-0-5"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="129.99997"
-       y="878.70367"
-       id="tspan3136-4-0">value</tspan>
-  </text>
-  <g
-     transform="translate(-147.83638,907.02793)"
-     id="g3710-3-3-1-29-0-3">
-    <path
-       d="m 298.83636,-53.824242 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-6-72-7-7-0-2-8"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text23-9-5-5-0-2-3-3"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       x="333.83636"
-       y="-54.824242">
-      <tspan
-         x="353.83636"
-         y="-28.824242"
-         id="tspan25-8-7-0-3-4-3-8">-2</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3058-23-2-0"
-     d="m 37.00005,911.20372 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 19.999998,0 0,-4 80.000002,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80.000002,0 -1.999998,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z" />
-  <text
-     y="894.20374"
-     x="36.000034"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3060-40-7-1">
-    <tspan
-       id="tspan3062-0-17-0"
-       y="922.20374"
-       x="150.00005">action</tspan>
-  </text>
-  <path
-     d="m 132.99997,643.20368 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path3172-2"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="642.20367"
-     x="115.99997"
-     id="text3174-06"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="135.99997"
-       y="668.20367"
-       id="tspan3176-0">box</tspan>
-  </text>
-  <path
-     d="m 18.99996,659.20368 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60,0 8,0 a 8,8 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8,8 0 0 1 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3124-24"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="642.20367"
-     x="17.99996"
-     id="text3126-2"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="111.99996"
-       y="691.20367"
-       id="tspan3128-3">add</tspan>
-  </text>
-  <text
-     y="644.20367"
-     x="17.99996"
-     id="text3130-24"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="111.99996"
-       y="666.70367"
-       id="tspan3132-41">to</tspan>
-  </text>
-  <text
-     y="646.20367"
-     x="17.99996"
-     id="text3134-5"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="111.99996"
-       y="710.70367"
-       id="tspan3136-3">value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-72-7-7-0-5"
-     d="m 132.99997,685.20368 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     y="684.20367"
-     x="167.99997"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-5-5-0-2-95">
-    <tspan
-       id="tspan25-8-7-0-3-4-97"
-       y="710.20367"
-       x="187.99997">-1</tspan>
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3058-23-1"
-     d="m 19.00004,743.20371 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 19.999998,0 0,-4 80.000002,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80.000002,0 -1.999998,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z" />
-  <text
-     y="726.20374"
-     x="18.000025"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3060-40-00">
-    <tspan
-       id="tspan3062-0-6"
-       y="754.20374"
-       x="132.00003">action</tspan>
-  </text>
-  <path
-     d="m 18.999939,995.20376 0,-8 c 0,-4.41828 3.581722,-8 8,-8 l 8,0 0,4 20,0 0,-4 140.000001,0 8,0 c 4.41828,0 8,3.58172 8,8 l 0,8 -8,0 0,-6 -8,0 0,20.00004 8,0 0,-6 8,0 0,8 c 0,4.4182 -3.58172,8 -8,8 l -8,0 -140.000001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.418278,0 -8,-3.5818 -8,-8 l 0,-8 z"
-     id="path21-5"
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="978.20374"
-     id="text23-8"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="93.999939">
-    <tspan
-       x="187.99994"
-       y="1006.2037"
-       id="tspan25-6">save as lilypond</tspan>
-  </text>
-  <text
-     y="978.20374"
-     x="17.999939"
-     id="text27-9"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="111.99994"
-       y="1000.7037"
-       id="tspan29-8" />
-  </text>
-  <path
-     d="m 212.99999,979.20376 140,0 0,40.00004 -140,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16.00004 4,0 0,6 12,0 0,-2 z"
-     id="path21-2-0-9"
-     style="fill:#5DC1BC;fill-opacity:1;stroke:#5AA4AF;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="219.21785"
-     y="977.65973"
-     id="text23-2-5"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="239.21785"
-       y="1003.6597"
-       id="tspan25-1-6">hotdog.ly</tspan>
-  </text>
-  <path
-     d="m 534.99997,249.20402 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path3172-5-0"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="248.20401"
-     x="518"
-     id="text3174-0-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="538"
-       y="274.20401"
-       id="tspan3176-5-1">box</tspan>
-  </text>
-  <path
-     d="m 358.99996,432.124 0,-8.00001 a 8.0000007,8.0000006 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 59.99999,0 8.00002,0 a 8.0000007,8.0000006 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8.00002,0 0,20.00001 8.00002,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00002,0 0,19.99999 8.00002,0 0,-6 8,0 0,8 a 8.0000007,8.0000006 0 0 1 -8,8 l -8.00002,0 -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000007,8.0000006 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3194-2"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196-91"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="357.99994"
-     y="415.12399">
-    <tspan
-       x="452"
-       y="464.12402"
-       id="tspan3198-2">pitch</tspan>
-  </text>
-  <text
-     id="text3200-7"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="357.99994"
-     y="417.12402">
-    <tspan
-       x="452"
-       y="439.62399"
-       id="tspan3202-0">name</tspan>
-  </text>
-  <text
-     id="text3204-93"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="357.99994"
-     y="419.12402">
-    <tspan
-       x="452"
-       y="483.62396"
-       id="tspan3206-6-1">octave</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-0"
-     d="m 472.99997,416.12399 120,0 0,40.00002 -120,0 0,-16.00001 0,-2 -12,0 0,6 -4.00002,0 0,-16.00001 4.00002,0 0,6.00001 12,0 0,-2 z" />
-  <text
-     x="501.99994"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-6"
-     y="415.12399">
-    <tspan
-       id="tspan25-2"
-       y="441.12399"
-       x="521.99994">do</tspan>
-  </text>
-  <path
-     d="m 472.99997,458.124 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z"
-     id="path21-6-6"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="507.99994"
-     y="457.12402">
-    <tspan
-       x="527.99994"
-       y="483.12396"
-       id="tspan25-8-8">4</tspan>
-  </text>
-  <path
-     d="m 340.99995,348.12401 0,-8 c 0,-4.41828 3.58173,-8 8.00001,-8 l 8,0 0,4 20,0 0,-4 18,0 59.99999,0 8.00002,0 c 4.41827,0 9.07158,3.71364 8,8 l 0,8 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,8 c 0,4.41828 -3.58173,8 -8,8 l -8.00002,0 -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,92.00001 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07161 -8,8.00001 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8.00001,-3.58173 -8.00001,-8.00001 l 0,-8 z"
-     id="path3035-5"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-3"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="329.12399"
-     x="337.99994">
-    <tspan
-       x="345.99994"
-       y="359.62396"
-       id="tspan3039-5">note value</tspan>
-  </text>
-  <path
-     d="m 586.99997,374.12401 120.00002,0 0,40 -120.00002,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-6-1-7"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="617.99994"
-     y="373.12396">
-    <tspan
-       x="637.99994"
-       y="399.12399"
-       id="tspan25-8-5-2">8</tspan>
-  </text>
-  <path
-     d="m 472.99997,348.12401 0,-8 a 8.0000007,8.0000006 0 0 1 8,-8 l 8,0 20,0 60,0 8,0 a 8.0000007,8.0000006 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8.0000007,8.0000006 0 0 1 -8,8 l -8,0 -60,0 -20,0 -8,0 a 8.0000007,8.0000006 0 0 1 -8,-8 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z"
-     id="path3798-4-4-5"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="331.12396"
-     id="text3800-3-2-0"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     x="448">
-    <tspan
-       x="557.99994"
-       y="380.12396"
-       id="tspan3802-6-2-5">/</tspan>
-  </text>
-  <g
-     transform="translate(339.99995,289.124)"
-     id="g5147">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-8-2-1-0-6"
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0-1-0-1-0"
-       y="44"
-       x="279">
-      <tspan
-         id="tspan25-7-0-5-2-5"
-         y="70.000031"
-         x="299">1</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-5"
-     d="m 358.99996,390.12401 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 59.99999,0 8.00002,0 c 4.41827,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41828 -3.71365,6.92841 -8,8 l -8.00002,0 -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z" />
-  <text
-     id="text6137"
-     y="401.04712"
-     x="440.823"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="401.04712"
-       x="440.823"
-       id="tspan6139">↓</tspan></text>
-  <path
-     d="m 358.99996,722.124 0,-8.00001 a 8.0000007,8.0000006 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 59.99999,0 8.00002,0 a 8.0000007,8.0000006 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8.00002,0 0,20.00001 8.00002,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00002,0 0,19.99999 8.00002,0 0,-6 8,0 0,8 a 8.0000007,8.0000006 0 0 1 -8,8 l -8.00002,0 -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000007,8.0000006 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3194-2-9"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196-91-7"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="357.99994"
-     y="705.12402">
-    <tspan
-       x="452"
-       y="754.12408"
-       id="tspan3198-2-7">pitch</tspan>
-  </text>
-  <text
-     id="text3200-7-6"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="357.99994"
-     y="707.12402">
-    <tspan
-       x="452"
-       y="729.62402"
-       id="tspan3202-0-7">name</tspan>
-  </text>
-  <text
-     id="text3204-93-3"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="357.99994"
-     y="709.12402">
-    <tspan
-       x="452"
-       y="773.62402"
-       id="tspan3206-6-1-6">octave</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-0-5"
-     d="m 472.99997,706.12399 120,0 0,40.00002 -120,0 0,-16.00001 0,-2 -12,0 0,6 -4.00002,0 0,-16.00001 4.00002,0 0,6.00001 12,0 0,-2 z" />
-  <text
-     x="501.99994"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-6-6"
-     y="705.12402">
-    <tspan
-       id="tspan25-2-3"
-       y="731.12402"
-       x="521.99994">do</tspan>
-  </text>
-  <path
-     d="m 472.99997,748.124 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z"
-     id="path21-6-6-9"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-1-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="507.99994"
-     y="747.12402">
-    <tspan
-       x="527.99994"
-       y="773.12402"
-       id="tspan25-8-8-8">4</tspan>
-  </text>
-  <path
-     d="m 340.99995,638.12401 0,-8 c 0,-4.41828 3.58173,-8 8.00001,-8 l 8,0 0,4 20,0 0,-4 18,0 59.99999,0 8.00002,0 c 4.41827,0 9.07158,3.71364 8,8 l 0,8 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,8 c 0,4.41828 -3.58173,8 -8,8 l -8.00002,0 -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,92.00001 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07161 -8,8.00001 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8.00001,-3.58173 -8.00001,-8.00001 l 0,-8 z"
-     id="path3035-5-1"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-3-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="619.12402"
-     x="337.99994">
-    <tspan
-       x="345.99994"
-       y="649.62396"
-       id="tspan3039-5-9">note value</tspan>
-  </text>
-  <path
-     d="m 586.99997,664.12401 120.00002,0 0,40 -120.00002,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-6-1-7-3"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-9-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="617.99994"
-     y="663.12396">
-    <tspan
-       x="637.99994"
-       y="689.12402"
-       id="tspan25-8-5-2-0">4</tspan>
-  </text>
-  <path
-     d="m 472.99997,638.12401 0,-8 a 8.0000007,8.0000006 0 0 1 8,-8 l 8,0 20,0 60,0 8,0 a 8.0000007,8.0000006 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8.0000007,8.0000006 0 0 1 -8,8 l -8,0 -60,0 -20,0 -8,0 a 8.0000007,8.0000006 0 0 1 -8,-8 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z"
-     id="path3798-4-4-5-8"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="621.12396"
-     id="text3800-3-2-0-8"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     x="448">
-    <tspan
-       x="557.99994"
-       y="670.12396"
-       id="tspan3802-6-2-5-5">/</tspan>
-  </text>
-  <g
-     transform="translate(339.99995,579.124)"
-     id="g5147-0">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-8-2-1-0-6-9"
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0-1-0-1-0-6"
-       y="44"
-       x="279">
-      <tspan
-         id="tspan25-7-0-5-2-5-3"
-         y="70.000031"
-         x="299">1</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-5-8"
-     d="m 358.99996,680.12401 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 59.99999,0 8.00002,0 c 4.41827,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41828 -3.71365,6.92841 -8,8 l -8.00002,0 -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z" />
-  <text
-     id="text6137-5"
-     y="691.04712"
-     x="440.823"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="691.04712"
-       x="440.823"
-       id="tspan6139-6">↓</tspan></text>
-  <g
-     transform="matrix(1.1111109,0,0,1.1111109,-74.156439,-16.865331)"
-     id="g4634">
-    <path
-       style="fill:#ffc1c1;fill-opacity:1;stroke:#ff0000;stroke-width:0.37087584px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4725"
-       d="m 167.00762,39.539118 c 0,0 -0.46531,-0.370876 -0.74175,-0.370876 -0.55287,0 -1.09256,0.350814 -1.4835,0.741752 -0.58641,0.586406 -0.62773,1.552489 -1.11263,2.225255 -0.30668,0.425495 -0.68713,0.805948 -1.11263,1.112627 -0.67276,0.484903 -1.63885,0.526222 -2.22525,1.112628 -0.39094,0.390937 -0.74175,0.930634 -0.74175,1.483503 0,0.552869 0.43649,1.312961 0.74175,1.483503 0.96247,0.537721 0.31028,0.240518 0.74175,0.741752 0,0 -0.38587,1.22419 -0.37088,1.854379 0.0165,1.238632 0.45294,2.480604 0.74176,2.967007 0.18935,0.318895 1.34328,1.657344 2.22525,2.225255 0.88807,0.571841 1.97446,0.763668 3.02812,0.8376 1.13698,0.07978 2.21652,-0.132168 3.21565,-0.680635 0.61304,-0.336524 1.12013,-0.71383 1.54462,-1.269593 0.60499,-0.792083 1.22769,-1.632821 1.48351,-2.59613 0.15865,-0.597419 0.0755,-1.240885 0,-1.85438 -0.0623,-0.505901 -0.47178,-0.983869 -0.37088,-1.483503 0.12236,-0.605895 0.86033,-0.919212 1.11263,-1.483503 0.2573,-0.575467 0.62589,-1.277899 0.37087,-1.854379 -0.29162,-0.659231 -1.24525,-0.727152 -1.85438,-1.112628 -0.37665,-0.238358 -0.78107,-0.443829 -1.11262,-0.741752 -0.71819,-0.645351 -1.2767,-1.451586 -1.85438,-2.225255 -0.26668,-0.357158 -0.38752,-0.842067 -0.74175,-1.112627 -0.31068,-0.237297 -0.73215,-0.460695 -1.11263,-0.370876 -0.17016,0.04017 -0.37088,0.370876 -0.37088,0.370876" />
-    <path
-       d="m 172.57866,47.803117 c 0,0 0.54294,2.128427 0.37128,3.183536 -0.18671,1.147562 -0.64302,2.34396 -1.48511,3.183536 -0.76475,0.762463 -1.18949,1.049013 -2.22767,1.414905 -0.47858,0.168668 -1.84456,0.353726 -2.4159,0.353726 -0.57135,0 -1.93733,-0.185059 -2.41591,-0.353727 -1.03818,-0.365892 -1.46292,-0.652441 -2.22766,-1.414904 -0.84209,-0.839576 -1.29841,-2.035975 -1.48512,-3.183536 -0.17166,-1.055109 0.37128,-3.183536 0.37128,-3.183536 m 4.82661,-2.122358 c 0,0 -1.52881,1.745204 -2.59894,2.122358 -0.69643,0.245448 -1.5584,0.30646 -2.22767,0 -0.71423,-0.327051 -1.32906,-1.028431 -1.48511,-1.768631 -0.17743,-0.841581 0.2073,-1.529325 0.91624,-2.050581 0.76674,-0.563756 1.70542,-0.616723 2.42526,-1.132956 0.93281,-0.668963 1.08012,-1.998936 1.85639,-2.829809 0.52688,-0.563939 2.04463,-1.414905 2.04463,-1.414905 0,0 1.51774,0.850966 2.04462,1.414905 0.77627,0.830873 0.92358,2.160847 1.85639,2.82981 0.71984,0.516232 1.68334,0.54353 2.45008,1.085677 0.71847,0.508023 1.06885,1.256279 0.89142,2.097859 -0.15605,0.740201 -0.77087,1.44158 -1.48511,1.768631 -0.66927,0.30646 -1.53123,0.245448 -2.22767,0 -1.07013,-0.377153 -2.59894,-2.122357 -2.59894,-2.122357"
-       id="path4505-6"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     transform="translate(-3.3333333e-6,7.4215375)"
+     id="g736">
     <g
-       id="g4565"
-       transform="matrix(0.37127797,0,0,0.35372622,176.72956,39.358074)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <g
-         id="g4553"
-         transform="translate(0,-1)"
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1">
-        <path
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664"
-           id="path3411-7"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285"
-           id="path3413-5"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <g
-         id="g4557"
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1">
-        <path
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658"
-           id="path3411-3"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075"
-           id="path3413-56"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </g>
-    <g
-       id="g4636"
-       transform="matrix(0.37127797,0,0,0.35372622,176.92563,38.650622)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <ellipse
-         cx="-30.836912"
-         cy="14.612609"
-         id="circle3409-2"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <ellipse
-         cx="-23.593306"
-         cy="14.699166"
-         id="ellipse4229-9"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="g4632"
-       transform="matrix(0.37127797,0,0,0.35372622,176.96142,38.650622)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+       transform="scale(1.5)"
+       id="g734">
       <path
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25"
-         id="path4303-1"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25"
-         id="path4303-1-2"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 462 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path728"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text732">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan730">start</tspan>
+      </text>
     </g>
-    <path
-       d="m 167.72688,38.606235 c -0.51355,0.487351 -0.73647,0.882428 -0.91229,0.882428 -0.24578,0 -0.47204,-0.395077 -0.91229,-0.882428 -0.36084,-0.399437 0.40844,-0.882428 0.91229,-0.882428 0.50385,0 1.3103,0.504726 0.91229,0.882428 z"
-       id="path4227-7"
-       style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.80251253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4653"
-       d="m 167.04984,55.935948 c 0,0 0.26819,1.158553 2.03989,1.361113 1.77169,0.202559 4.37064,-1.401457 5.48447,-3.523814 1.11384,-2.122358 0.8911,-4.261654 1.11384,-6.720799" />
+  </g>
+  <g
+     transform="translate(26.999997,362.92154)"
+     id="g754">
+    <g
+       transform="scale(1.5)"
+       id="g752">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path738"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text742">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan740">add</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text746">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan744">to</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text750">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan748">value</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,47.921537)"
+     id="g772">
+    <g
+       transform="scale(1.5)"
+       id="g770">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 32.792969 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path756"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text760">
+        <tspan
+           x="49.126301"
+           y="24"
+           id="tspan758">store in</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text764">
+        <tspan
+           x="49.126301"
+           y="11.25"
+           id="tspan762">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text768">
+        <tspan
+           x="49.126301"
+           y="32.25"
+           id="tspan766">value</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(91.189457,47.921537)"
+     id="g782">
+    <g
+       transform="scale(1.5)"
+       id="g780">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path774"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text778">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan776">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(91.189457,79.421537)"
+     id="g792">
+    <g
+       transform="scale(1.5)"
+       id="g790">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path784"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text788">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan786">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(313.66667,0.42153745)"
+     id="g806">
+    <g
+       transform="scale(1.5)"
+       id="g804">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 315 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path794"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text798">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan796">action</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text802">
+        <tspan
+           x="60.333332"
+           y="5.25"
+           id="tspan800" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(408.16667,9.4215375)"
+     id="g816">
+    <g
+       transform="scale(1.5)"
+       id="g814">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path808"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text812">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan810">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(327.16667,40.921537)"
+     id="g830">
+    <g
+       transform="scale(1.5)"
+       id="g828">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 273 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path818"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text822">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan820">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text826">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan824" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(490.06755,40.921537)"
+     id="g840">
+    <g
+       transform="scale(1.5)"
+       id="g838">
+      <path
+         d="m 8.5,0.5 h 80 v 20 h -80 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path832"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text836">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan834">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,110.92154)"
+     id="g850">
+    <g
+       transform="scale(1.5)"
+       id="g848">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path842"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text846">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan844">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,142.42154)"
+     id="g868">
+    <g
+       transform="scale(1.5)"
+       id="g866">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path852"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text856">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan854">add</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text860">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan858">to</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text864">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan862">value</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(86.999997,142.42154)"
+     id="g878">
+    <g
+       transform="scale(1.5)"
+       id="g876">
+      <path
+         d="m 8.5,0.5 h 80 v 20 h -80 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path870"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text874">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan872">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,205.42154)"
+     id="g888">
+    <g
+       transform="scale(1.5)"
+       id="g886">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path880"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text884">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan882">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(340.66667,72.421537)"
+     id="g902">
+    <g
+       transform="scale(1.5)"
+       id="g900">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 84 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path890"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text894">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan892">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text898">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan896" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(412.66667,72.421537)"
+     id="g912">
+    <g
+       transform="scale(1.5)"
+       id="g910">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path904"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text908">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan906">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(354.16667,103.92154)"
+     id="g926">
+    <g
+       transform="scale(1.5)"
+       id="g924">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path914"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text918">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan916">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text922">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan920" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(450.38786,103.92154)"
+     id="g944">
+    <g
+       transform="scale(1.5)"
+       id="g942">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path928"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text932">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan930">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text936">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan934" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text940">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan938" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(535.88786,103.92154)"
+     id="g954">
+    <g
+       transform="scale(1.5)"
+       id="g952">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path946"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text950">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan948">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(535.88786,135.42154)"
+     id="g964">
+    <g
+       transform="scale(1.5)"
+       id="g962">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path956"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text960">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan958">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(367.66667,135.42154)"
+     id="g974">
+    <g
+       transform="scale(1.5)"
+       id="g972">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text970">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan968">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(367.66667,166.92154)"
+     id="g992">
+    <g
+       transform="scale(1.5)"
+       id="g990">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path976"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text980">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan978">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text984">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan982">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text988">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan986">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(441.16667,166.92154)"
+     id="g1002">
+    <g
+       transform="scale(1.5)"
+       id="g1000">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path994"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text998">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan996">do</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(441.16667,198.42154)"
+     id="g1012">
+    <g
+       transform="scale(1.5)"
+       id="g1010">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1004"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1008">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1006">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(340.66667,292.92154)"
+     id="g1026">
+    <g
+       transform="scale(1.5)"
+       id="g1024">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 84 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1014"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1018">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan1016">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1022">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan1020" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(412.66667,292.92154)"
+     id="g1036">
+    <g
+       transform="scale(1.5)"
+       id="g1034">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1028"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1032">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1030">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(354.16667,324.42154)"
+     id="g1050">
+    <g
+       transform="scale(1.5)"
+       id="g1048">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1038"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1042">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan1040">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1046">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan1044" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(450.38786,324.42154)"
+     id="g1068">
+    <g
+       transform="scale(1.5)"
+       id="g1066">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1052"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1056">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan1054">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1060">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan1058" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1064">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan1062" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(535.88786,324.42154)"
+     id="g1078">
+    <g
+       transform="scale(1.5)"
+       id="g1076">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1070"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1074">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1072">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(535.88786,355.92154)"
+     id="g1088">
+    <g
+       transform="scale(1.5)"
+       id="g1086">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1080"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1084">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1082">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(367.66667,355.92154)"
+     id="g1098">
+    <g
+       transform="scale(1.5)"
+       id="g1096">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1090"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1094">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan1092">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(367.66667,387.42154)"
+     id="g1116">
+    <g
+       transform="scale(1.5)"
+       id="g1114">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1100"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1104">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan1102">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1108">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan1106">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1112">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan1110">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(441.16667,387.42154)"
+     id="g1126">
+    <g
+       transform="scale(1.5)"
+       id="g1124">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1118"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1122">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1120">do</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(441.16667,418.92154)"
+     id="g1136">
+    <g
+       transform="scale(1.5)"
+       id="g1134">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1128"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1132">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1130">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,331.42154)"
+     id="g1150">
+    <g
+       transform="scale(1.5)"
+       id="g1148">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1138"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1142">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan1140">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1146">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan1144" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.499997,331.42154)"
+     id="g1160">
+    <g
+       transform="scale(1.5)"
+       id="g1158">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1152"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1156">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1154">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,362.92154)"
+     id="g1170">
+    <g
+       transform="scale(1.5)"
+       id="g1168">
+      <path
+         d="m 8.5,0.5 h 80 v 20 h -80 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1162"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1166">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1164">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,551.92154)"
+     id="g1180">
+    <g
+       transform="scale(1.5)"
+       id="g1178">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1172"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1176">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan1174">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,236.92154)"
+     id="g1198">
+    <g
+       transform="scale(1.5)"
+       id="g1196">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1182"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1186">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan1184">add</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1190">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan1188">to</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1194">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan1192">value</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(86.999997,236.92154)"
+     id="g1208">
+    <g
+       transform="scale(1.5)"
+       id="g1206">
+      <path
+         d="m 8.5,0.5 h 80 v 20 h -80 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1200"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1204">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1202">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,299.92154)"
+     id="g1218">
+    <g
+       transform="scale(1.5)"
+       id="g1216">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1210"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1214">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan1212">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,583.42154)"
+     id="g1232">
+    <g
+       transform="scale(1.5)"
+       id="g1230">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1220"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1224">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan1222">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1228">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan1226" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.499997,583.42154)"
+     id="g1242">
+    <g
+       transform="scale(1.5)"
+       id="g1240">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1234"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1238">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1236">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,425.92154)"
+     id="g1252">
+    <g
+       transform="scale(1.5)"
+       id="g1250">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1244"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1248">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan1246">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,677.92154)"
+     id="g1262">
+    <g
+       transform="scale(1.5)"
+       id="g1260">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1254"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1258">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan1256">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,488.92154)"
+     id="g1280">
+    <g
+       transform="scale(1.5)"
+       id="g1278">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1264"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1268">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan1266">add</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1272">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan1270">to</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1276">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan1274">value</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,614.92154)"
+     id="g1298">
+    <g
+       transform="scale(1.5)"
+       id="g1296">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1282"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1286">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan1284">add</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1290">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan1288">to</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1294">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan1292">value</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(86.999997,488.92154)"
+     id="g1308">
+    <g
+       transform="scale(1.5)"
+       id="g1306">
+      <path
+         d="m 8.5,0.5 h 80 v 20 h -80 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1300"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1304">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1302">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,614.92154)"
+     id="g1318">
+    <g
+       transform="scale(1.5)"
+       id="g1316">
+      <path
+         d="m 8.5,0.5 h 80 v 20 h -80 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1310"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1314">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1312">box</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,740.92154)"
+     id="g1332">
+    <g
+       transform="scale(1.5)"
+       id="g1330">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 71.152344 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1320"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1324">
+        <tspan
+           x="87.48568"
+           y="13.5"
+           id="tspan1322">save as lilypond</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1328">
+        <tspan
+           x="87.48568"
+           y="11.25"
+           id="tspan1326" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(148.72852,740.92154)"
+     id="g1342">
+    <g
+       transform="scale(1.5)"
+       id="g1340">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1334"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1338">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1336">hotdog.ly</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,394.42154)"
+     id="g1352">
+    <g
+       transform="scale(1.5)"
+       id="g1350">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1344"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1348">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1346">-2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(86.999997,520.42154)"
+     id="g1362">
+    <g
+       transform="scale(1.5)"
+       id="g1360">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1354"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1358">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1356">-1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,646.42154)"
+     id="g1372">
+    <g
+       transform="scale(1.5)"
+       id="g1370">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1364"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1368">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1366">-2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(86.999997,268.42154)"
+     id="g1382">
+    <g
+       transform="scale(1.5)"
+       id="g1380">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1374"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1378">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1376">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(86.999997,173.92154)"
+     id="g1392">
+    <g
+       transform="scale(1.5)"
+       id="g1390">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1384"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1388">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1386">7</tspan>
+      </text>
+    </g>
   </g>
 </svg>

--- a/guide/tempo0.svg
+++ b/guide/tempo0.svg
@@ -7,13 +7,26 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="119.66222mm"
-   height="42.086136mm"
-   viewBox="0 0 424 149.1241"
-   id="svg4167"
+   width="307.24072"
+   height="113.34308"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="tempo0.svg">
+   id="svg46"
+   sodipodi:docname="tempo0.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <metadata
+     id="metadata52">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs50" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,79 +36,86 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="640"
-     inkscape:window-height="480"
-     id="namedview16"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     id="namedview48"
      showgrid="false"
-     inkscape:zoom="0.73113211"
-     inkscape:cx="211.99999"
-     inkscape:cy="74.562052"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg4167" />
-  <defs
-     id="defs4169" />
-  <metadata
-     id="metadata4172">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <path
-     d="m 19,70.1241 0,-8 c 0,-4.418278 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 230,0 8,0 c 4.41828,0 6.92841,3.713641 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.418278 -3.58172,8 -8,8 l -8,0 -230,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.581722 -8,-8 l 0,-8 0,0 z"
-     id="path3194"
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="33.1241"
-     x="188"
-     id="text3196"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="282"
-       y="82.1241"
-       id="tspan3198">master beats per minutes</tspan>
-  </text>
+     inkscape:zoom="0.2079063"
+     inkscape:cx="301"
+     inkscape:cy="-57.078463"
+     inkscape:window-x="-8"
+     inkscape:window-y="274"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg46" />
   <g
-     id="g3710"
-     transform="translate(4.16364,107.94834)">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-6"
-       d="m 298.83636,-53.824242 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-    <text
-       y="-52.824242"
-       x="325.83636"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-9">
-      <tspan
-         id="tspan25-8"
-         y="-26.824242"
-         x="345.83636">90</tspan>
-    </text>
+     transform="translate(0,0.42153745)"
+     id="g20">
+    <g
+       transform="scale(1.5)"
+       id="g18">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#9ddd5f;fill-opacity:1;stroke:#003e00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path12"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text16">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan14">tempo</tspan>
+      </text>
+    </g>
   </g>
   <g
-     id="g3990"
-     transform="translate(0,1.1240999)">
-    <path
-       style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3660"
-       d="m 1,28.43795 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 L 27,0.43795006 37,12.43795 l 18,0 60,0 8,0 c 4.18879,0 6.98407,3.936277 8,8 l 0,8 0,8 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 C 18.07773,57.218083 17,59.819956 17,62.43795 l 0,8 0,6 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.531247,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.936277,9.01593 -8,8 l -8,0 -18,0 -10,12 -10,-12 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z" />
-    <text
-       y="-4"
-       x="1.1454468"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text3662">
-      <tspan
-         id="tspan3664"
-         y="39"
-         x="9.1454468">tempo</tspan>
-    </text>
+     transform="translate(13.5,40.921537)"
+     id="g34">
+    <g
+       transform="scale(1.5)"
+       id="g32">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 107.82715 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path22"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text26">
+        <tspan
+           x="124.16048"
+           y="13.5"
+           id="tspan24">master beats per minute</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text30">
+        <tspan
+           x="124.16048"
+           y="11.25"
+           id="tspan28" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(203.74072,40.921537)"
+     id="g44">
+    <g
+       transform="scale(1.5)"
+       id="g42">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path36"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text40">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan38">90</tspan>
+      </text>
+    </g>
   </g>
 </svg>

--- a/guide/transform0.svg
+++ b/guide/transform0.svg
@@ -5,588 +5,732 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="312.22119"
+   height="617.34308"
    version="1.1"
-   width="404"
-   height="818.68616"
-   id="svg3641"
-   viewBox="0 0 404 818.68616">
+   id="svg4367"
+   sodipodi:docname="blockArtwork.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata3670">
+     id="metadata4373">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3668" />
-  <path
-     d="m 1,29.56205 v -8 c 0,-4.18879 3.8112098,-8 8,-8 h 8 L 27,1.5620499 37,13.56205 h 18 60 8 c 4.18879,0 8,3.81121 8,8 v 8 8 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -60 -2 v 4 H 37 v -4 h -2 -8 c -2.617994,0 -5.219867,1.077731 -7.071068,2.928932 C 18.077731,58.342183 17,60.944056 17,63.56205 v 8 8 675.56203 c 0,2.61799 1.077731,5.21987 2.928932,7.07107 1.851201,1.8512 4.531239,2.29397 7.071068,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.936277,6.98407 -8,8 H 55 37 l -10,12 -10,-12 H 9 c -4.1887902,0 -8,-3.81121 -8,-8 v -8 z"
-     id="path3660"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="0.56205004"
-     id="text3662"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="8"
-       y="43.56205"
-       id="tspan3664">start</tspan>
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3095"
-     x="36"
-     y="475.12411">
-    <tspan
-       id="tspan3097"
-       y="497.62411"
-       x="146" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3107"
-     x="36"
-     y="265.12411">
-    <tspan
-       id="tspan3109"
-       y="287.62411"
-       x="130" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033"
-     x="36"
-     y="223.1241">
-    <tspan
-       id="tspan3035"
-       y="245.6241"
-       x="138" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3317"
-     x="18"
-     y="55.1241">
-    <tspan
-       id="tspan3319"
-       y="77.6241"
-       x="160" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3095-2"
-     x="36"
-     y="433.12411">
-    <tspan
-       id="tspan3097-4"
-       y="455.62411"
-       x="146" />
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035"
-     d="m 19,531.12408 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.41828,0 8,3.58172 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -40 -2 v 4 H 55 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,10 v 8 132 8 c 0,5.52285 4.64205,8.66051 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.41828 -3.71364,6.92841 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037"
-     x="18"
-     y="514.12408">
-    <tspan
-       id="tspan3039"
-       y="544.62408"
-       x="26">repeat</tspan>
-  </text>
-  <path
-     d="m 131,515.12409 h 120 v 40 H 131 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-72-7-7"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-5-5-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="166"
-     y="514.12408">
-    <tspan
-       x="186"
-       y="540.12408"
-       id="tspan25-8-7-0-3">7</tspan>
-  </text>
+     id="defs4371" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     id="namedview4369"
+     showgrid="false"
+     inkscape:zoom="0.61910667"
+     inkscape:cx="963.06847"
+     inkscape:cy="403.83508"
+     inkscape:window-x="-8"
+     inkscape:window-y="274"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4367" />
   <g
-     transform="translate(0,84.562077)"
-     id="g4731">
-    <path
-       d="m 55,321.12408 v -8 c 0,-4.41828 3.581722,-8 8,-8 h 8 v 4 h 20 v -4 h 72 8 c 4.41828,0 8,3.58172 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -72 -2 v 4 H 73 v -4 h -2 -8 c -4.418278,0 -8,-3.58172 -8,-8 v -8 z"
-       id="path3101"
-       style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       y="304.12408"
-       x="66"
-       id="text3103"
-       style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="160"
-         y="332.12408"
-         id="tspan3105">step pitch</tspan>
-    </text>
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-6-72-7-7-8"
-       d="m 181,305.12409 h 120 v 40 H 181 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       y="304.12408"
-       x="208"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-9-5-5-0-93">
-      <tspan
-         id="tspan25-8-7-0-3-6"
-         y="330.12408"
-         x="228">1</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-1"
-     d="m 19,281.12406 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.41828,0 8,3.58172 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -40 -2 v 4 H 55 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,10 v 8 132 8 c 0,5.52285 4.64205,8.66051 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.41828 -3.71364,6.92841 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-6"
-     x="18"
-     y="264.12408">
-    <tspan
-       id="tspan3039-26"
-       y="294.62408"
-       x="26">repeat</tspan>
-  </text>
-  <path
-     d="m 131,265.12407 h 120 v 40 H 131 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-72-7-7-13"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-5-5-0-82"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="166"
-     y="264.12408">
-    <tspan
-       x="186"
-       y="290.12408"
-       id="tspan25-8-7-0-3-8">7</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194"
-     d="m 37,155.68614 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -5.99999 h -8 v 19.99999 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 -42 z" />
-  <text
-     y="138.68614"
-     x="36"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196">
-    <tspan
-       id="tspan3198"
-       y="187.68616"
-       x="130">pitch</tspan>
-  </text>
-  <text
-     y="140.68614"
-     x="36"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200">
-    <tspan
-       id="tspan3202"
-       y="163.18614"
-       x="130">note</tspan>
-  </text>
-  <text
-     y="142.68614"
-     x="36"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204">
-    <tspan
-       id="tspan3206"
-       y="207.18616"
-       x="130">octave</tspan>
-  </text>
-  <path
-     d="m 151,139.68614 h 120 v 40.00001 H 151 v -16.00001 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="138.68614"
-     id="text23"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="180">
-    <tspan
-       x="200"
-       y="164.68614"
-       id="tspan25">do</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6"
-     d="m 151,181.68614 h 120 v 40 H 151 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     y="180.68616"
-     x="186"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9">
-    <tspan
-       id="tspan25-8"
-       y="206.68616"
-       x="206">4</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5"
-     d="m 19,71.68616 v -8 c 0,-4.418278 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18 60 8 c 4.41828,0 9.07159,3.713641 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.418278 -3.58172,8 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,10 v 8 92 7.99999 c 0,5.52285 4.64205,11.3395 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.41828 -3.71364,9.0716 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 z" />
-  <text
-     x="16"
-     y="52.686161"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3">
-    <tspan
-       id="tspan3039-5"
-       y="83.186157"
-       x="24">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1"
-     d="M 265,97.686163 H 385 V 137.68616 H 265 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     y="96.686165"
-     x="300"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82">
-    <tspan
-       id="tspan25-8-5"
-       y="122.68616"
-       x="320">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5"
-     d="m 151,71.68616 v -8 a 8,8 0 0 1 8,-8 h 8 20 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -20 -8 a 8,8 0 0 1 -8,-8 v -8 -42 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 z" />
-  <text
-     x="126"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0"
-     y="54.686138">
-    <tspan
-       id="tspan3802-6-2-5"
-       y="103.68616"
-       x="236">/</tspan>
-  </text>
-  <g
-     id="g5147"
-     transform="translate(18,12.68616)">
-    <path
-       d="M 247,43 H 367 V 83 H 247 V 67 65 h -12 v 6 h -4 V 55 h 4 v 6 h 12 v -2 z"
-       id="path21-8-2-1-0-6"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5">1</tspan>
-    </text>
-  </g>
-  <path
-     d="m 37,113.68616 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 60 8 c 4.41828,0 8,3.58172 8,8 v 8 8 8 c 0,4.41828 -3.71364,6.92841 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 0 z"
-     id="path3124"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="118.823"
-     y="124.60925"
-     id="text6137"><tspan
-       id="tspan6139"
-       x="118.823"
-       y="124.60925"
-       style="font-size:22.5px">↓</tspan></text>
-  <g
-     transform="translate(0,126.56208)"
-     id="g4739">
-    <path
-       d="m 55,529.12408 v -8 c 0,-4.41828 3.581722,-8 8,-8 h 8 v 4 h 20 v -4 h 72 8 c 4.41828,0 9.07159,3.71364 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -72 -2 v 4 H 73 v -4 h -2 -8 c -4.418278,0 -8,-3.58172 -8,-8 v -8 z"
-       id="path3101-1"
-       style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       y="512.12408"
-       x="66"
-       id="text3103-5"
-       style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="160"
-         y="540.12408"
-         id="tspan3105-3">step pitch</tspan>
-    </text>
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-6-72-7-7-8-2"
-       d="m 181,513.12409 h 120 v 40 H 181 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       y="512.12408"
-       x="208"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-9-5-5-0-93-0">
-      <tspan
-         id="tspan25-8-7-0-3-6-8"
-         y="538.12408"
-         x="228">-1</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-0"
-     d="m 37,571.68617 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18 60 8 c 4.41828,0 9.07159,3.71364 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41827 -3.58172,8 -8,8 h -8 -60 -2 v 4 H 73 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,9.99999 v 8 50.00001 7.99999 c 0,5.52285 4.64205,11.3395 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.41828 -3.71365,9.0716 -8,8 H 91 73 71 v 4 H 55 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 z" />
-  <text
-     x="34"
-     y="552.68616"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-6-6">
-    <tspan
-       id="tspan3039-2"
-       y="583.18616"
-       x="42">note value</tspan>
-  </text>
-  <g
-     id="g5152-6"
-     transform="translate(36,596.68617)">
-    <path
-       d="m 247,1.000003 h 120 v 40 H 247 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-       id="path21-6-1-1"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text23-9-82-8"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       x="282"
-       y="4.7314452e-06">
-      <tspan
-         x="302"
-         y="26.000004"
-         id="tspan25-8-5-7">8</tspan>
-    </text>
-  </g>
-  <g
-     id="g5157-9"
-     transform="translate(36,554.68617)">
-    <path
-       d="M 133,17 V 9 a 8,8 0 0 1 8,-8 h 8 20 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -20 -8 a 8,8 0 0 1 -8,-8 V 67 25 23 h -12 v 6 h -4 V 13 h 4 v 6 h 12 z"
-       id="path3798-4-4-5-2"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       y="-2.2888184e-05"
-       id="text3800-3-2-0-0"
-       style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-       x="108">
-      <tspan
-         x="218"
-         y="49"
-         id="tspan3802-6-2-5-2">/</tspan>
-    </text>
+     transform="translate(-3.3333326e-7,0.42153745)"
+     id="g4045">
     <g
-       transform="translate(0,-42)"
-       id="g5147-3">
+       transform="scale(1.5)"
+       id="g4043">
       <path
-         style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path21-8-2-1-0-6-7"
-         d="M 247,43 H 367 V 83 H 247 V 67 65 h -12 v 6 h -4 V 55 h 4 v 6 h 12 v -2 z" />
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 336 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4037"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-         id="text23-0-1-0-1-0-5"
-         y="44"
-         x="279">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4041">
         <tspan
-           id="tspan25-7-0-5-2-5-9"
-           y="70.000031"
-           x="299">1</tspan>
+           x="5.3333335"
+           y="21.5"
+           id="tspan4039">start</tspan>
       </text>
     </g>
   </g>
-  <path
-     d="m 55,613.68617 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 60 8 c 4.41828,0 8,3.58172 8,8 v 8 8 8 c 0,4.41828 -3.71364,6.92841 -8,8 h -8 -60 -2 v 4 H 73 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 0 z"
-     id="path3124-2"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="136.823"
-     y="624.60925"
-     id="text6137-2"><tspan
-       id="tspan6139-8"
-       x="136.823"
-       y="624.60925"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-6"
-     d="m 37,321.68617 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18 60 8 c 4.41828,0 9.07159,3.71364 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41828 -3.58172,8 -8,8 h -8 -60 -2 v 4 H 73 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,9.99999 v 8 50.00001 7.99999 c 0,5.52285 4.64205,11.3395 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.41828 -3.71364,9.0716 -8,8 H 91 73 71 v 4 H 55 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 z" />
-  <text
-     x="34"
-     y="302.68616"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-1">
-    <tspan
-       id="tspan3039-0"
-       y="333.18616"
-       x="42">note value</tspan>
-  </text>
   <g
-     id="g5152-63"
-     transform="translate(36,346.68617)">
-    <path
-       d="m 247,1.000003 h 120 v 40 H 247 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-       id="path21-6-1-20"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text23-9-82-6"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       x="282"
-       y="4.7314452e-06">
-      <tspan
-         x="302"
-         y="26.000004"
-         id="tspan25-8-5-15">8</tspan>
-    </text>
-  </g>
-  <g
-     id="g5157-5"
-     transform="translate(36,304.68617)">
-    <path
-       d="M 133,17 V 9 a 8,8 0 0 1 8,-8 h 8 20 60 8 a 8,8 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8,8 0 0 1 -8,8 h -8 -60 -20 -8 a 8,8 0 0 1 -8,-8 V 67 25 23 h -12 v 6 h -4 V 13 h 4 v 6 h 12 z"
-       id="path3798-4-4-5-4"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       y="-2.2888184e-05"
-       id="text3800-3-2-0-7"
-       style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-       x="108">
-      <tspan
-         x="218"
-         y="49"
-         id="tspan3802-6-2-5-6">/</tspan>
-    </text>
+     transform="translate(13.499997,40.921537)"
+     id="g4059">
     <g
-       transform="translate(0,-42)"
-       id="g5147-5">
+       transform="scale(1.5)"
+       id="g4057">
       <path
-         style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path21-8-2-1-0-6-6"
-         d="M 247,43 H 367 V 83 H 247 V 67 65 h -12 v 6 h -4 V 55 h 4 v 6 h 12 v -2 z" />
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4047"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-         id="text23-0-1-0-1-0-9"
-         y="44"
-         x="279">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4051">
         <tspan
-           id="tspan25-7-0-5-2-5-3"
-           y="70.000031"
-           x="299">1</tspan>
+           x="5.3333335"
+           y="15.25"
+           id="tspan4049">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4055">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan4053" />
       </text>
     </g>
   </g>
-  <path
-     d="m 55,363.68617 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 60 8 c 4.41828,0 8,3.58172 8,8 v 8 8 8 c 0,4.41828 -3.71364,6.92841 -8,8 h -8 -60 -2 v 4 H 73 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 0 z"
-     id="path3124-7"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="136.823"
-     y="374.60925"
-     id="text6137-4"><tspan
-       id="tspan6139-5"
-       x="136.823"
-       y="374.60925"
-       style="font-size:22.5px">↓</tspan></text>
   <g
-     id="g4634"
-     transform="matrix(1.185185,0,0,1.185185,-87.5673,-22.577108)">
-    <path
-       d="m 167.00762,39.539118 c 0,0 -0.46531,-0.370876 -0.74175,-0.370876 -0.55287,0 -1.09256,0.350814 -1.4835,0.741752 -0.58641,0.586406 -0.62773,1.552489 -1.11263,2.225255 -0.30668,0.425495 -0.68713,0.805948 -1.11263,1.112627 -0.67276,0.484903 -1.63885,0.526222 -2.22525,1.112628 -0.39094,0.390937 -0.74175,0.930634 -0.74175,1.483503 0,0.552869 0.43649,1.312961 0.74175,1.483503 0.96247,0.537721 0.31028,0.240518 0.74175,0.741752 0,0 -0.38587,1.22419 -0.37088,1.854379 0.0165,1.238632 0.45294,2.480604 0.74176,2.967007 0.18935,0.318895 1.34328,1.657344 2.22525,2.225255 0.88807,0.571841 1.97446,0.763668 3.02812,0.8376 1.13698,0.07978 2.21652,-0.132168 3.21565,-0.680635 0.61304,-0.336524 1.12013,-0.71383 1.54462,-1.269593 0.60499,-0.792083 1.22769,-1.632821 1.48351,-2.59613 0.15865,-0.597419 0.0755,-1.240885 0,-1.85438 -0.0623,-0.505901 -0.47178,-0.983869 -0.37088,-1.483503 0.12236,-0.605895 0.86033,-0.919212 1.11263,-1.483503 0.2573,-0.575467 0.62589,-1.277899 0.37087,-1.854379 -0.29162,-0.659231 -1.24525,-0.727152 -1.85438,-1.112628 -0.37665,-0.238358 -0.78107,-0.443829 -1.11262,-0.741752 -0.71819,-0.645351 -1.2767,-1.451586 -1.85438,-2.225255 -0.26668,-0.357158 -0.38752,-0.842067 -0.74175,-1.112627 -0.31068,-0.237297 -0.73215,-0.460695 -1.11263,-0.370876 -0.17016,0.04017 -0.37088,0.370876 -0.37088,0.370876"
-       id="path4725"
-       style="fill:#ffc1c1;fill-opacity:1;stroke:#ff0000;stroke-width:0.37087584px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4505-6"
-       d="m 172.57866,47.803117 c 0,0 0.54294,2.128427 0.37128,3.183536 -0.18671,1.147562 -0.64302,2.34396 -1.48511,3.183536 -0.76475,0.762463 -1.18949,1.049013 -2.22767,1.414905 -0.47858,0.168668 -1.84456,0.353726 -2.4159,0.353726 -0.57135,0 -1.93733,-0.185059 -2.41591,-0.353727 -1.03818,-0.365892 -1.46292,-0.652441 -2.22766,-1.414904 -0.84209,-0.839576 -1.29841,-2.035975 -1.48512,-3.183536 -0.17166,-1.055109 0.37128,-3.183536 0.37128,-3.183536 m 4.82661,-2.122358 c 0,0 -1.52881,1.745204 -2.59894,2.122358 -0.69643,0.245448 -1.5584,0.30646 -2.22767,0 -0.71423,-0.327051 -1.32906,-1.028431 -1.48511,-1.768631 -0.17743,-0.841581 0.2073,-1.529325 0.91624,-2.050581 0.76674,-0.563756 1.70542,-0.616723 2.42526,-1.132956 0.93281,-0.668963 1.08012,-1.998936 1.85639,-2.829809 0.52688,-0.563939 2.04463,-1.414905 2.04463,-1.414905 0,0 1.51774,0.850966 2.04462,1.414905 0.77627,0.830873 0.92358,2.160847 1.85639,2.82981 0.71984,0.516232 1.68334,0.54353 2.45008,1.085677 0.71847,0.508023 1.06885,1.256279 0.89142,2.097859 -0.15605,0.740201 -0.77087,1.44158 -1.48511,1.768631 -0.66927,0.30646 -1.53123,0.245448 -2.22767,0 -1.07013,-0.377153 -2.59894,-2.122357 -2.59894,-2.122357" />
+     transform="translate(109.72119,40.921537)"
+     id="g4077">
     <g
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.37127797,0,0,0.35372622,176.72956,39.358074)"
-       id="g4565">
-      <g
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1"
-         transform="translate(0,-1)"
-         id="g4553">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-7"
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-5"
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285" />
-      </g>
-      <g
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1"
-         id="g4557">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-3"
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-56"
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075" />
-      </g>
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.37127797,0,0,0.35372622,176.92563,38.650622)"
-       id="g4636">
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="circle3409-2"
-         cy="14.612609"
-         cx="-30.836912" />
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="ellipse4229-9"
-         cy="14.699166"
-         cx="-23.593306" />
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.37127797,0,0,0.35372622,176.96142,38.650622)"
-       id="g4632">
+       transform="scale(1.5)"
+       id="g4075">
       <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1"
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1-2"
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25" />
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4061"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4065">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4063">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4069">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4067" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4073">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4071" />
+      </text>
     </g>
-    <path
-       style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.80251253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4227-7"
-       d="m 167.72688,38.606235 c -0.51355,0.487351 -0.73647,0.882428 -0.91229,0.882428 -0.24578,0 -0.47204,-0.395077 -0.91229,-0.882428 -0.36084,-0.399437 0.40844,-0.882428 0.91229,-0.882428 0.50385,0 1.3103,0.504726 0.91229,0.882428 z" />
-    <path
-       d="m 167.04984,55.935948 c 0,0 0.26819,1.158553 2.03989,1.361113 1.77169,0.202559 4.37064,-1.401457 5.48447,-3.523814 1.11384,-2.122358 0.8911,-4.261654 1.11384,-6.720799"
-       id="path4653"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <g
+     transform="translate(195.22119,40.921537)"
+     id="g4087">
+    <g
+       transform="scale(1.5)"
+       id="g4085">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4079"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4083">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4081">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,72.421537)"
+     id="g4097">
+    <g
+       transform="scale(1.5)"
+       id="g4095">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4089"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4093">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4091">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,72.421537)"
+     id="g4107">
+    <g
+       transform="scale(1.5)"
+       id="g4105">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4099"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4103">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan4101">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,103.92154)"
+     id="g4125">
+    <g
+       transform="scale(1.5)"
+       id="g4123">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4109"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4113">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan4111">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4117">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan4115">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4121">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan4119">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,103.92154)"
+     id="g4135">
+    <g
+       transform="scale(1.5)"
+       id="g4133">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4127"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4131">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4129">do</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,135.42154)"
+     id="g4145">
+    <g
+       transform="scale(1.5)"
+       id="g4143">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4137"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4141">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4139">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,229.92154)"
+     id="g4159">
+    <g
+       transform="scale(1.5)"
+       id="g4157">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4147"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4151">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4149">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4155">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan4153" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(123.22119,229.92154)"
+     id="g4177">
+    <g
+       transform="scale(1.5)"
+       id="g4175">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4161"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4165">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4163">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4169">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4167" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4173">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4171" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(208.72119,229.92154)"
+     id="g4187">
+    <g
+       transform="scale(1.5)"
+       id="g4185">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4179"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4183">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4181">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(208.72119,261.42154)"
+     id="g4197">
+    <g
+       transform="scale(1.5)"
+       id="g4195">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4189"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4193">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4191">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,261.42154)"
+     id="g4207">
+    <g
+       transform="scale(1.5)"
+       id="g4205">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4199"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4203">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan4201">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,292.92154)"
+     id="g4221">
+    <g
+       transform="scale(1.5)"
+       id="g4219">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 71.972656 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4209"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4213">
+        <tspan
+           x="88.305992"
+           y="13.5"
+           id="tspan4211">scalar step (+/–)</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4217">
+        <tspan
+           x="88.305992"
+           y="11.25"
+           id="tspan4215" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(176.95899,292.92154)"
+     id="g4231">
+    <g
+       transform="scale(1.5)"
+       id="g4229">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4223"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4227">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4225">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,198.42154)"
+     id="g4245">
+    <g
+       transform="scale(1.5)"
+       id="g4243">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4233"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4237">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4235">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4241">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan4239" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.499997,198.42154)"
+     id="g4255">
+    <g
+       transform="scale(1.5)"
+       id="g4253">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4247"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4251">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4249">7</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,387.42154)"
+     id="g4269">
+    <g
+       transform="scale(1.5)"
+       id="g4267">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4257"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4261">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4259">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4265">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan4263" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.499997,387.42154)"
+     id="g4279">
+    <g
+       transform="scale(1.5)"
+       id="g4277">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4271"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4275">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4273">7</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,418.92154)"
+     id="g4293">
+    <g
+       transform="scale(1.5)"
+       id="g4291">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4281"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4285">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4283">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4289">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan4287" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(123.22119,418.92154)"
+     id="g4311">
+    <g
+       transform="scale(1.5)"
+       id="g4309">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4295"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4299">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4297">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4303">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4301" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4307">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4305" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(208.72119,418.92154)"
+     id="g4321">
+    <g
+       transform="scale(1.5)"
+       id="g4319">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4313"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4317">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4315">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(208.72119,450.42154)"
+     id="g4331">
+    <g
+       transform="scale(1.5)"
+       id="g4329">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4323"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4327">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4325">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,450.42154)"
+     id="g4341">
+    <g
+       transform="scale(1.5)"
+       id="g4339">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4333"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4337">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan4335">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,481.92154)"
+     id="g4355">
+    <g
+       transform="scale(1.5)"
+       id="g4353">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 71.972656 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4343"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4347">
+        <tspan
+           x="88.305992"
+           y="13.5"
+           id="tspan4345">scalar step (+/–)</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4351">
+        <tspan
+           x="88.305992"
+           y="11.25"
+           id="tspan4349" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(176.95899,481.92154)"
+     id="g4365">
+    <g
+       transform="scale(1.5)"
+       id="g4363">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4357"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4361">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4359">-1</tspan>
+      </text>
+    </g>
   </g>
 </svg>

--- a/guide/transform10.svg
+++ b/guide/transform10.svg
@@ -5,15 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   width="114.01777mm"
-   height="254.75806mm"
-   viewBox="0 0 403.99997 902.68614"
-   id="svg5587"
-   version="1.1">
-  <defs
-     id="defs5589" />
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="312.22119"
+   height="680.34308"
+   version="1.1"
+   id="svg2630"
+   sodipodi:docname="transform10.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata5592">
+     id="metadata2636">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,644 +25,792 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs2634" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="677"
+     inkscape:window-height="480"
+     id="namedview2632"
+     showgrid="false"
+     inkscape:zoom="0.2079063"
+     inkscape:cx="576.66667"
+     inkscape:cy="427.92154"
+     inkscape:window-x="0"
+     inkscape:window-y="282"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2630" />
   <g
-     transform="translate(17.999955,54.68606)"
-     id="g4741">
-    <path
-       style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-2-3-94"
-       d="m 114.99996,1 120,0 0,39.999999 -120,0 0,-16 0,-2 -12,0 0,6 -3.999996,0 0,-15.999999 3.999996,0 0,5.999999 12,0 0,-2 z" />
-    <text
-       x="145.99997"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0-6-52"
-       y="-1.0482422e-05">
-      <tspan
-         id="tspan25-7-2-4"
-         y="25.99999"
-         x="165.99997">C</tspan>
-    </text>
-    <path
-       d="m 0.99993896,16.999999 0,-7.999999 A 8,8 0 0 1 8.999939,1 l 8,0 0,4 20,0 0,-4 59.999995,0 7.999996,0 a 8,8 0 0 1 8,8 l 0,7.999999 -8,0 0,-5.999999 -7.999996,0 0,19.999999 7.999996,0 0,-6 8,0 0,34 -8,0 0,-6 -7.999996,0 0,20 7.999996,0 0,-6 8,0 0,8 a 8,8 0 0 1 -8,8 l -7.999996,0 -59.999995,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8.00000004,-8 l 0,-8 0,-42 0,-8 z"
-       id="path3194-3-8-43"
-       style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text3196-7-6-6"
-       style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-       x="0.89641547"
-       y="-0.28319836">
-      <tspan
-         x="94.896423"
-         y="48.716801"
-         id="tspan3198-0-1-1">set key</tspan>
-    </text>
-    <text
-       id="text3200-6-0-8"
-       style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-       x="1.4091108"
-       y="1.7168016">
-      <tspan
-         x="95.409119"
-         y="24.216803"
-         id="tspan3202-5-0-1">key</tspan>
-    </text>
-    <text
-       id="text3204-9-5-7"
-       style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-       x="0.89641547"
-       y="3.7168016">
-      <tspan
-         x="94.896423"
-         y="68.21682"
-         id="tspan3206-0-8-6">mode</tspan>
-    </text>
+     transform="translate(-3.3333333e-6,0.42153745)"
+     id="g2270">
     <g
-       transform="translate(-36.000046,-210.00004)"
-       id="g4225">
+       transform="scale(1.5)"
+       id="g2268">
       <path
-         d="m 150.99998,253.00004 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-         id="path21-2-3-9-1"
-         style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 378 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2262"
+         inkscape:connector-curvature="0" />
       <text
-         y="252.00005"
-         id="text23-0-6-5-0"
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-         x="161.99998">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2266">
         <tspan
-           x="181.99998"
-           y="278.00006"
-           id="tspan25-7-2-2-6">Major</tspan>
+           x="5.3333335"
+           y="21.5"
+           id="tspan2264">start</tspan>
       </text>
     </g>
   </g>
-  <path
-     d="m 0.99998474,29.56205 0,-8 c 0,-4.18879 3.81120996,-8 7.99999996,-8 l 8.0000003,0 10,-12.0000001 10,12.0000001 18,0 60.000005,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 0,8 0,8 c 0,4.18879 -3.93628,9.01593 -8,8 l -8,0 -60.000005,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.85121 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,8 0,759.56207 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,2.29397 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.93628,6.98407 -8,8 l -8,0 -18,0 -10,12 -10,-12 -8.0000003,0 c -4.18879,0 -7.99999996,-3.81121 -7.99999996,-8 l 0,-8 z"
-     id="path3660"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="0.56206709"
-     x="-1.4739401e-05"
-     id="text3662"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="7.9999852"
-       y="43.562065"
-       id="tspan3664">start</tspan>
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3095"
-     x="35.999985"
-     y="559.12415">
-    <tspan
-       id="tspan3097"
-       y="581.62415"
-       x="146" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3107"
-     x="35.999985"
-     y="349.12415">
-    <tspan
-       id="tspan3109"
-       y="371.62415"
-       x="130" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033"
-     x="35.999985"
-     y="307.12411">
-    <tspan
-       id="tspan3035"
-       y="329.62411"
-       x="138" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3317"
-     x="17.999985"
-     y="139.12411">
-    <tspan
-       id="tspan3319"
-       y="161.62411"
-       x="160" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3095-2"
-     x="35.999985"
-     y="517.12415">
-    <tspan
-       id="tspan3097-4"
-       y="539.62415"
-       x="146" />
-  </text>
-  <path
-     style="fill:#eeeeee;stroke:#AA5968;stroke-width:1.75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path4206-4"
-     d="m 131.37631,127.03497 c -0.24354,0 -0.48399,-0.0159 -0.72092,-0.0455 l 0.61126,1.06779 0.60246,-1.05143 c -0.16339,0.0136 -0.32633,0.0291 -0.4928,0.0291 z" />
-  <path
-     d="m 18.999995,615.12406 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20.00001,0 0,-4 18,0 40.000015,0 8,0 c 4.41828,0 8,3.58172 8,8 l 0,8 -8,0 0,-6 -8,0 0,20.00001 8,0 0,-6.00001 8,0 0,8.00001 c 0,4.41828 -3.58172,8 -8,8 l -8,0 -40.000015,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,132.00002 0,8 c 0,5.52285 4.64205,8.66051 10,10 l 8.00001,0 0,4 20,0 0,-4 16,0 0,12.00001 0,12 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8,0 -18,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 z"
-     id="path3035-38"
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="598.12402"
-     x="17.999996"
-     id="text3037-37"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="25.999996"
-       y="628.62402"
-       id="tspan3039-9">repeat</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-72-7-7-3"
-     d="m 131.00002,599.12407 120.00001,0 0,40.00001 -120.00001,0 0,-16.00001 0,-2 -12,0 0,6.00001 -4,0 0,-16.00001 4,0 0,6 12,0 0,-2 z" />
-  <text
-     y="598.12402"
-     x="166.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-5-5-0-7">
-    <tspan
-       id="tspan25-8-7-0-3-87"
-       y="624.12402"
-       x="186.00003">7</tspan>
-  </text>
   <g
-     id="g4731"
-     transform="translate(-5.7333867e-6,168.56199)">
-    <path
-       style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3101-4"
-       d="m 55,321.12408 0,-8 c 0,-4.41828 3.581722,-8 8,-8 l 8,0 0,4 20,0 0,-4 72,0 8,0 c 4.41828,0 8,3.58172 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8,0 -72,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.418278,0 -8,-3.58172 -8,-8 l 0,-8 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-       id="text3103-1"
-       x="66"
-       y="304.12408">
-      <tspan
-         id="tspan3105-9"
-         y="332.12408"
-         x="160">step pitch</tspan>
-    </text>
-    <path
-       d="m 181,305.12409 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-6-72-7-7-8-0"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text23-9-5-5-0-93-9"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       x="208"
-       y="304.12408">
-      <tspan
-         x="228"
-         y="330.12408"
-         id="tspan25-8-7-0-3-6-88">1</tspan>
-    </text>
-  </g>
-  <path
-     d="m 18.999995,365.124 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20.00001,0 0,-4 18,0 40.000015,0 8,0 c 4.41828,0 8,3.58172 8,8 l 0,8 -8,0 0,-6 -8,0 0,20.00001 8,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8,0 -40.000015,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,132.00002 0,8 c 0,5.52285 4.64205,8.66051 10,10 l 8.00001,0 0,4 20,0 0,-4 16,0 0,12.00001 0,12 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8,0 -18,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 z"
-     id="path3035-1-5"
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="348.12402"
-     x="17.999996"
-     id="text3037-6-8"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="25.999996"
-       y="378.62402"
-       id="tspan3039-26-4">repeat</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-72-7-7-13-3"
-     d="m 131.00002,349.12401 120.00001,0 0,40.00001 -120.00001,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16.00001 4,0 0,6 12,0 0,-2 z" />
-  <text
-     y="348.12402"
-     x="166.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-5-5-0-82-7">
-    <tspan
-       id="tspan25-8-7-0-3-8-1"
-       y="374.12402"
-       x="186.00003">7</tspan>
-  </text>
-  <path
-     d="m 36.999995,239.68606 0,-8 a 8.0000008,8.0000013 0 0 1 8,-8 l 8.00001,0 0,4 20,0 0,-4 60.000015,0 8,0 a 8.0000008,8.0000013 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20.00001 8,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8,0 0,19.99999 8,0 0,-6 8,0 0,8 a 8.0000008,8.0000013 0 0 1 -8,8 l -8,0 -60.000015,0 -2,0 0,4.00001 -16,0 0,-4.00001 -2,0 -8.00001,0 a 8.0000008,8.0000013 0 0 1 -8,-8 l 0,-8 0,-42 0,-8.00001 z"
-     id="path3194"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="35.999996"
-     y="222.68607">
-    <tspan
-       x="130.00003"
-       y="271.6861"
-       id="tspan3198">pitch</tspan>
-  </text>
-  <text
-     id="text3200"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="35.999996"
-     y="224.68607">
-    <tspan
-       x="130.00003"
-       y="247.18607"
-       id="tspan3202">name</tspan>
-  </text>
-  <text
-     id="text3204"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="35.999996"
-     y="226.68607">
-    <tspan
-       x="130.00003"
-       y="291.1861"
-       id="tspan3206">octave</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21"
-     d="m 151.00002,223.68606 120.00001,0 0,40.00002 -120.00001,0 0,-16.00001 0,-2 -12,0 0,6 -4,0 0,-16.00001 4,0 0,6 12,0 0,-2 z" />
-  <text
-     x="180.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23"
-     y="222.68607">
-    <tspan
-       id="tspan25"
-       y="248.68607"
-       x="200.00003">do</tspan>
-  </text>
-  <path
-     d="m 151.00002,265.68607 120.00001,0 0,40 -120.00001,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-6"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="186.00003"
-     y="264.6861">
-    <tspan
-       x="206.00003"
-       y="290.6861"
-       id="tspan25-8">4</tspan>
-  </text>
-  <path
-     d="m 18.999995,155.68607 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20.00001,0 0,-4 18,0 60.000015,0 8,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8,0 -60.000015,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 c -5.52285,0 -10,4.47716 -10,10.00001 l 0,8 0,92.00001 0,7.99999 c 0,5.52285 4.64205,11.33951 10,10.00001 l 8.00001,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.0716 -8,8 l -8,0 -18,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 z"
-     id="path3035-5"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-3"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="136.68608"
-     x="15.999998">
-    <tspan
-       x="23.999996"
-       y="167.18608"
-       id="tspan3039-5">note value</tspan>
-  </text>
-  <path
-     d="m 265.00003,181.68608 120.00002,0 0,40 -120.00002,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-6-1"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="300.00003"
-     y="180.68608">
-    <tspan
-       x="320.00003"
-       y="206.68608"
-       id="tspan25-8-5">8</tspan>
-  </text>
-  <path
-     d="m 151.00002,155.68607 0,-8 a 8.0000008,8.0000013 0 0 1 8,-8 l 8,0 20,0 60.00001,0 8,0 a 8.0000008,8.0000013 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34.00001 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8.0000008,8.0000013 0 0 1 -8,8 l -8,0 -60.00001,0 -20,0 -8,0 a 8.0000008,8.0000013 0 0 1 -8,-8 l 0,-8 0,-42.00001 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path3798-4-4-5"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="138.68605"
-     id="text3800-3-2-0"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     x="126.00003">
-    <tspan
-       x="236.00003"
-       y="187.68608"
-       id="tspan3802-6-2-5">/</tspan>
-  </text>
-  <g
-     transform="translate(17.999995,96.68606)"
-     id="g5147">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-8-2-1-0-6"
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0-1-0-1-0"
-       y="44"
-       x="279">
-      <tspan
-         id="tspan25-7-0-5-2-5"
-         y="70.000031"
-         x="299">1</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124"
-     d="m 36.999995,197.68608 0,-8 c 0,-4.41828 3.58172,-8.00001 8,-8.00001 l 8.00001,0 0,4.00001 20,0 0,-4.00001 60.000015,0 8,0 c 4.41828,0 8,3.58173 8,8.00001 l 0,8 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8,0 -60.000015,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z" />
-  <text
-     id="text6137"
-     y="208.60918"
-     x="118.82303"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="208.60918"
-       x="118.82303"
-       id="tspan6139">↓</tspan></text>
-  <g
-     id="g4739"
-     transform="translate(-5.7333867e-6,210.562)">
-    <path
-       style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3101-1-3"
-       d="m 55,529.12408 0,-8 c 0,-4.41828 3.581722,-8 8,-8 l 8,0 0,4 20,0 0,-4 72,0 8,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8,0 -72,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.418278,0 -8,-3.58172 -8,-8 l 0,-8 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-       id="text3103-5-8"
-       x="66"
-       y="512.12408">
-      <tspan
-         id="tspan3105-3-0"
-         y="540.12408"
-         x="160">step pitch</tspan>
-    </text>
-    <path
-       d="m 181,513.12409 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-6-72-7-7-8-2-9"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text23-9-5-5-0-93-0-7"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       x="208"
-       y="512.12408">
-      <tspan
-         x="228"
-         y="538.12408"
-         id="tspan25-8-7-0-3-6-8-9">-1</tspan>
-    </text>
-  </g>
-  <path
-     d="m 36.999995,655.68616 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8.00001,0 0,4 20,0 0,-4 18,0 60.000015,0 8,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41827 -3.58172,8 -8,8 l -8,0 -60.000015,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,50.00001 0,8 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16.000015,0 0,12 0,12 0,8 c 0,4.41828 -3.71365,9.0716 -8.000015,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 z"
-     id="path3035-0"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-6-6"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="636.6861"
-     x="33.999996">
-    <tspan
-       x="41.999996"
-       y="667.1861"
-       id="tspan3039-2">note value</tspan>
-  </text>
-  <g
-     transform="translate(35.999995,680.68616)"
-     id="g5152-6">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-6-1-1"
-       d="m 247,1.000003 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-    <text
-       y="4.7314452e-06"
-       x="282"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-9-82-8">
-      <tspan
-         id="tspan25-8-5-7"
-         y="26.000004"
-         x="302">8</tspan>
-    </text>
-  </g>
-  <g
-     transform="translate(35.999995,638.68616)"
-     id="g5157-9">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3798-4-4-5-2"
-       d="m 133,17 0,-8 a 8,8 0 0 1 8,-8 l 8,0 20,0 60,0 8,0 a 8,8 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8,8 0 0 1 -8,8 l -8,0 -60,0 -20,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 0,-42 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-    <text
-       x="108"
-       style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-       id="text3800-3-2-0-0"
-       y="-2.2888184e-05">
-      <tspan
-         id="tspan3802-6-2-5-2"
-         y="49"
-         x="218">/</tspan>
-    </text>
+     transform="translate(26.999997,292.92154)"
+     id="g2284">
     <g
-       id="g5147-3"
-       transform="translate(0,-42)">
+       transform="scale(1.5)"
+       id="g2282">
       <path
-         d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-         id="path21-8-2-1-0-6-7"
-         style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2272"
+         inkscape:connector-curvature="0" />
       <text
-         x="279"
-         y="44"
-         id="text23-0-1-0-1-0-5"
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2276">
         <tspan
-           x="299"
-           y="70.000031"
-           id="tspan25-7-0-5-2-5-9">1</tspan>
+           x="5.3333335"
+           y="15.25"
+           id="tspan2274">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2280">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan2278" />
       </text>
     </g>
   </g>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-2"
-     d="m 55.000005,697.68617 0,-8 c 0,-4.41829 3.58172,-8.00001 8,-8.00001 l 8,0 0,4 20,0 0,-4 60.000015,0 8,0 c 4.41828,0 8,3.58172 8,8.00001 l 0,8 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8,0 -60.000015,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z" />
-  <text
-     id="text6137-2"
-     y="708.60925"
-     x="136.82303"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="708.60925"
-       x="136.82303"
-       id="tspan6139-8">↓</tspan></text>
-  <path
-     d="m 36.999995,405.68612 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8.00001,0 0,4 20,0 0,-4 18,0 60.000015,0 8,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8,0 -60.000015,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47716 -10,10 l 0,8 0,50.00002 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16.000015,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.0716 -8.000015,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 z"
-     id="path3035-6"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="386.6861"
-     x="33.999996">
-    <tspan
-       x="41.999996"
-       y="417.1861"
-       id="tspan3039-0">note value</tspan>
-  </text>
   <g
-     transform="translate(35.999995,430.68612)"
-     id="g5152-63">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-6-1-20"
-       d="m 247,1.000003 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-    <text
-       y="4.7314452e-06"
-       x="282"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-9-82-6">
-      <tspan
-         id="tspan25-8-5-15"
-         y="26.000004"
-         x="302">8</tspan>
-    </text>
-  </g>
-  <g
-     transform="translate(35.999995,388.68612)"
-     id="g5157-5">
-    <path
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3798-4-4-5-4"
-       d="m 133,17 0,-8 a 8,8 0 0 1 8,-8 l 8,0 20,0 60,0 8,0 a 8,8 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8,8 0 0 1 -8,8 l -8,0 -60,0 -20,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 0,-42 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-    <text
-       x="108"
-       style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-       id="text3800-3-2-0-7"
-       y="-2.2888184e-05">
-      <tspan
-         id="tspan3802-6-2-5-6"
-         y="49"
-         x="218">/</tspan>
-    </text>
+     transform="translate(123.22119,292.92154)"
+     id="g2302">
     <g
-       id="g5147-5"
-       transform="translate(0,-42)">
+       transform="scale(1.5)"
+       id="g2300">
       <path
-         d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-         id="path21-8-2-1-0-6-6"
-         style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2286"
+         inkscape:connector-curvature="0" />
       <text
-         x="279"
-         y="44"
-         id="text23-0-1-0-1-0-9"
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2290">
         <tspan
-           x="299"
-           y="70.000031"
-           id="tspan25-7-0-5-2-5-3">1</tspan>
+           x="54.333332"
+           y="23.799999"
+           id="tspan2288">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2294">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan2292" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2298">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan2296" />
       </text>
     </g>
   </g>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-7"
-     d="m 55.000005,447.68613 0,-8 c 0,-4.41828 3.58172,-8.00001 8,-8.00001 l 8,0 0,4.00001 20,0 0,-4.00001 60.000015,0 8,0 c 4.41828,0 8,3.58173 8,8.00001 l 0,8 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8,0 -60.000015,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z" />
-  <text
-     id="text6137-4"
-     y="458.60919"
-     x="136.82303"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="458.60919"
-       x="136.82303"
-       id="tspan6139-5">↓</tspan></text>
   <g
-     id="g4634"
-     transform="matrix(1.111111,0,0,1.111111,-77.280006,-18.464581)">
-    <path
-       d="m 167.00762,39.539118 c 0,0 -0.46531,-0.370876 -0.74175,-0.370876 -0.55287,0 -1.09256,0.350814 -1.4835,0.741752 -0.58641,0.586406 -0.62773,1.552489 -1.11263,2.225255 -0.30668,0.425495 -0.68713,0.805948 -1.11263,1.112627 -0.67276,0.484903 -1.63885,0.526222 -2.22525,1.112628 -0.39094,0.390937 -0.74175,0.930634 -0.74175,1.483503 0,0.552869 0.43649,1.312961 0.74175,1.483503 0.96247,0.537721 0.31028,0.240518 0.74175,0.741752 0,0 -0.38587,1.22419 -0.37088,1.854379 0.0165,1.238632 0.45294,2.480604 0.74176,2.967007 0.18935,0.318895 1.34328,1.657344 2.22525,2.225255 0.88807,0.571841 1.97446,0.763668 3.02812,0.8376 1.13698,0.07978 2.21652,-0.132168 3.21565,-0.680635 0.61304,-0.336524 1.12013,-0.71383 1.54462,-1.269593 0.60499,-0.792083 1.22769,-1.632821 1.48351,-2.59613 0.15865,-0.597419 0.0755,-1.240885 0,-1.85438 -0.0623,-0.505901 -0.47178,-0.983869 -0.37088,-1.483503 0.12236,-0.605895 0.86033,-0.919212 1.11263,-1.483503 0.2573,-0.575467 0.62589,-1.277899 0.37087,-1.854379 -0.29162,-0.659231 -1.24525,-0.727152 -1.85438,-1.112628 -0.37665,-0.238358 -0.78107,-0.443829 -1.11262,-0.741752 -0.71819,-0.645351 -1.2767,-1.451586 -1.85438,-2.225255 -0.26668,-0.357158 -0.38752,-0.842067 -0.74175,-1.112627 -0.31068,-0.237297 -0.73215,-0.460695 -1.11263,-0.370876 -0.17016,0.04017 -0.37088,0.370876 -0.37088,0.370876"
-       id="path4725"
-       style="fill:#ffc1c1;fill-opacity:1;stroke:#ff0000;stroke-width:0.37087584px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4505-6"
-       d="m 172.57866,47.803117 c 0,0 0.54294,2.128427 0.37128,3.183536 -0.18671,1.147562 -0.64302,2.34396 -1.48511,3.183536 -0.76475,0.762463 -1.18949,1.049013 -2.22767,1.414905 -0.47858,0.168668 -1.84456,0.353726 -2.4159,0.353726 -0.57135,0 -1.93733,-0.185059 -2.41591,-0.353727 -1.03818,-0.365892 -1.46292,-0.652441 -2.22766,-1.414904 -0.84209,-0.839576 -1.29841,-2.035975 -1.48512,-3.183536 -0.17166,-1.055109 0.37128,-3.183536 0.37128,-3.183536 m 4.82661,-2.122358 c 0,0 -1.52881,1.745204 -2.59894,2.122358 -0.69643,0.245448 -1.5584,0.30646 -2.22767,0 -0.71423,-0.327051 -1.32906,-1.028431 -1.48511,-1.768631 -0.17743,-0.841581 0.2073,-1.529325 0.91624,-2.050581 0.76674,-0.563756 1.70542,-0.616723 2.42526,-1.132956 0.93281,-0.668963 1.08012,-1.998936 1.85639,-2.829809 0.52688,-0.563939 2.04463,-1.414905 2.04463,-1.414905 0,0 1.51774,0.850966 2.04462,1.414905 0.77627,0.830873 0.92358,2.160847 1.85639,2.82981 0.71984,0.516232 1.68334,0.54353 2.45008,1.085677 0.71847,0.508023 1.06885,1.256279 0.89142,2.097859 -0.15605,0.740201 -0.77087,1.44158 -1.48511,1.768631 -0.66927,0.30646 -1.53123,0.245448 -2.22767,0 -1.07013,-0.377153 -2.59894,-2.122357 -2.59894,-2.122357" />
+     transform="translate(208.72119,292.92154)"
+     id="g2312">
     <g
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.37127797,0,0,0.35372622,176.72956,39.358074)"
-       id="g4565">
-      <g
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1"
-         transform="translate(0,-1)"
-         id="g4553">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-7"
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-5"
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285" />
-      </g>
-      <g
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1"
-         id="g4557">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-3"
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-56"
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075" />
-      </g>
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.37127797,0,0,0.35372622,176.92563,38.650622)"
-       id="g4636">
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="circle3409-2"
-         cy="14.612609"
-         cx="-30.836912" />
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="ellipse4229-9"
-         cy="14.699166"
-         cx="-23.593306" />
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.37127797,0,0,0.35372622,176.96142,38.650622)"
-       id="g4632">
+       transform="scale(1.5)"
+       id="g2310">
       <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1"
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1-2"
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25" />
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2304"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2308">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2306">1</tspan>
+      </text>
     </g>
-    <path
-       style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.80251253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4227-7"
-       d="m 167.72688,38.606235 c -0.51355,0.487351 -0.73647,0.882428 -0.91229,0.882428 -0.24578,0 -0.47204,-0.395077 -0.91229,-0.882428 -0.36084,-0.399437 0.40844,-0.882428 0.91229,-0.882428 0.50385,0 1.3103,0.504726 0.91229,0.882428 z" />
-    <path
-       d="m 167.04984,55.935948 c 0,0 0.26819,1.158553 2.03989,1.361113 1.77169,0.202559 4.37064,-1.401457 5.48447,-3.523814 1.11384,-2.122358 0.8911,-4.261654 1.11384,-6.720799"
-       id="path4653"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <g
+     transform="translate(208.72119,324.42154)"
+     id="g2322">
+    <g
+       transform="scale(1.5)"
+       id="g2320">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2314"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2318">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2316">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,324.42154)"
+     id="g2332">
+    <g
+       transform="scale(1.5)"
+       id="g2330">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2324"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2328">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan2326">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,103.92154)"
+     id="g2346">
+    <g
+       transform="scale(1.5)"
+       id="g2344">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2334"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2338">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan2336">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2342">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan2340" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(109.72119,103.92154)"
+     id="g2364">
+    <g
+       transform="scale(1.5)"
+       id="g2362">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2348"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2352">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan2350">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2356">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan2354" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2360">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan2358" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,103.92154)"
+     id="g2374">
+    <g
+       transform="scale(1.5)"
+       id="g2372">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2366"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2370">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2368">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,135.42154)"
+     id="g2384">
+    <g
+       transform="scale(1.5)"
+       id="g2382">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2376"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2380">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2378">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,135.42154)"
+     id="g2394">
+    <g
+       transform="scale(1.5)"
+       id="g2392">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2386"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2390">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan2388">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,166.92154)"
+     id="g2412">
+    <g
+       transform="scale(1.5)"
+       id="g2410">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2396"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2400">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan2398">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2404">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan2402">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2408">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan2406">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,166.92154)"
+     id="g2422">
+    <g
+       transform="scale(1.5)"
+       id="g2420">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2414"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2418">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2416">do</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,198.42154)"
+     id="g2432">
+    <g
+       transform="scale(1.5)"
+       id="g2430">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2424"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2428">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2426">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,40.921537)"
+     id="g2450">
+    <g
+       transform="scale(1.5)"
+       id="g2448">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 31.679687 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2434"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2438">
+        <tspan
+           x="48.01302"
+           y="24"
+           id="tspan2436">set key</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2442">
+        <tspan
+           x="48.01302"
+           y="11.25"
+           id="tspan2440">key</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2446">
+        <tspan
+           x="48.01302"
+           y="32.25"
+           id="tspan2444">mode</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(89.519527,40.921537)"
+     id="g2460">
+    <g
+       transform="scale(1.5)"
+       id="g2458">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2452"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2456">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2454">C</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(89.519527,72.421537)"
+     id="g2470">
+    <g
+       transform="scale(1.5)"
+       id="g2468">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2462"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2466">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2464">major</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,261.42154)"
+     id="g2484">
+    <g
+       transform="scale(1.5)"
+       id="g2482">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2472"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2476">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan2474">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2480">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan2478" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.499997,261.42154)"
+     id="g2494">
+    <g
+       transform="scale(1.5)"
+       id="g2492">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2486"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2490">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2488">7</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,355.92154)"
+     id="g2508">
+    <g
+       transform="scale(1.5)"
+       id="g2506">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 71.972656 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2496"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2500">
+        <tspan
+           x="88.305992"
+           y="13.5"
+           id="tspan2498">scalar step (+/–)</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2504">
+        <tspan
+           x="88.305992"
+           y="11.25"
+           id="tspan2502" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(176.95899,355.92154)"
+     id="g2518">
+    <g
+       transform="scale(1.5)"
+       id="g2516">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2510"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2514">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2512">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,450.42154)"
+     id="g2532">
+    <g
+       transform="scale(1.5)"
+       id="g2530">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2520"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2524">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan2522">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2528">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan2526" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.499997,450.42154)"
+     id="g2542">
+    <g
+       transform="scale(1.5)"
+       id="g2540">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2534"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2538">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2536">7</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,481.92154)"
+     id="g2556">
+    <g
+       transform="scale(1.5)"
+       id="g2554">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2544"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2548">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan2546">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2552">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan2550" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(123.22119,481.92154)"
+     id="g2574">
+    <g
+       transform="scale(1.5)"
+       id="g2572">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2558"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2562">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan2560">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2566">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan2564" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2570">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan2568" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(208.72119,481.92154)"
+     id="g2584">
+    <g
+       transform="scale(1.5)"
+       id="g2582">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2576"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2580">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2578">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(208.72119,513.42154)"
+     id="g2594">
+    <g
+       transform="scale(1.5)"
+       id="g2592">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2586"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2590">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2588">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,513.42154)"
+     id="g2604">
+    <g
+       transform="scale(1.5)"
+       id="g2602">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2596"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2600">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan2598">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,544.92154)"
+     id="g2618">
+    <g
+       transform="scale(1.5)"
+       id="g2616">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 71.972656 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2606"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2610">
+        <tspan
+           x="88.305992"
+           y="13.5"
+           id="tspan2608">scalar step (+/–)</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text2614">
+        <tspan
+           x="88.305992"
+           y="11.25"
+           id="tspan2612" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(176.95899,544.92154)"
+     id="g2628">
+    <g
+       transform="scale(1.5)"
+       id="g2626">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path2620"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text2624">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan2622">-1</tspan>
+      </text>
+    </g>
   </g>
 </svg>

--- a/guide/transform12.svg
+++ b/guide/transform12.svg
@@ -5,15 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="298.72119"
+   height="381"
    version="1.1"
-   id="svg5587"
-   viewBox="0 0 386.00007 508.00003"
-   height="143.36888mm"
-   width="108.9378mm">
-  <defs
-     id="defs5589" />
+   id="svg1878"
+   sodipodi:docname="transform12.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata5592">
+     id="metadata1884">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,304 +25,491 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <path
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-8-1-5-4-3"
-     d="m 0.99998474,17.00001 0,-8 c 0,-4.41828 3.58171996,-8 7.99999996,-8 l 8.0000003,0 0,4 20,0 0,-4 18,0 78.000005,0 7.99999,0 c 4.41828,0 9.07159,3.7136388 8,8 l 0,8 -8,0 0,-6 -7.99999,0 0,20 7.99999,0 0,-6 8,0 0,8 c 0,4.41827 -3.58172,8 -8,8 l -7.99999,0 -78.000005,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52284,0 -10,4.47715 -10,10 l 0,8 0,386.00002 0,7.99998 c 0,5.52286 4.64205,11.3395 10,10.00001 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41827 -3.71364,9.0716 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.0000003,0 c -4.41828,0 -7.99999996,-3.58173 -7.99999996,-8 l 0,-8 z" />
-  <text
-     y="-0.28318751"
-     x="0.89646912"
-     id="text3037-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="8.8964691"
-       y="30.216812"
-       id="tspan3039-2">set voice</tspan>
-  </text>
-  <path
-     d="m 150.99998,1 120,0 0,40.00001 -120,0 0,-16.00001 0,-2 -12,0 0,6 -3.99999,0 0,-16 3.99999,0 0,6 12,0 0,-2 z"
-     id="path21-6-7-2-6-4"
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-8-9-35-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="161.99998"
-     y="-1.49096e-05">
-    <tspan
-       x="181.99998"
-       y="26.000031"
-       id="tspan25-8-2-4-4-6">violin</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2"
-     d="m 36.99995,142.99997 0,-8.00002 a 8.0000024,8.0000018 0 0 1 8,-8 l 8.00001,0 0,4 20,0 0,-4 60.00001,0 8.00002,0 a 8.0000024,8.0000018 0 0 1 8,8 l 0,8.00002 -8,0 0,-6.00002 -8.00002,0 0,20.00003 8.00002,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00002,0 0,19.99999 8.00002,0 0,-6 8,0 0,8 a 8.0000024,8.0000018 0 0 1 -8,8 l -8.00002,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 a 8.0000024,8.0000018 0 0 1 -8,-8 l 0,-8 0,-42 0,-8.00001 z" />
-  <text
-     y="125.99995"
-     x="35.999947"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91">
-    <tspan
-       id="tspan3198-2"
-       y="174.99998"
-       x="129.99997">pitch</tspan>
-  </text>
-  <text
-     y="127.99995"
-     x="35.999947"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7">
-    <tspan
-       id="tspan3202-0"
-       y="150.49994"
-       x="129.99997">name</tspan>
-  </text>
-  <text
-     y="129.99997"
-     x="35.999947"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93">
-    <tspan
-       id="tspan3206-6"
-       y="194.49997"
-       x="129.99997">octave</tspan>
-  </text>
-  <path
-     d="m 150.99999,126.99995 120.00003,0 0,40.00004 -120.00003,0 0,-16.00001 0,-2 -12.00001,0 0,6 -4.00001,0 0,-16.00003 4.00001,0 0,6.00002 12.00001,0 0,-2 z"
-     id="path21-0"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="125.99995"
-     id="text23-6"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="179.99997">
-    <tspan
-       x="199.99997"
-       y="151.99994"
-       id="tspan25-2">re</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6"
-     d="m 150.99999,168.99998 120.00003,0 0,40 -120.00003,0 0,-16 0,-2 -12.00001,0 0,6 -4.00001,0 0,-16 4.00001,0 0,6 12.00001,0 0,-2 z" />
-  <text
-     y="168"
-     x="185.99997"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1">
-    <tspan
-       id="tspan25-8-8"
-       y="193.99997"
-       x="205.99997">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5"
-     d="m 18.99995,58.999963 0,-8.000011 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20.00001,0 0,-4 18,0 60.00001,0 8.00002,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8.000011 -8,0 0,-6 -8.00002,0 0,20.000002 8.00002,0 0,-6 8,0 0,8.000001 c 0,4.41828 -3.58172,8.000001 -8,8.000001 l -8.00002,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 c -5.52285,0 -10,4.477151 -10,10.000001 l 0,8.000002 0,92.00003 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8.00001,0 0,4 20,0 0,-4 16,0 0,12.00001 0,12 0,8 c 0,4.41828 -3.71364,9.07161 -8,8.00001 l -8,0 -18,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58173 -8,-8.00001 l 0,-8 z" />
-  <text
-     x="15.999947"
-     y="39.999954"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3">
-    <tspan
-       id="tspan3039-5"
-       y="70.499969"
-       x="23.999947">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7"
-     d="m 265.00002,84.999967 120.00004,0 0,40.000003 -120.00004,0 0,-16 0,-2 -12,0 0,6 -4.00001,0 0,-16.000001 4.00001,0 0,6.000001 12,0 0,-2 z" />
-  <text
-     y="83.999969"
-     x="296.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9">
-    <tspan
-       id="tspan25-8-5-2"
-       y="109.99995"
-       x="316.00003">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5"
-     d="m 150.99999,58.999963 0,-8.000011 a 8.0000024,8.0000018 0 0 1 8,-8 l 8,0 20.00001,0 60.00001,0 8.00001,0 a 8.0000024,8.0000018 0 0 1 8,8 l 0,8.000011 -8,0 0,-6 -8.00001,0 0,20.000002 8.00001,0 0,-6 8,0 0,34.000005 -8,0 0,-6.000001 -8.00001,0 0,20.000001 8.00001,0 0,-6 8,0 0,8 a 8.0000024,8.0000018 0 0 1 -8,8 l -8.00001,0 -60.00001,0 -20.00001,0 -8,0 a 8.0000024,8.0000018 0 0 1 -8,-8 l 0,-8 0,-42.000005 0,-2.000001 -12.00001,0 0,6.000001 -4.00001,0 0,-16.000002 4.00001,0 0,6.000001 12.00001,0 0,-2.000001 z" />
-  <text
-     x="126.00002"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0"
-     y="41.999924">
-    <tspan
-       id="tspan3802-6-2-5"
-       y="90.999954"
-       x="236">/</tspan>
-  </text>
+  <defs
+     id="defs1882" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="774"
+     inkscape:window-height="480"
+     id="namedview1880"
+     showgrid="false"
+     inkscape:zoom="0.2079063"
+     inkscape:cx="586"
+     inkscape:cy="125"
+     inkscape:window-x="0"
+     inkscape:window-y="282"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1878" />
   <g
-     id="g5147"
-     transform="translate(17.99995,-5.7387902e-5)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5">1</tspan>
-    </text>
+     id="g1666">
+    <g
+       transform="scale(1.5)"
+       id="g1664">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 33.901367 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 189 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1654"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1658">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan1656">set timbre</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1662">
+        <tspan
+           x="59.234699"
+           y="11.25"
+           id="tspan1660" />
+      </text>
+    </g>
   </g>
-  <path
-     d="m 36.99995,100.99997 0,-8.000002 c 0,-4.41828 3.58172,-8.000001 8,-8.000001 l 8.00001,0 0,4.000001 20,0 0,-4.000001 60.00001,0 8.00002,0 c 4.41828,0 8,3.581721 8,8.000001 l 0,8.000002 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8.00002,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z"
-     id="path3124"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="118.82295"
-     y="111.92309"
-     id="text6137"><tspan
-       id="tspan6139"
-       x="118.82295"
-       y="111.92309"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-1"
-     d="m 36.99995,352.99999 0,-8.00001 a 8.0000031,8.0000024 0 0 1 8,-8 l 8.00001,0 0,4 20.00001,0 0,-4 60,0 8.00003,0 a 8.0000031,8.0000024 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8.00003,0 0,20.00002 8.00003,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00003,0 0,19.99999 8.00003,0 0,-6 8,0 0,8 a 8.0000031,8.0000024 0 0 1 -8,8 l -8.00003,0 -60,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8.00001,0 a 8.0000031,8.0000024 0 0 1 -8,-8 l 0,-8 0,-42 0,-8.00001 z" />
-  <text
-     y="336"
-     x="35.999947"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-5">
-    <tspan
-       id="tspan3198-2-5"
-       y="385.00003"
-       x="129.99997">pitch</tspan>
-  </text>
-  <text
-     y="338.00003"
-     x="35.999947"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-4">
-    <tspan
-       id="tspan3202-0-7"
-       y="360.5"
-       x="129.99997">name</tspan>
-  </text>
-  <text
-     y="340.00003"
-     x="35.999947"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-6">
-    <tspan
-       id="tspan3206-6-5"
-       y="404.5"
-       x="129.99997">octave</tspan>
-  </text>
-  <path
-     d="m 151,336.99998 120.00004,0 0,40.00003 -120.00004,0 0,-16.00001 0,-2 -12.00001,0 0,6 -4.00002,0 0,-16.00002 4.00002,0 0,6.00002 12.00001,0 0,-2.00001 z"
-     id="path21-0-6"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="336"
-     id="text23-6-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="180.00003">
-    <tspan
-       x="200.00003"
-       y="362"
-       id="tspan25-2-3">mi</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-7"
-     d="m 151,379 120.00004,0 0,40 L 151,419 l 0,-16 0,-2 -12.00001,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12.00001,0 0,-2 z" />
-  <text
-     y="378.00003"
-     x="186.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-4">
-    <tspan
-       id="tspan25-8-8-5"
-       y="404"
-       x="206.00003">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-2"
-     d="m 18.99995,268.99998 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20.00001,0 0,-4 18.00001,0 60,0 8.00003,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8.00003,0 0,20 8.00003,0 0,-6 8,0 0,8 c 0,4.41829 -3.58172,8.00001 -8,8.00001 l -8.00003,0 -60,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8.00001,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,92.00003 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8.00001,0 0,4.00001 20.00001,0 0,-4.00001 16,0 0,12.00001 0,12 0,8 c 0,4.41828 -3.71364,9.07162 -8,8.00002 l -8,0 -18.00001,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58174 -8,-8.00002 l 0,-8 z" />
-  <text
-     x="15.999947"
-     y="249.99997"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-5">
-    <tspan
-       id="tspan3039-5-4"
-       y="280.50003"
-       x="23.999947">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-7"
-     d="m 265.00004,294.99999 120.00005,0 0,40.00001 -120.00005,0 0,-16.00001 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z" />
-  <text
-     y="294.00003"
-     x="296.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-4">
-    <tspan
-       id="tspan25-8-5-2-4"
-       y="320"
-       x="316.00003">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-3"
-     d="m 151,268.99998 0,-8 a 8.0000031,8.0000024 0 0 1 8,-8 l 8,0 20.00001,0 60.00001,0 8.00002,0 a 8.0000031,8.0000024 0 0 1 8,8 l 0,8 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,34.00001 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,8 a 8.0000031,8.0000024 0 0 1 -8,8.00001 l -8.00002,0 -60.00001,0 -20.00001,0 -8,0 a 8.0000031,8.0000024 0 0 1 -8,-8.00001 l 0,-8 0,-42.00001 0,-2 -12.00001,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12.00001,0 0,-2 z" />
-  <text
-     x="126.00002"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-0"
-     y="251.99994">
-    <tspan
-       id="tspan3802-6-2-5-7"
-       y="301"
-       x="236">/</tspan>
-  </text>
   <g
-     id="g5147-8"
-     transform="translate(17.99994,209.99995)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-6"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-8"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-8">1</tspan>
-    </text>
+     transform="translate(92.85205)"
+     id="g1676">
+    <g
+       transform="scale(1.5)"
+       id="g1674">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1668"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1672">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1670">violin</tspan>
+      </text>
+    </g>
   </g>
-  <path
-     d="m 36.99995,310.99999 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8.00001,0 0,4 20.00001,0 0,-4 60,0 8.00003,0 c 4.41828,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41829 -3.71364,6.92842 -8,8.00001 l -8.00003,0 -60,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8.00001,0 c -4.41828,0 -8,-3.58172 -8,-8.00001 l 0,-8 0,0 z"
-     id="path3124-4"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="118.82301"
-     y="321.92313"
-     id="text6137-3"><tspan
-       id="tspan6139-1"
-       x="118.82301"
-       y="321.92313"
-       style="font-size:22.5px">↓</tspan></text>
+  <g
+     transform="translate(13.5,31.5)"
+     id="g1690">
+    <g
+       transform="scale(1.5)"
+       id="g1688">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1678"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1682">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan1680">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1686">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan1684" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(109.72119,31.5)"
+     id="g1708">
+    <g
+       transform="scale(1.5)"
+       id="g1706">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1692"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1696">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan1694">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1700">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan1698" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1704">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan1702" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,31.5)"
+     id="g1718">
+    <g
+       transform="scale(1.5)"
+       id="g1716">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1710"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1714">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1712">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,63)"
+     id="g1728">
+    <g
+       transform="scale(1.5)"
+       id="g1726">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1720"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1724">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1722">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,63)"
+     id="g1738">
+    <g
+       transform="scale(1.5)"
+       id="g1736">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1730"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1734">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan1732">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,94.5)"
+     id="g1756">
+    <g
+       transform="scale(1.5)"
+       id="g1754">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1740"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1744">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan1742">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1748">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan1746">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1752">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan1750">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,94.5)"
+     id="g1766">
+    <g
+       transform="scale(1.5)"
+       id="g1764">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1758"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1762">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1760">re</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,126)"
+     id="g1776">
+    <g
+       transform="scale(1.5)"
+       id="g1774">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1768"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1772">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1770">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,189)"
+     id="g1790">
+    <g
+       transform="scale(1.5)"
+       id="g1788">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1778"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1782">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan1780">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1786">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan1784" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(109.72119,189)"
+     id="g1808">
+    <g
+       transform="scale(1.5)"
+       id="g1806">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1792"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1796">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan1794">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1800">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan1798" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1804">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan1802" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,189)"
+     id="g1818">
+    <g
+       transform="scale(1.5)"
+       id="g1816">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1810"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1814">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1812">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,220.5)"
+     id="g1828">
+    <g
+       transform="scale(1.5)"
+       id="g1826">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1820"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1824">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1822">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,220.5)"
+     id="g1838">
+    <g
+       transform="scale(1.5)"
+       id="g1836">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1830"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1834">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan1832">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,252)"
+     id="g1856">
+    <g
+       transform="scale(1.5)"
+       id="g1854">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1840"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1844">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan1842">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1848">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan1846">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text1852">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan1850">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,252)"
+     id="g1866">
+    <g
+       transform="scale(1.5)"
+       id="g1864">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1858"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1862">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1860">mi</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,283.5)"
+     id="g1876">
+    <g
+       transform="scale(1.5)"
+       id="g1874">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path1868"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text1872">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan1870">5</tspan>
+      </text>
+    </g>
+  </g>
 </svg>

--- a/guide/transform14.svg
+++ b/guide/transform14.svg
@@ -5,15 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="931.30859"
+   height="446"
    version="1.1"
-   id="svg5587"
-   viewBox="0 0 797.25014 546.37509"
-   height="154.19917mm"
-   width="225.00171mm">
-  <defs
-     id="defs5589" />
+   id="svg9330"
+   sodipodi:docname="transform14.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata5592">
+     id="metadata9336">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,682 +25,1281 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <path
-     style="fill:#76c61c;fill-opacity:1;stroke:#538d38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-19"
-     d="m 448.25004,183.99995 v -8.00002 a 8.0000024,8.0000018 0 0 1 8,-8 h 8 v 4 h 20.00001 v -4 h 60.00001 8.00002 a 8.0000024,8.0000018 0 0 1 8,8 v 8.00002 h -8 v -6.00001 h -8.00002 v 20.00002 h 8.00002 v -6 h 8 v 34 h -8 v -5.99999 h -8.00002 v 19.99999 h 8.00002 v -6 h 8 v 8 a 8.0000024,8.0000018 0 0 1 -8,8 h -8.00002 -60.00001 -2 v 4 h -16.00001 v -4 h -2 -8 a 8.0000024,8.0000018 0 0 1 -8,-8 v -8 -42 z" />
-  <text
-     y="166.99994"
-     x="447.25006"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-6">
-    <tspan
-       id="tspan3198-2-2"
-       y="216"
-       x="541.25006">pitch</tspan>
-  </text>
-  <text
-     y="168.99994"
-     x="447.25006"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-1">
-    <tspan
-       id="tspan3202-0-2"
-       y="191.49991"
-       x="541.25006">name</tspan>
-  </text>
-  <text
-     y="170.99994"
-     x="447.25006"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-0">
-    <tspan
-       id="tspan3206-6-7"
-       y="235.49997"
-       x="541.25006">octave</tspan>
-  </text>
-  <path
-     d="m 562.25008,167.99993 h 120.00003 v 40.00004 H 562.25008 v -16.00001 -2 h -12.00001 v 6 h -4.00001 v -16.00002 h 4.00001 v 6.00001 h 12.00001 v -2 z"
-     id="path21-0-3"
-     style="fill:#76c61c;fill-opacity:1;stroke:#538d38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="166.99994"
-     id="text23-6-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="591.25006">
-    <tspan
-       x="611.25006"
-       y="192.99991"
-       id="tspan25-2-1">re</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-9"
-     d="m 562.25008,209.99996 h 120.00003 v 40 H 562.25008 v -16 -2 h -12.00001 v 6 h -4.00001 v -16 h 4.00001 v 6 h 12.00001 v -2 z" />
-  <text
-     y="208.99997"
-     x="597.25006"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-0">
-    <tspan
-       id="tspan25-8-8-56"
-       y="234.99997"
-       x="617.25006">5</tspan>
-  </text>
-  <path
-     style="fill:#f2740b;fill-opacity:1;stroke:#a86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-7"
-     d="m 430.25004,99.999953 v -8.00001 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18.00001 60.00001 8.00002 c 4.41828,0 9.07159,3.71364 8,8 v 8.00001 h -8 v -6 h -8.00002 v 19.999997 h 8.00002 v -6 h 8 v 8 c 0,4.41828 -3.58172,8 -8,8 h -8.00002 -60.00001 -2 v 4 h -16.00001 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,10 v 8 92.00003 7.99999 c 0,5.52285 4.64205,11.3395 10,10 h 8 v 4.00001 h 20.00001 v -4.00001 h 16 v 12.00002 12 8 c 0,4.41828 -3.71364,9.07161 -8,8.00001 h -8 -18.00001 -2 v 4 h -16 v -4 h -2 -8 c -4.41828,0 -8,-3.58173 -8,-8.00001 v -8 z" />
-  <text
-     x="427.25006"
-     y="80.999916"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-7">
-    <tspan
-       id="tspan3039-5-40"
-       y="111.49994"
-       x="435.25006">note value</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-6"
-     d="m 676.25011,125.99995 h 120.00004 v 40 H 676.25011 v -16 -2 h -12 v 6 h -4.00001 v -16 h 4.00001 v 6 h 12 v -2 z" />
-  <text
-     y="124.99994"
-     x="707.25006"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-47">
-    <tspan
-       id="tspan25-8-5-2-48"
-       y="150.99994"
-       x="727.25006">8</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-5"
-     d="m 562.25008,99.999953 v -8.00001 a 8.0000024,8.0000018 0 0 1 8,-8 h 8 20.00001 60.00001 8.00001 a 8.0000024,8.0000018 0 0 1 8,8 v 8.00001 h -8 v -6 h -8.00001 v 19.999997 h 8.00001 v -6 h 8 v 34 h -8 v -6 h -8.00001 v 20 h 8.00001 v -6 h 8 v 8 a 8.0000024,8.0000018 0 0 1 -8,8 h -8.00001 -60.00001 -20.00001 -8 a 8.0000024,8.0000018 0 0 1 -8,-8 v -8 -42 -2 h -12.00001 v 6 h -4.00001 V 95.999953 h 4.00001 v 5.999997 h 12.00001 z" />
-  <text
-     x="537.25012"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-8"
-     y="82.999908">
-    <tspan
-       id="tspan3802-6-2-5-2"
-       y="131.99992"
-       x="647.25006">/</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-2-1-0-6-0"
-     d="m 676.25004,83.999933 h 120 v 39.999997 h -120 v -16 -2 h -12 v 6 h -4 V 95.999933 h 4 v 5.999997 h 12 v -1.999997 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-1-0-1-0-6"
-     y="84.999924"
-     x="708.25006">
-    <tspan
-       id="tspan25-7-0-5-2-5-6"
-       y="110.99995"
-       x="728.25006">1</tspan>
-  </text>
-  <path
-     d="m 448.25004,141.99995 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20.00001 v -4 h 60.00001 8.00002 c 4.41828,0 8,3.58172 8,8 v 8 8 8 c 0,4.41828 -3.71364,6.92841 -8,8 h -8.00002 -60.00001 -2 v 4 h -16.00001 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 0 z"
-     id="path3124-46"
-     style="fill:#be6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="530.073"
-     y="152.92308"
-     id="text6137-2"><tspan
-       id="tspan6139-8"
-       x="530.073"
-       y="152.92308"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#76c61c;fill-opacity:1;stroke:#538d38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-1-9"
-     d="m 448.25004,393.99998 v -8.00001 a 8.0000031,8.0000024 0 0 1 8,-8 h 8 v 4 h 20.00002 v -4 h 60 8.00003 a 8.0000031,8.0000024 0 0 1 8,8 v 8.00001 h -8 v -6.00001 h -8.00003 v 20.00002 h 8.00003 v -6 h 8 v 34 h -8 V 430 h -8.00003 v 19.99999 h 8.00003 v -6 h 8 v 8 a 8.0000031,8.0000024 0 0 1 -8,8 h -8.00003 -60 -2 v 4 h -16.00002 v -4 h -2 -8 a 8.0000031,8.0000024 0 0 1 -8,-8 v -8 -42 z" />
-  <text
-     y="377"
-     x="447.25006"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-5-6">
-    <tspan
-       id="tspan3198-2-5-0"
-       y="426.00006"
-       x="541.25006">pitch</tspan>
-  </text>
-  <text
-     y="379.00003"
-     x="447.25006"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-4-7">
-    <tspan
-       id="tspan3202-0-7-0"
-       y="401.5"
-       x="541.25006">name</tspan>
-  </text>
-  <text
-     y="381.00003"
-     x="447.25006"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-6-1">
-    <tspan
-       id="tspan3206-6-5-0"
-       y="445.50003"
-       x="541.25006">octave</tspan>
-  </text>
-  <path
-     d="M 562.25009,377.99997 H 682.25013 V 418 H 562.25009 v -16.00001 -2 h -12.00001 v 6 h -4.00002 v -16.00002 h 4.00002 v 6.00002 h 12.00001 v -2.00001 z"
-     id="path21-0-6-1"
-     style="fill:#76c61c;fill-opacity:1;stroke:#538d38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="377"
-     id="text23-6-9-3"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="591.25012">
-    <tspan
-       x="611.25012"
-       y="403"
-       id="tspan25-2-3-7">mi</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-7-7"
-     d="m 562.25009,419.99999 h 120.00004 v 40 H 562.25009 v -16 -2 h -12.00001 v 6 h -4.00002 v -16 h 4.00002 v 6 h 12.00001 v -2 z" />
-  <text
-     y="419.00006"
-     x="597.25012"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-4-2">
-    <tspan
-       id="tspan25-8-8-5-6"
-       y="445.00003"
-       x="617.25012">5</tspan>
-  </text>
-  <path
-     style="fill:#f2740b;fill-opacity:1;stroke:#a86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-2-4"
-     d="m 430.25004,309.99997 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18.00002 60 8.00003 c 4.41828,0 9.07159,3.71364 8,8 v 8 h -8 v -6 h -8.00003 v 20 h 8.00003 v -6 h 8 v 8 c 0,4.41829 -3.58172,8.00001 -8,8.00001 h -8.00003 -60 -2 v 4 h -16.00002 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,10 v 8 92.00003 V 452 c 0,5.52285 4.64205,11.3395 10,10 h 8 v 4.00001 h 20.00002 V 462 h 16 v 12.00001 12 8 c 0,4.41828 -3.71364,9.07162 -8,8.00002 h -8 -18.00002 -2 v 4 h -16 v -4 h -2 -8 c -4.41828,0 -8,-3.58174 -8,-8.00002 v -8 z" />
-  <text
-     x="427.25006"
-     y="290.99997"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-5-5">
-    <tspan
-       id="tspan3039-5-4-2"
-       y="321.5"
-       x="435.25006">note value</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-7-0"
-     d="m 676.25013,335.99998 h 120.00005 v 40.00001 H 676.25013 v -16.00001 -2 h -12 v 6 h -4.00002 v -16 h 4.00002 v 6 h 12 v -2 z" />
-  <text
-     y="335"
-     x="707.25006"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-4-2">
-    <tspan
-       id="tspan25-8-5-2-4-9"
-       y="361"
-       x="727.25006">8</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-3-0"
-     d="m 562.25009,309.99997 v -8 a 8.0000031,8.0000024 0 0 1 8,-8 h 8 20.00001 60.00001 8.00002 a 8.0000031,8.0000024 0 0 1 8,8 v 8 h -8 v -6 h -8.00002 v 20 h 8.00002 v -6 h 8 v 34.00001 h -8 v -6 h -8.00002 v 20 h 8.00002 v -6 h 8 v 8 a 8.0000031,8.0000024 0 0 1 -8,8.00001 h -8.00002 -60.00001 -20.00001 -8 a 8.0000031,8.0000024 0 0 1 -8,-8.00001 v -8 -42.00001 -2 h -12.00001 v 6 h -4.00002 v -16 h 4.00002 v 6 h 12.00001 z" />
-  <text
-     x="537.25012"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-0-9"
-     y="292.99994">
-    <tspan
-       id="tspan3802-6-2-5-7-9"
-       y="342"
-       x="647.25006">/</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-2-1-0-6-6-5"
-     d="m 676.25003,293.99993 h 120 v 40 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-1-0-1-0-8-1"
-     y="294.99994"
-     x="708.25">
-    <tspan
-       id="tspan25-7-0-5-2-5-8-0"
-       y="320.99997"
-       x="728.25">1</tspan>
-  </text>
-  <path
-     d="m 448.25004,351.99998 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20.00002 v -4 h 60 8.00003 c 4.41828,0 8,3.58172 8,8 v 8 8 8 c 0,4.41829 -3.71364,6.92842 -8,8.00001 h -8.00003 -60 -2 v 4 h -16.00002 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8.00001 v -8 0 z"
-     id="path3124-4-3"
-     style="fill:#be6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="530.07306"
-     y="362.92313"
-     id="text6137-3-7"><tspan
-       id="tspan6139-1-8"
-       x="530.07306"
-       y="362.92313"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-6-6"
-     d="M 562.62504,42.250004 H 682.62503 V 82.250003 H 562.62504 v -16 -2 h -12 v 6 h -4.00001 V 54.250002 h 4.00001 v 6.000001 h 12 v -2 z" />
-  <text
-     y="41.250004"
-     x="599.25"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-47-7">
-    <tspan
-       id="tspan25-8-5-2-48-5"
-       y="67.249992"
-       x="619.25">1</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-2-1-0-6-0-9-6"
-     d="m 562.62503,1.000001 h 120 V 41 h -120 V 25 23 h -12 v 6 h -4 V 13 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-1-0-1-0-6-1-1"
-     y="1.9999998"
-     x="594.625">
-    <tspan
-       id="tspan25-7-0-5-2-5-6-2-8"
-       y="28.000027"
-       x="614.625">3</tspan>
-  </text>
+  <defs
+     id="defs9334" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     id="namedview9332"
+     showgrid="false"
+     inkscape:zoom="0.83162518"
+     inkscape:cx="551.83928"
+     inkscape:cy="257.56604"
+     inkscape:window-x="-8"
+     inkscape:window-y="274"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg9330"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0" />
   <g
-     id="g5147-6-2-9"
-     transform="translate(-96.874992,-0.749997)">
-    <path
-       d="M 247,43 H 367 V 83 H 247 V 67 65 h -12 v 6 h -4 V 55 h 4 v 6 h 12 v -2 z"
-       id="path21-8-2-1-0-6-0-9-2"
-       style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-6-1-2"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-6-2-89">0</tspan>
-    </text>
+     transform="translate(13.5,65)"
+     id="g8752">
+    <g
+       transform="scale(1.5)"
+       id="g8750">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8740"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8744">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan8742">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8748">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan8746" />
+      </text>
+    </g>
   </g>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-2-1-0-6-0-9-6-2"
-     d="m 150.12501,1 h 120 v 40 h -120 V 25 23 h -12 v 6 h -4 V 13 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-1-0-1-0-6-1-1-9"
-     y="5.1249804"
-     x="182.625">
-    <tspan
-       id="tspan25-7-0-5-2-5-6-2-8-3"
-       y="31.125011"
-       x="202.625">5</tspan>
-  </text>
-  <path
-     d="m 0.9518615,17.74862 v -7.59556 c 0,-4.19491 3.5396665,-8.601207 7.63427,-7.595561 H 16.220412 V 6.35528 h 19.08568 V 2.557499 h 17.17712 80.503858 7.63427 c 4.21629,0 6.62892,3.5229 7.63428,7.595561 v 7.59556 h -8.10269 v -5.83466 h -7.5 v 18.75 h 7.5 l 0.007,-5.625 h 8.10269 l 3.1e-4,33.750003 h -8.10267 l -0.008,-5.624997 h -7.50001 v 18.749997 h 7.50001 l 0.008,-5.625 h 8.10268 l -0.007,7.9584 c -0.004,4.19491 -3.41798,8.06514 -7.63427,8.06514 h -7.63427 -79.533118 -1.90856 v 4.6875 h -16.84144 v -4.6875 h -1.90856 -7.03214 c -5.27036,0 -9.54284,3.78123 -9.54284,9.02487 v 7.59556 386.157097 7.59555 c 0,5.24364 4.59034,8.76182 9.54284,10.56445 h 7.98642 v 4.6875 h 18.750001 v -4.6875 h 15.252089 v 10.32334 11.39334 9.06313 c 0,4.19491 -3.53968,6.59496 -7.63428,7.59556 h -7.63427 -17.17712 -1.90856 v 3.79777 h -15.26855 v -3.79777 h -1.90857 -7.6342805 c -4.21629,0 -7.63427,-3.40065 -7.63427,-7.59556 v -9.06313 z"
-     id="path21-8"
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:1.903723;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="17.841873"
-     x="0.89645386"
-     id="text3037-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="8.8964539"
-       y="48.341869"
-       id="tspan3039-2">augmented</tspan>
-  </text>
-  <path
-     d="m 413.45189,17.748621 v -7.59556 c 0,-4.19491 3.53967,-8.60121 7.63427,-7.59556 h 7.63428 v 3.79778 h 19.08568 v -3.79778 h 17.17712 80.50386 7.63427 c 4.21629,0 6.62892,3.5229 7.63428,7.59556 v 7.59556 h -8.10269 v -5.83466 h -7.5 v 18.75 h 7.5 l 0.007,-5.625 h 8.10268 l 3.2e-4,33.750002 h -8.10267 l -0.008,-5.625002 h -7.50001 v 18.750002 h 7.50001 l 0.008,-5.625 h 8.10268 l -0.007,7.9584 c -0.004,4.19491 -3.41798,8.06514 -7.63427,8.06514 h -7.63427 -79.53312 -1.90856 v 4.6875 h -16.84144 v -4.6875 h -1.90856 -7.03214 c -5.27036,0 -9.54284,3.78123 -9.54284,9.02487 v 7.59556 386.157097 7.59555 c 0,5.24364 4.59034,8.76182 9.54284,10.56445 h 7.98642 v 4.6875 h 18.75001 v -4.6875 h 15.25208 v 10.32334 11.39335 9.06312 c 0,4.19491 -3.53968,6.59496 -7.63428,7.59556 h -7.63427 -17.17712 -1.90856 v 3.79777 h -15.26855 v -3.79777 h -1.90857 -7.63428 c -4.21629,0 -7.63427,-3.40065 -7.63427,-7.59556 v -9.06312 z"
-     id="path21-8-3"
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:1.903723;stroke-linecap:round;stroke-opacity:1" />
-  <path
-     style="fill:#76c61c;fill-opacity:1;stroke:#538d38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-19-6"
-     d="m 35.875001,183.99995 v -8.00002 a 8.0000024,8.0000018 0 0 1 8,-8 h 8 v 4 h 20.00001 v -4 h 60.000009 8.00002 a 8.0000024,8.0000018 0 0 1 8,8 v 8.00002 h -8 v -6.00001 h -8.00002 v 20.00002 h 8.00002 v -6 h 8 v 34 h -8 v -5.99999 h -8.00002 v 19.99999 h 8.00002 v -6 h 8 v 8 a 8.0000024,8.0000018 0 0 1 -8,8 h -8.00002 -60.000009 -2 v 4 h -16.00001 v -4 h -2 -8 a 8.0000024,8.0000018 0 0 1 -8,-8 v -8 -42 z" />
-  <text
-     y="166.99994"
-     x="34.875019"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3196-91-6-7">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3198-2-2-5"
-       y="215.99997"
-       x="128.87502">pitch</tspan>
-  </text>
-  <text
-     y="168.99994"
-     x="34.875019"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3200-7-1-3">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3202-0-2-5"
-       y="191.49991"
-       x="128.87502">name</tspan>
-  </text>
-  <text
-     y="170.99994"
-     x="34.875019"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3204-93-0-6">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3206-6-7-2"
-       y="235.49994"
-       x="128.87502">octave</tspan>
-  </text>
-  <path
-     d="m 149.87504,167.99993 h 120.00003 v 40.00004 H 149.87504 v -16.00001 -2 h -12.00001 v 6 h -4.00001 v -16.00002 h 4.00001 v 6.00001 h 12.00001 v -2 z"
-     id="path21-0-3-9"
-     style="fill:#76c61c;fill-opacity:1;stroke:#538d38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="166.99994"
-     id="text23-6-1-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000;stroke-width:1"
-     x="178.87502">
-    <tspan
-       style="stroke-width:1"
-       x="198.87502"
-       y="192.99991"
-       id="tspan25-2-1-2">re</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-9-7"
-     d="m 149.87504,209.99996 h 120.00003 v 40 H 149.87504 v -16 -2 h -12.00001 v 6 h -4.00001 v -16 h 4.00001 v 6 h 12.00001 v -2 z" />
-  <text
-     y="208.99997"
-     x="184.87502"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000;stroke-width:1"
-     id="text23-9-1-0-0">
-    <tspan
-       style="stroke-width:1"
-       id="tspan25-8-8-56-9"
-       y="234.99994"
-       x="204.87502">5</tspan>
-  </text>
-  <path
-     style="fill:#f2740b;fill-opacity:1;stroke:#a86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-7-3"
-     d="m 17.875001,99.999953 v -8.00001 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18.00001 60.000009 8.00002 c 4.41828,0 9.07159,3.71364 8,8 v 8.00001 h -8 v -6 h -8.00002 v 19.999997 h 8.00002 v -6 h 8 v 8 c 0,4.41828 -3.58172,8 -8,8 h -8.00002 -60.000009 -2 v 4 h -16.00001 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,10 v 8 92.00003 7.99999 c 0,5.52285 4.64205,11.3395 10,10 h 8 v 4.00001 h 20.00001 v -4.00001 h 16 v 12.00002 12 8 c 0,4.41828 -3.71364,9.07161 -8,8.00001 h -8 -18.00001 -2 v 4 h -16 v -4 h -2 -8 c -4.41828,0 -8,-3.58173 -8,-8.00001 v -8 z" />
-  <text
-     x="14.875018"
-     y="80.999908"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000;stroke-width:1"
-     id="text3037-3-7-6">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3039-5-40-0"
-       y="111.49994"
-       x="22.875019">note value</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-6-62"
-     d="m 263.87507,125.99995 h 120.00002 v 40 H 263.87507 v -16 -2 h -12 v 6 h -4.00001 v -16 h 4.00001 v 6 h 12 v -2 z" />
-  <text
-     y="124.99994"
-     x="294.87503"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000;stroke-width:1"
-     id="text23-9-82-9-47-6">
-    <tspan
-       style="stroke-width:1"
-       id="tspan25-8-5-2-48-1"
-       y="150.99994"
-       x="314.87503">8</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-5-8"
-     d="m 149.87504,99.999953 v -8.00001 a 8.0000024,8.0000018 0 0 1 8,-8 h 8 20.00001 60.00001 8.00001 a 8.0000024,8.0000018 0 0 1 8,8 v 8.00001 h -8 v -6 h -8.00001 v 19.999997 h 8.00001 v -6 h 8 v 34 h -8 v -6 h -8.00001 v 20 h 8.00001 v -6 h 8 v 8 a 8.0000024,8.0000018 0 0 1 -8,8 h -8.00001 -60.00001 -20.00001 -8 a 8.0000024,8.0000018 0 0 1 -8,-8 v -8 -42 -2 h -12.00001 v 6 h -4.00001 V 95.999953 h 4.00001 v 5.999997 h 12.00001 z" />
-  <text
-     x="124.87508"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3800-3-2-0-8-7"
-     y="82.999908">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3802-6-2-5-2-9"
-       y="131.99991"
-       x="234.87502">/</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-2-1-0-6-0-2"
-     d="M 263.875,83.999933 H 383.87499 V 123.99993 H 263.875 v -16 -2 h -12 v 6 h -4 V 95.999933 h 4 v 5.999997 h 12 v -1.999997 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000;stroke-width:1"
-     id="text23-0-1-0-1-0-6-0"
-     y="84.999908"
-     x="295.87503">
-    <tspan
-       style="stroke-width:1"
-       id="tspan25-7-0-5-2-5-6-2"
-       y="110.99994"
-       x="315.87503">1</tspan>
-  </text>
-  <path
-     d="m 35.875001,141.99995 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20.00001 v -4 h 60.000009 8.00002 c 4.41828,0 8,3.58172 8,8 v 8 8 8 c 0,4.41828 -3.71364,6.92841 -8,8 h -8.00002 -60.000009 -2 v 4 h -16.00001 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8 v -8 0 z"
-     id="path3124-46-3"
-     style="fill:#be6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
+  <g
+     transform="translate(109.72119,65)"
+     id="g8770">
+    <g
+       transform="scale(1.5)"
+       id="g8768">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8754"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8758">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan8756">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8762">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan8760" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8766">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan8764" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,65)"
+     id="g8780">
+    <g
+       transform="scale(1.5)"
+       id="g8778">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8772"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8776">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8774">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,96.5)"
+     id="g8790">
+    <g
+       transform="scale(1.5)"
+       id="g8788">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8782"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8786">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8784">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,96.5)"
+     id="g8800">
+    <g
+       transform="scale(1.5)"
+       id="g8798">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8792"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8796">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan8794">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,128)"
+     id="g8818">
+    <g
+       transform="scale(1.5)"
+       id="g8816">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8802"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8806">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan8804">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8810">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan8808">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8814">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan8812">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,128)"
+     id="g8828">
+    <g
+       transform="scale(1.5)"
+       id="g8826">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8820"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8824">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8822">re</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,159.5)"
+     id="g8838">
+    <g
+       transform="scale(1.5)"
+       id="g8836">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8830"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8834">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8832">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,222.5)"
+     id="g8852">
+    <g
+       transform="scale(1.5)"
+       id="g8850">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8840"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8844">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan8842">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8848">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan8846" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(109.72119,222.5)"
+     id="g8870">
+    <g
+       transform="scale(1.5)"
+       id="g8868">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8854"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8858">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan8856">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8862">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan8860" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8866">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan8864" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,222.5)"
+     id="g8880">
+    <g
+       transform="scale(1.5)"
+       id="g8878">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8872"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8876">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8874">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,254)"
+     id="g8890">
+    <g
+       transform="scale(1.5)"
+       id="g8888">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8882"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8886">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8884">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,254)"
+     id="g8900">
+    <g
+       transform="scale(1.5)"
+       id="g8898">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8892"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8896">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan8894">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,285.5)"
+     id="g8918">
+    <g
+       transform="scale(1.5)"
+       id="g8916">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8902"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8906">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan8904">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8910">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan8908">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8914">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan8912">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,285.5)"
+     id="g8928">
+    <g
+       transform="scale(1.5)"
+       id="g8926">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8920"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8924">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8922">mi</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,317)"
+     id="g8938">
+    <g
+       transform="scale(1.5)"
+       id="g8936">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8930"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8934">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8932">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(489.5,63)"
+     id="g8952">
+    <g
+       transform="scale(1.5)"
+       id="g8950">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8940"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8944">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan8942">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8948">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan8946" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(585.72119,63)"
+     id="g8970">
+    <g
+       transform="scale(1.5)"
+       id="g8968">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8954"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8958">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan8956">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8962">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan8960" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8966">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan8964" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(671.22119,63)"
+     id="g8980">
+    <g
+       transform="scale(1.5)"
+       id="g8978">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8972"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8976">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8974">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(671.22119,94.5)"
+     id="g8990">
+    <g
+       transform="scale(1.5)"
+       id="g8988">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8982"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8986">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8984">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(503,94.5)"
+     id="g9000">
+    <g
+       transform="scale(1.5)"
+       id="g8998">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8992"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8996">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan8994">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(503,126)"
+     id="g9018">
+    <g
+       transform="scale(1.5)"
+       id="g9016">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9002"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9006">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan9004">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9010">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan9008">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9014">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan9012">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(576.5,126)"
+     id="g9028">
+    <g
+       transform="scale(1.5)"
+       id="g9026">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9020"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9024">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9022">re</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(576.5,157.5)"
+     id="g9038">
+    <g
+       transform="scale(1.5)"
+       id="g9036">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9030"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9034">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9032">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(0,2)"
+     id="g9052">
+    <g
+       transform="scale(1.5)"
+       id="g9050">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 92.53906 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 231 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9040"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9044">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan9042">semi-tone interval (+/–)</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9048">
+        <tspan
+           x="117.8724"
+           y="11.25"
+           id="tspan9046" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(180.80859,2)"
+     id="g9070">
+    <g
+       transform="scale(1.5)"
+       id="g9068">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9054"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9058">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan9056">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9062">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan9060" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9066">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan9064" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(266.30859,2)"
+     id="g9080">
+    <g
+       transform="scale(1.5)"
+       id="g9078">
+      <path
+         d="m 8.5,0.5 h 110 v 20 H 8.5 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9072"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9076">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9074" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(266.30859,33.5)"
+     id="g9098">
+    <g
+       transform="scale(1.5)"
+       id="g9096">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9082"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9086">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan9084">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9090">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan9088" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9094">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan9092" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(351.80859,33.5)"
+     id="g9108">
+    <g
+       transform="scale(1.5)"
+       id="g9106">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9100"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9104">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9102">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(351.80859,65)"
+     id="g9118">
+    <g
+       transform="scale(1.5)"
+       id="g9116">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9110"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9114">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9112">12</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,380)"
+     id="g9128">
+    <g
+       transform="scale(1.5)"
+       id="g9126">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9120"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9124">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan9122">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(476)"
+     id="g9142">
+    <g
+       transform="scale(1.5)"
+       id="g9140">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 92.53906 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 210 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9130"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9134">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan9132">semi-tone interval (+/–)</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9138">
+        <tspan
+           x="117.8724"
+           y="11.25"
+           id="tspan9136" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(656.80859)"
+     id="g9160">
+    <g
+       transform="scale(1.5)"
+       id="g9158">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9144"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9148">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan9146">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9152">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan9150" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9156">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan9154" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(742.3086)"
+     id="g9170">
+    <g
+       transform="scale(1.5)"
+       id="g9168">
+      <path
+         d="m 8.5,0.5 h 110 v 20 H 8.5 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9162"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9166">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9164" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(742.3086,31.5)"
+     id="g9188">
+    <g
+       transform="scale(1.5)"
+       id="g9186">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9172"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9176">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan9174">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9180">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan9178" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9184">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan9182" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(827.8086,31.5)"
+     id="g9198">
+    <g
+       transform="scale(1.5)"
+       id="g9196">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9190"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9194">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9192">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(827.8086,63)"
+     id="g9208">
+    <g
+       transform="scale(1.5)"
+       id="g9206">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9200"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9204">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9202">12</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(489.5,31.5)"
+     id="g9218">
+    <g
+       transform="scale(1.5)"
+       id="g9216">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9210"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9214">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan9212">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,33.5)"
+     id="g9228">
+    <g
+       transform="scale(1.5)"
+       id="g9226">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9220"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9224">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan9222">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(489.5,220.5)"
+     id="g9242">
+    <g
+       transform="scale(1.5)"
+       id="g9240">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9230"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9234">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan9232">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9238">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan9236" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(585.72119,220.5)"
+     id="g9260">
+    <g
+       transform="scale(1.5)"
+       id="g9258">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9244"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9248">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan9246">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9252">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan9250" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9256">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan9254" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(671.22119,220.5)"
+     id="g9270">
+    <g
+       transform="scale(1.5)"
+       id="g9268">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9262"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9266">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9264">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(671.22119,252)"
+     id="g9280">
+    <g
+       transform="scale(1.5)"
+       id="g9278">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9272"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9276">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9274">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(503,252)"
+     id="g9290">
+    <g
+       transform="scale(1.5)"
+       id="g9288">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9282"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9286">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan9284">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(503,283.5)"
+     id="g9308">
+    <g
+       transform="scale(1.5)"
+       id="g9306">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9292"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9296">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan9294">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9300">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan9298">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text9304">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan9302">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(576.5,283.5)"
+     id="g9318">
+    <g
+       transform="scale(1.5)"
+       id="g9316">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9310"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9314">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9312">mi</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(576.5,315)"
+     id="g9328">
+    <g
+       transform="scale(1.5)"
+       id="g9326">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path9320"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text9324">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan9322">5</tspan>
+      </text>
+    </g>
+  </g>
   <text
      xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="117.69795"
-     y="152.92307"
-     id="text6137-2-7"><tspan
-       id="tspan6139-8-5"
-       x="117.69795"
-       y="152.92307"
-       style="font-size:22.5px;stroke-width:1px">↓</tspan></text>
-  <path
-     style="fill:#76c61c;fill-opacity:1;stroke:#538d38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-1-9-9"
-     d="m 35.875001,393.99998 v -8.00001 a 8.0000031,8.0000024 0 0 1 8,-8 h 8 v 4 h 20.00002 v -4 h 59.999999 8.00003 a 8.0000031,8.0000024 0 0 1 8,8 v 8.00001 h -8 v -6.00001 h -8.00003 v 20.00002 h 8.00003 v -6 h 8 v 34 h -8 V 430 h -8.00003 v 19.99999 h 8.00003 v -6 h 8 v 8 a 8.0000031,8.0000024 0 0 1 -8,8 h -8.00003 -59.999999 -2 v 4 h -16.00002 v -4 h -2 -8 a 8.0000031,8.0000024 0 0 1 -8,-8 v -8 -42 z" />
-  <text
-     y="376.99997"
-     x="34.875019"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3196-91-5-6-2">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3198-2-5-0-2"
-       y="426.00003"
-       x="128.87502">pitch</tspan>
-  </text>
-  <text
-     y="379.00003"
-     x="34.875019"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3200-7-4-7-8">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3202-0-7-0-9"
-       y="401.49997"
-       x="128.87502">name</tspan>
-  </text>
-  <text
-     y="381.00003"
-     x="34.875019"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3204-93-6-1-7">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3206-6-5-0-3"
-       y="445.50003"
-       x="128.87502">octave</tspan>
-  </text>
-  <path
-     d="M 149.87505,377.99997 H 269.87509 V 418 H 149.87505 v -16.00001 -2 h -12.00001 v 6 h -4.00002 v -16.00002 h 4.00002 v 6.00002 h 12.00001 v -2.00001 z"
-     id="path21-0-6-1-6"
-     style="fill:#76c61c;fill-opacity:1;stroke:#538d38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="376.99997"
-     id="text23-6-9-3-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000;stroke-width:1"
-     x="178.87508">
-    <tspan
-       style="stroke-width:1"
-       x="198.87508"
-       y="402.99997"
-       id="tspan25-2-3-7-2">mi</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-7-7-9"
-     d="m 149.87505,419.99999 h 120.00004 v 40 H 149.87505 v -16 -2 h -12.00001 v 6 h -4.00002 v -16 h 4.00002 v 6 h 12.00001 v -2 z" />
-  <text
-     y="419.00003"
-     x="184.87508"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000;stroke-width:1"
-     id="text23-9-1-4-2-3">
-    <tspan
-       style="stroke-width:1"
-       id="tspan25-8-8-5-6-1"
-       y="445.00003"
-       x="204.87508">5</tspan>
-  </text>
-  <path
-     style="fill:#f2740b;fill-opacity:1;stroke:#a86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-2-4-9"
-     d="m 17.875001,309.99997 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20 v -4 h 18.00002 59.999999 8.00003 c 4.41828,0 9.07159,3.71364 8,8 v 8 h -8 v -6 h -8.00003 v 20 h 8.00003 v -6 h 8 v 8 c 0,4.41829 -3.58172,8.00001 -8,8.00001 h -8.00003 -59.999999 -2 v 4 h -16.00002 v -4 h -2 -8 c -5.52285,0 -10,4.47715 -10,10 v 8 92.00003 V 452 c 0,5.52285 4.64205,11.3395 10,10 h 8 v 4.00001 h 20.00002 V 462 h 16 v 12.00001 12 8 c 0,4.41828 -3.71364,9.07162 -8,8.00002 h -8 -18.00002 -2 v 4 h -16 v -4 h -2 -8 c -4.41828,0 -8,-3.58174 -8,-8.00002 v -8 z" />
-  <text
-     x="14.875018"
-     y="290.99997"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000;stroke-width:1"
-     id="text3037-3-5-5-4">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3039-5-4-2-7"
-       y="321.49997"
-       x="22.875019">note value</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-7-0-8"
-     d="m 263.87509,335.99998 h 120 v 40.00001 h -120 v -16.00001 -2 h -12 v 6 h -4.00002 v -16 h 4.00002 v 6 h 12 v -2 z" />
-  <text
-     y="334.99997"
-     x="294.87503"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000;stroke-width:1"
-     id="text23-9-82-9-4-2-4">
-    <tspan
-       style="stroke-width:1"
-       id="tspan25-8-5-2-4-9-5"
-       y="360.99997"
-       x="314.87503">8</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-3-0-0"
-     d="m 149.87505,309.99997 v -8 a 8.0000031,8.0000024 0 0 1 8,-8 h 8 20.00001 60.00001 8.00002 a 8.0000031,8.0000024 0 0 1 8,8 v 8 h -8 v -6 h -8.00002 v 20 h 8.00002 v -6 h 8 v 34.00001 h -8 v -6 h -8.00002 v 20 h 8.00002 v -6 h 8 v 8 a 8.0000031,8.0000024 0 0 1 -8,8.00001 h -8.00002 -60.00001 -20.00001 -8 a 8.0000031,8.0000024 0 0 1 -8,-8.00001 v -8 -42.00001 -2 h -12.00001 v 6 h -4.00002 v -16 h 4.00002 v 6 h 12.00001 z" />
-  <text
-     x="124.87508"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3800-3-2-0-0-9-3"
-     y="292.99991">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3802-6-2-5-7-9-6"
-       y="341.99997"
-       x="234.87502">/</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-2-1-0-6-6-5-1"
-     d="m 263.87499,293.99993 h 120 v 40 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000;stroke-width:1"
-     id="text23-0-1-0-1-0-8-1-0"
-     y="294.99991"
-     x="295.87497">
-    <tspan
-       style="stroke-width:1"
-       id="tspan25-7-0-5-2-5-8-0-6"
-       y="320.99997"
-       x="315.87497">1</tspan>
-  </text>
-  <path
-     d="m 35.875001,351.99998 v -8 c 0,-4.41828 3.58172,-8 8,-8 h 8 v 4 h 20.00002 v -4 h 59.999999 8.00003 c 4.41828,0 8,3.58172 8,8 v 8 8 8 c 0,4.41829 -3.71364,6.92842 -8,8.00001 h -8.00003 -59.999999 -2 v 4 h -16.00002 v -4 h -2 -8 c -4.41828,0 -8,-3.58172 -8,-8.00001 v -8 0 z"
-     id="path3124-4-3-3"
-     style="fill:#be6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
+     style="font-style:normal;font-weight:normal;font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="292.19922"
+     y="24.103144"
+     id="text10574"><tspan
+       sodipodi:role="line"
+       x="292.19922"
+       y="24.103144"
+       id="tspan10572"><tspan
+         x="292.19922"
+         y="24.103144"
+         id="tspan10570">augmented 5</tspan></tspan></text>
   <text
      xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="117.69801"
-     y="362.92313"
-     id="text6137-3-7-2"><tspan
-       id="tspan6139-1-8-0"
-       x="117.69801"
-       y="362.92313"
-       style="font-size:22.5px;stroke-width:1px">↓</tspan></text>
-  <text
-     y="19.716831"
-     x="419.64655"
-     id="text3037-2-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="427.64655"
-       y="50.216831"
-       id="tspan3039-2-1">minor</tspan>
-  </text>
-  <text
-     y="2.7684021"
-     x="31.373363"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3204-93-0-6-6">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3206-6-7-2-1"
-       y="67.268402"
-       x="125.37335">octave +/-</tspan>
-  </text>
-  <text
-     y="2.7683976"
-     x="442.38278"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3204-93-0-6-6-5">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3206-6-7-2-1-5"
-       y="67.268402"
-       x="536.38275">octave +/-</tspan>
-  </text>
-  <text
-     y="3.370697"
-     x="31.959299"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3200-7-1-3-4">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3202-0-2-5-7"
-       y="25.870667"
-       x="125.95929">interval</tspan>
-  </text>
-  <text
-     y="3.370697"
-     x="442.96872"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000;stroke-width:1"
-     id="text3200-7-1-3-4-6">
-    <tspan
-       style="stroke-width:1"
-       id="tspan3202-0-2-5-7-5"
-       y="25.870667"
-       x="536.96869">interval</tspan>
-  </text>
+     style="font-style:normal;font-weight:normal;font-size:16px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="770.7793"
+     y="21.696894"
+     id="text10580"><tspan
+       sodipodi:role="line"
+       x="770.7793"
+       y="21.696894"
+       id="tspan10578"><tspan
+         x="770.7793"
+         y="21.696894"
+         id="tspan10576">minor 3</tspan></tspan></text>
 </svg>

--- a/guide/transform2.svg
+++ b/guide/transform2.svg
@@ -5,15 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="437.40088"
+   height="412.5"
    version="1.1"
-   id="svg5185"
-   viewBox="0 0 386.00002 508"
-   height="143.36888mm"
-   width="108.93778mm">
-  <defs
-     id="defs5187" />
+   id="svg4307"
+   sodipodi:docname="transform2.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata5190">
+     id="metadata4313">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,304 +25,642 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <path
-     d="m 0.99998474,17.000003 0,-8 c 0,-4.1887902 3.81120976,-8 7.99999996,-8 l 8.0000003,0 0,4 20,0 0,-4 18,0 157.999995,0 8,0 c 4.18879,0 8,3.8112098 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -157.999995,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.617994,0 -5.219867,1.077731 -7.071068,2.928932 -1.851201,1.851201 -2.928932,4.453074 -2.928932,7.071068 l 0,8 0,8 0,386.000007 c 0,1.30899 0.269433,2.61396 0.770266,3.82308 0.500832,1.20912 1.233065,2.32239 2.158666,3.24799 0.9256,0.9256 2.038869,1.65783 3.247986,2.15866 1.209118,0.50083 2.514084,0.77027 3.823082,0.77027 l 4,0 4,0 0,2 0,2 10,0 10,0 0,-2 0,-2 8,0 8,0 0,6 0,6 0,6 0,6 0,4 0,4 c 0,2.09439 -0.984069,4.34837 -2.476104,5.95177 -1.492034,1.60339 -3.492034,2.04823 -5.523896,2.04823 l -4,0 -4,0 -9,0 -9,0 -1,0 -1,0 0,2 0,2 -8,0 -8,0 0,-2 0,-2 -1,0 -1,0 -4,0 -4.0000003,0 c -2.0943951,0 -4.0943951,-0.95281 -5.5707963,-2.42921 -1.4764012,-1.4764 -2.42920366,-3.4764 -2.42920366,-5.57079 l 0,-4 0,-4 z"
-     id="path3035-23"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="-1.5258791e-05"
-     id="text3037-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="-1.9999973">
-    <tspan
-       x="7.9999847"
-       y="28.500004"
-       id="tspan3039-7">adjust transposition</tspan>
-  </text>
-  <path
-     d="m 231.00005,1 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8-2"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="261.00003"
-     y="2.0000014"
-     id="text23-0-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="281.00003"
-       y="27.999998"
-       id="tspan25-7-8">12</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2"
-     d="m 36.999973,142.99998 0,-8.00001 a 8.0000007,8.0000006 0 0 1 8.000001,-8 l 8.000001,0 0,4 20.000002,0 0,-4 59.999993,0 8.00001,0 a 8.0000007,8.0000006 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8.00001,0 0,20.00001 8.00001,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00001,0 0,19.99999 8.00001,0 0,-6 8,0 0,8 a 8.0000007,8.0000006 0 0 1 -8,8 l -8.00001,0 -59.999993,0 -2.000001,0 0,4 -16.000001,0 0,-4 -2,0 -8.000001,0 a 8.0000007,8.0000006 0 0 1 -8.000001,-8 l 0,-8 0,-42 0,-8 z" />
-  <text
-     y="125.99998"
-     x="35.999989"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91">
-    <tspan
-       id="tspan3198-2"
-       y="175"
-       x="130">pitch</tspan>
-  </text>
-  <text
-     y="128"
-     x="35.999989"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7">
-    <tspan
-       id="tspan3202-0"
-       y="150.49997"
-       x="130">name</tspan>
-  </text>
-  <text
-     y="130"
-     x="35.999989"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93">
-    <tspan
-       id="tspan3206-6"
-       y="194.49998"
-       x="130">octave</tspan>
-  </text>
-  <path
-     d="m 150.99998,126.99997 120.00001,0 0,40.00002 -120.00001,0 0,-16.00001 0,-2 -12,0 0,6 -4.00001,0 0,-16.00001 4.00001,0 0,6.00001 12,0 0,-2 z"
-     id="path21-0"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="125.99998"
-     id="text23-6"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="180">
-    <tspan
-       x="200"
-       y="151.99997"
-       id="tspan25-2">re</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6"
-     d="m 150.99998,168.99998 120.00001,0 0,40 -120.00001,0 0,-16 0,-2 -12,0 0,6 -4.00001,0 0,-16 4.00001,0 0,6 12,0 0,-2 z" />
-  <text
-     y="168"
-     x="186"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1">
-    <tspan
-       id="tspan25-8-8"
-       y="193.99998"
-       x="206">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5"
-     d="m 18.999971,58.999993 0,-8 c 0,-4.41828 3.581721,-8 8.000001,-8 l 8.000001,0 0,4 20.000002,0 0,-4 18.000002,0 59.999993,0 8.00001,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8.00001,0 0,20 8.00001,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8.00001,0 -59.999993,0 -2.000001,0 0,4 -16.000001,0 0,-4 -2,0 -8.000001,0 c -5.52285,0 -10.000001,4.47715 -10.000001,10 l 0,7.999997 0,92.00001 0,7.99999 c 0,5.52285 4.642051,11.3395 10.000001,10 l 8.000001,0 0,4 20.000002,0 0,-4 16.000001,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07161 -8.000001,8.00001 l -8,0 -18.000002,0 -2,0 0,4 -16.000002,0 0,-4 -2,0 -8.000001,0 c -4.41828,0 -8.000001,-3.58173 -8.000001,-8.00001 l 0,-8 z" />
-  <text
-     x="15.999984"
-     y="39.999989"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3">
-    <tspan
-       id="tspan3039-5"
-       y="70.499992"
-       x="23.999985">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7"
-     d="m 264.99999,84.999993 120.00001,0 0,39.999997 -120.00001,0 0,-16 0,-2 -12,0 0,6 -4.00001,0 0,-15.999997 4.00001,0 0,5.999997 12,0 0,-2 z" />
-  <text
-     y="83.999992"
-     x="295.99994"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9">
-    <tspan
-       id="tspan25-8-5-2"
-       y="109.99998"
-       x="315.99994">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5"
-     d="m 150.99998,58.999993 0,-8 a 8.0000007,8.0000006 0 0 1 8,-8 l 8,0 20,0 60,0 8.00001,0 a 8.0000007,8.0000006 0 0 1 8,8 l 0,8 -8,0 0,-6 -8.00001,0 0,20 8.00001,0 0,-6 8,0 0,33.999997 -8,0 0,-5.999997 -8.00001,0 0,19.999997 8.00001,0 0,-6 8,0 0,8 a 8.0000007,8.0000006 0 0 1 -8,8 l -8.00001,0 -60,0 -20,0 -8,0 a 8.0000007,8.0000006 0 0 1 -8,-8 l 0,-8 0,-41.999997 0,-2 -12,0 0,6 -4.00001,0 0,-16 4.00001,0 0,6 12,0 0,-2 z" />
-  <text
-     x="126.00001"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0"
-     y="41.999966">
-    <tspan
-       id="tspan3802-6-2-5"
-       y="90.999977"
-       x="235.99997">/</tspan>
-  </text>
+  <defs
+     id="defs4311" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     id="namedview4309"
+     showgrid="false"
+     inkscape:zoom="1.2993939"
+     inkscape:cx="218.70044"
+     inkscape:cy="206.25"
+     inkscape:window-x="-8"
+     inkscape:window-y="274"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4307" />
   <g
-     id="g5147"
-     transform="translate(17.999971,-1.5643951e-5)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5">1</tspan>
-    </text>
+     transform="translate(1065.5,380.5)"
+     id="g4015">
+    <g
+       transform="scale(1.5)"
+       id="g4013" />
   </g>
-  <path
-     d="m 36.999973,100.99999 0,-7.999997 c 0,-4.41828 3.581721,-8 8.000001,-8 l 8.000001,0 0,4 20.000002,0 0,-4 59.999993,0 8.00001,0 c 4.41828,0 8,3.58172 8,8 l 0,7.999997 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8.00001,0 -59.999993,0 -2.000001,0 0,4 -16.000001,0 0,-4 -2,0 -8.000001,0 c -4.41828,0 -8.000001,-3.58172 -8.000001,-8 l 0,-8 0,0 z"
-     id="path3124"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="118.823"
-     y="111.9231"
-     id="text6137"><tspan
-       id="tspan6139"
-       x="118.823"
-       y="111.9231"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-1"
-     d="m 36.999975,352.99997 0,-8.00001 a 8.0000014,8.0000012 0 0 1 8.000002,-8 l 8.000002,0 0,4 20.000004,0 0,-4 59.999987,0 8.00002,0 a 8.0000014,8.0000012 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8.00002,0 0,20.00001 8.00002,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00002,0 0,19.99999 8.00002,0 0,-6 8,0 0,8 a 8.0000014,8.0000012 0 0 1 -8,8 l -8.00002,0 -59.999987,0 -2.000002,0 0,4 -16.000002,0 0,-4 -2,0 -8.000002,0 a 8.0000014,8.0000012 0 0 1 -8.000002,-8 l 0,-8 0,-42 0,-8 z" />
-  <text
-     y="335.99997"
-     x="35.999989"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-5">
-    <tspan
-       id="tspan3198-2-5"
-       y="385"
-       x="130">pitch</tspan>
-  </text>
-  <text
-     y="338"
-     x="35.999989"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-4">
-    <tspan
-       id="tspan3202-0-7"
-       y="360.49997"
-       x="130">name</tspan>
-  </text>
-  <text
-     y="340"
-     x="35.999989"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-6">
-    <tspan
-       id="tspan3206-6-5"
-       y="404.49997"
-       x="130">octave</tspan>
-  </text>
-  <path
-     d="m 150.99999,336.99996 120.00002,0 0,40.00002 -120.00002,0 0,-16.00001 0,-2 -12,0 0,6 -4.00002,0 0,-16.00001 4.00002,0 0,6.00001 12,0 0,-2 z"
-     id="path21-0-6"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="335.99997"
-     id="text23-6-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="180.00002">
-    <tspan
-       x="200.00002"
-       y="361.99997"
-       id="tspan25-2-3">mi</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-7"
-     d="m 150.99999,378.99997 120.00002,0 0,40 -120.00002,0 0,-16 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z" />
-  <text
-     y="378"
-     x="186.00002"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-4">
-    <tspan
-       id="tspan25-8-8-5"
-       y="403.99997"
-       x="206.00002">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-2"
-     d="m 18.999971,268.99997 0,-8 c 0,-4.41828 3.581722,-8 8.000002,-8 l 8.000002,0 0,4 20.000004,0 0,-4 18.000004,0 59.999987,0 8.00002,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8.00002,0 -59.999987,0 -2.000002,0 0,4 -16.000002,0 0,-4 -2,0 -8.000002,0 c -5.52285,0 -10.000002,4.47715 -10.000002,10 l 0,8 0,92.00002 0,7.99999 c 0,5.52285 4.642052,11.3395 10.000002,10 l 8.000002,0 0,4 20.000004,0 0,-4 16.000002,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07162 -8.000002,8.00002 l -8,0 -18.000004,0 -2,0 0,4 -16.000004,0 0,-4 -2,0 -8.000002,0 c -4.41828,0 -8.000002,-3.58174 -8.000002,-8.00002 l 0,-8 z" />
-  <text
-     x="15.999984"
-     y="249.99997"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-5">
-    <tspan
-       id="tspan3039-5-4"
-       y="280.5"
-       x="23.999985">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-7"
-     d="m 265.00001,294.99997 120.00002,0 0,40.00001 -120.00002,0 0,-16.00001 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z" />
-  <text
-     y="294"
-     x="295.99994"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-4">
-    <tspan
-       id="tspan25-8-5-2-4"
-       y="319.99997"
-       x="315.99994">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-3"
-     d="m 150.99999,268.99997 0,-8 a 8.0000014,8.0000012 0 0 1 8,-8 l 8,0 20,0 60,0 8.00002,0 a 8.0000014,8.0000012 0 0 1 8,8 l 0,8 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,34 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,8 a 8.0000014,8.0000012 0 0 1 -8,8.00001 l -8.00002,0 -60,0 -20,0 -8,0 a 8.0000014,8.0000012 0 0 1 -8,-8.00001 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z" />
-  <text
-     x="126.00002"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-0"
-     y="251.99994">
-    <tspan
-       id="tspan3802-6-2-5-7"
-       y="300.99997"
-       x="235.99998">/</tspan>
-  </text>
   <g
-     id="g5147-8"
-     transform="translate(17.99997,209.99996)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-6"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-8"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-8">1</tspan>
-    </text>
+     id="g4029">
+    <g
+       transform="scale(1.5)"
+       id="g4027">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 210 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4017"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4021">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4019">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4025">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan4023" />
+      </text>
+    </g>
   </g>
-  <path
-     d="m 36.999975,310.99997 0,-8 c 0,-4.41828 3.581722,-8 8.000002,-8 l 8.000002,0 0,4 20.000004,0 0,-4 59.999987,0 8.00002,0 c 4.41828,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41829 -3.71364,6.92842 -8,8.00001 l -8.00002,0 -59.999987,0 -2.000002,0 0,4 -16.000002,0 0,-4 -2,0 -8.000002,0 c -4.41828,0 -8.000002,-3.58172 -8.000002,-8.00001 l 0,-8 0,0 z"
-     id="path3124-4"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="118.82301"
-     y="321.9231"
-     id="text6137-3"><tspan
-       id="tspan6139-1"
-       x="118.82301"
-       y="321.9231"
-       style="font-size:22.5px">↓</tspan></text>
+  <g
+     transform="translate(162.90088)"
+     id="g4047">
+    <g
+       transform="scale(1.5)"
+       id="g4045">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4031"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4035">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4033">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4039">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4037" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4043">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4041" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(248.40088)"
+     id="g4057">
+    <g
+       transform="scale(1.5)"
+       id="g4055">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4049"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4053">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4051">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(248.40088,31.5)"
+     id="g4075">
+    <g
+       transform="scale(1.5)"
+       id="g4073">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4059"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4063">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4061">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4067">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4065" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4071">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4069" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(333.90088,31.5)"
+     id="g4085">
+    <g
+       transform="scale(1.5)"
+       id="g4083">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4077"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4081">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4079">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(333.90088,63)"
+     id="g4095">
+    <g
+       transform="scale(1.5)"
+       id="g4093">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4087"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4091">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4089">12</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,31.5)"
+     id="g4105">
+    <g
+       transform="scale(1.5)"
+       id="g4103">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4097"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4101">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan4099">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,63)"
+     id="g4119">
+    <g
+       transform="scale(1.5)"
+       id="g4117">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4107"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4111">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4109">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4115">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan4113" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(109.72119,63)"
+     id="g4137">
+    <g
+       transform="scale(1.5)"
+       id="g4135">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4121"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4125">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4123">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4129">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4127" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4133">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4131" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,63)"
+     id="g4147">
+    <g
+       transform="scale(1.5)"
+       id="g4145">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4139"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4143">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4141">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,94.5)"
+     id="g4157">
+    <g
+       transform="scale(1.5)"
+       id="g4155">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4149"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4153">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4151">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,94.5)"
+     id="g4167">
+    <g
+       transform="scale(1.5)"
+       id="g4165">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4159"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4163">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan4161">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,126)"
+     id="g4185">
+    <g
+       transform="scale(1.5)"
+       id="g4183">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4169"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4173">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan4171">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4177">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan4175">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4181">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan4179">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,126)"
+     id="g4195">
+    <g
+       transform="scale(1.5)"
+       id="g4193">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4187"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4191">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4189">re</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,157.5)"
+     id="g4205">
+    <g
+       transform="scale(1.5)"
+       id="g4203">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4197"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4201">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4199">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,220.5)"
+     id="g4219">
+    <g
+       transform="scale(1.5)"
+       id="g4217">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4207"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4211">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4209">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4215">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan4213" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(109.72119,220.5)"
+     id="g4237">
+    <g
+       transform="scale(1.5)"
+       id="g4235">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4221"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4225">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4223">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4229">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4227" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4233">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4231" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,220.5)"
+     id="g4247">
+    <g
+       transform="scale(1.5)"
+       id="g4245">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4239"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4243">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4241">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,252)"
+     id="g4257">
+    <g
+       transform="scale(1.5)"
+       id="g4255">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4249"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4253">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4251">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,252)"
+     id="g4267">
+    <g
+       transform="scale(1.5)"
+       id="g4265">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4259"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4263">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan4261">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,283.5)"
+     id="g4285">
+    <g
+       transform="scale(1.5)"
+       id="g4283">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4269"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4273">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan4271">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4277">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan4275">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4281">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan4279">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,283.5)"
+     id="g4295">
+    <g
+       transform="scale(1.5)"
+       id="g4293">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4287"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4291">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4289">mi</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,315)"
+     id="g4305">
+    <g
+       transform="scale(1.5)"
+       id="g4303">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4297"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4301">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4299">5</tspan>
+      </text>
+    </g>
+  </g>
+  <rect
+     id="rect4327"
+     width="0"
+     height="43.22768"
+     x="453.2724"
+     y="453.89914"
+     ry="1.23507" />
 </svg>

--- a/guide/transform3.svg
+++ b/guide/transform3.svg
@@ -5,15 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="450.90088"
+   height="522.84308"
    version="1.1"
-   id="svg4075"
-   viewBox="0 0 370.00001 695.12411"
-   height="196.17947mm"
-   width="104.42223mm">
-  <defs
-     id="defs4077" />
+   id="svg4802"
+   sodipodi:docname="transform3.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata4080">
+     id="metadata4808">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,369 +25,497 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <text
-     x="18"
-     y="115.59847"
-     id="text3033"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="120"
-       y="138.09846"
-       id="tspan3035" />
-  </text>
-  <text
-     x="36"
-     y="180.56206"
-     id="text3107"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="130"
-       y="203.06206"
-       id="tspan3109" />
-  </text>
-  <text
-     x="18"
-     y="199.59846"
-     id="text3033-0"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="120"
-       y="222.09846"
-       id="tspan3035-1" />
-  </text>
-  <text
-     x="18"
-     y="283.59845"
-     id="text3033-1"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="120"
-       y="306.09845"
-       id="tspan3035-8" />
-  </text>
-  <text
-     x="18"
-     y="367.59845"
-     id="text3033-0-9"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="120"
-       y="390.09845"
-       id="tspan3035-1-5" />
-  </text>
+  <defs
+     id="defs4806" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="895"
+     inkscape:window-height="760"
+     id="namedview4804"
+     showgrid="false"
+     inkscape:zoom="1.1303583"
+     inkscape:cx="225.45044"
+     inkscape:cy="261.42154"
+     inkscape:window-x="0"
+     inkscape:window-y="282"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4802" />
   <g
-     transform="translate(54,138.40578)"
-     id="g3918">
-    <path
-       d="M 1,17 V 9 A 8,8 0 0 1 9,1 h 8 V 5 H 37 V 1 h 80 8 a 8,8 0 0 1 8,8 v 8 8 8 a 8,8 0 0 1 -8,8 h -8 -80 -2 v 4 H 19 V 41 H 17 9 A 8,8 0 0 1 1,33 v -8 z"
-       id="path3058"
-       style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text3060"
-       style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000">
-      <tspan
-         x="114"
-         y="28"
-         id="tspan3062">chunk</tspan>
-    </text>
-  </g>
-  <path
-     d="m 37,113.40577 v -8 c 0,-4.18879 3.81121,-8.000005 8,-8.000005 h 8 v 4.000005 h 20 v -4.000005 h 18 40 8 c 4.18879,0 8,3.811215 8,8.000005 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 H 73 v -4 h -2 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 C 54.07773,142.18591 53,144.78778 53,147.40577 v 8 8 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.1888 -3.93628,6.98407 -8,8 H 91 73 71 v 4 H 55 v -4 h -2 -8 c -4.18879,0 -8,-3.8112 -8,-8 v -8 z"
-     id="path3035"
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="36"
-     y="96.405762"
-     id="text3037"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="44"
-       y="126.90576"
-       id="tspan3039">repeat</tspan>
-  </text>
-  <path
-     d="M 149,97.405775 H 269 V 137.40578 H 149 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-8"
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="179"
-     y="98.405769"
-     id="text23-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="199"
-       y="124.40577"
-       id="tspan25-7">2</tspan>
-  </text>
-  <path
-     d="m 1,29.56205 0,-8 c 0,-4.18879 3.8112098,-8 8,-8 l 8,0 10,-12.0000001 10,12.0000001 18,0 60,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 0,8 0,8 c 0,4.18879 -3.93628,9.015931 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.617994,0 -5.219867,1.077731 -7.071068,2.928932 C 18.077731,58.342183 17,60.944056 17,63.56205 l 0,8 0,552 0,8 c 0,2.61799 1.077731,5.21987 2.928932,7.07107 1.851201,1.8512 4.53124,3.56389 7.071068,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.936277,9.01593 -8,8 l -8,0 -18,0 -10,12 -10,-12 -8,0 c -4.1887902,0 -8,-3.81121 -8,-8 l 0,-8 z"
-     id="path3660-4"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3662-8"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="0.56204981">
-    <tspan
-       x="8"
-       y="43.56205"
-       id="tspan3664-5">start</tspan>
-  </text>
-  <g
-     id="g4021-2"
-     transform="translate(18,418.96779)">
+     transform="translate(-3.3333326e-7,0.42153745)"
+     id="g4584">
     <g
-       id="g3918-2"
-       transform="translate(36,96.562056)">
+       transform="scale(1.5)"
+       id="g4582">
       <path
-         style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path3058-9"
-         d="M 1,17 V 9 A 8,8 0 0 1 9,1 h 8 V 5 H 37 V 1 h 80 8 a 8,8 0 0 1 8,8 v 8 8 8 a 8,8 0 0 1 -8,8 h -8 -80 -2 v 4 H 19 V 41 H 17 9 A 8,8 0 0 1 1,33 v -8 z" />
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 273 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4576"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text3060-7">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4580">
         <tspan
-           id="tspan3062-7"
-           y="28"
-           x="114">chunk3</tspan>
+           x="5.3333335"
+           y="21.5"
+           id="tspan4578">start</tspan>
       </text>
     </g>
-    <path
-       style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3035-2"
-       d="m 19,71.562042 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 H 55 v -4 h -2 -8 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 C 36.07773,100.34218 35,102.94405 35,105.56204 v 8 8 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.1888 -3.93628,6.98407 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.18879,0 -8,-3.8112 -8,-8 v -8 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text3037-4"
-       y="54.562042"
-       x="18">
-      <tspan
-         id="tspan3039-2"
-         y="85.062042"
-         x="26">repeat</tspan>
-    </text>
-    <path
-       style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-8-8"
-       d="m 131,55.562052 h 120 v 40 H 131 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0-5"
-       y="56.562054"
-       x="161">
-      <tspan
-         id="tspan25-7-7"
-         y="82.56205"
-         x="181">2</tspan>
-    </text>
   </g>
   <g
-     id="g4021-1"
-     transform="translate(18,292.96779)">
+     transform="translate(13.499997,40.921537)"
+     id="g4598">
     <g
-       id="g3918-1"
-       transform="translate(36,96.562056)">
+       transform="scale(1.5)"
+       id="g4596">
       <path
-         style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path3058-90"
-         d="M 1,17 V 9 A 8,8 0 0 1 9,1 h 8 V 5 H 37 V 1 h 80 8 a 8,8 0 0 1 8,8 v 8 8 8 a 8,8 0 0 1 -8,8 h -8 -80 -2 v 4 H 19 V 41 H 17 9 A 8,8 0 0 1 1,33 v -8 z" />
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 231 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4586"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text3060-8">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4590">
         <tspan
-           id="tspan3062-6"
-           y="28"
-           x="114">chunk2</tspan>
+           x="5.3333335"
+           y="15.25"
+           id="tspan4588">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4594">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan4592" />
       </text>
     </g>
-    <path
-       style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3035-9"
-       d="m 19,71.562042 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 H 55 v -4 h -2 -8 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 C 36.07773,100.34218 35,102.94405 35,105.56204 v 8 8 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.1888 -3.93628,6.98407 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.18879,0 -8,-3.8112 -8,-8 v -8 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text3037-7"
-       y="54.562042"
-       x="18">
-      <tspan
-         id="tspan3039-6"
-         y="85.062042"
-         x="26">repeat</tspan>
-    </text>
-    <path
-       style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-8-84"
-       d="m 131,55.562052 h 120 v 40 H 131 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0-6"
-       y="56.562054"
-       x="161">
-      <tspan
-         id="tspan25-7-5"
-         y="82.56205"
-         x="181">2</tspan>
-    </text>
   </g>
   <g
-     id="g4021-7"
-     transform="translate(18,166.96779)">
+     transform="translate(176.40088,40.921537)"
+     id="g4616">
     <g
-       id="g3918-19"
-       transform="translate(36,96.562056)">
+       transform="scale(1.5)"
+       id="g4614">
       <path
-         style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path3058-5"
-         d="M 1,17 V 9 A 8,8 0 0 1 9,1 h 8 V 5 H 37 V 1 h 80 8 a 8,8 0 0 1 8,8 v 8 8 8 a 8,8 0 0 1 -8,8 h -8 -80 -2 v 4 H 19 V 41 H 17 9 A 8,8 0 0 1 1,33 v -8 z" />
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4600"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-         id="text3060-6">
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4604">
         <tspan
-           id="tspan3062-0"
-           y="28"
-           x="114">chunk1</tspan>
+           x="54.333332"
+           y="23.799999"
+           id="tspan4602">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4608">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4606" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4612">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4610" />
       </text>
     </g>
-    <path
-       style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3035-0"
-       d="m 19,71.562042 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 H 55 v -4 h -2 -8 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 C 36.07773,100.34218 35,102.94405 35,105.56204 v 8 8 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.1888 -3.93628,6.98407 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.18879,0 -8,-3.8112 -8,-8 v -8 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text3037-9"
-       y="54.562042"
-       x="18">
-      <tspan
-         id="tspan3039-4"
-         y="85.062042"
-         x="26">repeat</tspan>
-    </text>
-    <path
-       style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-8-9"
-       d="m 131,55.562052 h 120 v 40 H 131 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0-61"
-       y="56.562054"
-       x="161">
-      <tspan
-         id="tspan25-7-1"
-         y="82.56205"
-         x="181">2</tspan>
-    </text>
-  </g>
-  <path
-     d="m 19,71.967845 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 158 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 H 231 73 71 v 4 H 55 v -4 h -2 -8 c -2.617994,0 -5.219867,1.077731 -7.071068,2.928932 C 36.077731,100.74798 35,103.34986 35,105.96785 v 8 8 468 c 0,2.61799 1.077731,5.21987 2.928932,7.07107 1.851201,1.8512 4.531241,2.29397 7.071068,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.936277,6.98407 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.18879,0 -8,-3.81121 -8,-8 v -8 z"
-     id="path3035-23"
-     style="fill:#76c61c;fill-opacity:1;stroke:#538d38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="18"
-     y="54.967846">
-    <tspan
-       x="26"
-       y="85.467842"
-       id="tspan3039-7">adjust transposition</tspan>
-  </text>
-  <g
-     id="g4578"
-     transform="translate(178.06083,31.516434)">
-    <path
-       style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path21-8-2"
-       d="M 70.939166,24.451407 H 190.93917 v 40 H 70.939166 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-    <text
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       id="text23-0-2"
-       y="25.451408"
-       x="100.93916">
-      <tspan
-         id="tspan25-7-8"
-         y="51.451405"
-         x="120.93916">12</tspan>
-    </text>
   </g>
   <g
-     transform="matrix(1.1111109,0,0,1.1111109,-79.40215,-19.773204)"
-     id="g4634">
-    <path
-       style="fill:#ffc1c1;fill-opacity:1;stroke:#ff0000;stroke-width:0.37087584px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4725"
-       d="m 167.00762,39.539118 c 0,0 -0.46531,-0.370876 -0.74175,-0.370876 -0.55287,0 -1.09256,0.350814 -1.4835,0.741752 -0.58641,0.586406 -0.62773,1.552489 -1.11263,2.225255 -0.30668,0.425495 -0.68713,0.805948 -1.11263,1.112627 -0.67276,0.484903 -1.63885,0.526222 -2.22525,1.112628 -0.39094,0.390937 -0.74175,0.930634 -0.74175,1.483503 0,0.552869 0.43649,1.312961 0.74175,1.483503 0.96247,0.537721 0.31028,0.240518 0.74175,0.741752 0,0 -0.38587,1.22419 -0.37088,1.854379 0.0165,1.238632 0.45294,2.480604 0.74176,2.967007 0.18935,0.318895 1.34328,1.657344 2.22525,2.225255 0.88807,0.571841 1.97446,0.763668 3.02812,0.8376 1.13698,0.07978 2.21652,-0.132168 3.21565,-0.680635 0.61304,-0.336524 1.12013,-0.71383 1.54462,-1.269593 0.60499,-0.792083 1.22769,-1.632821 1.48351,-2.59613 0.15865,-0.597419 0.0755,-1.240885 0,-1.85438 -0.0623,-0.505901 -0.47178,-0.983869 -0.37088,-1.483503 0.12236,-0.605895 0.86033,-0.919212 1.11263,-1.483503 0.2573,-0.575467 0.62589,-1.277899 0.37087,-1.854379 -0.29162,-0.659231 -1.24525,-0.727152 -1.85438,-1.112628 -0.37665,-0.238358 -0.78107,-0.443829 -1.11262,-0.741752 -0.71819,-0.645351 -1.2767,-1.451586 -1.85438,-2.225255 -0.26668,-0.357158 -0.38752,-0.842067 -0.74175,-1.112627 -0.31068,-0.237297 -0.73215,-0.460695 -1.11263,-0.370876 -0.17016,0.04017 -0.37088,0.370876 -0.37088,0.370876" />
-    <path
-       d="m 172.57866,47.803117 c 0,0 0.54294,2.128427 0.37128,3.183536 -0.18671,1.147562 -0.64302,2.34396 -1.48511,3.183536 -0.76475,0.762463 -1.18949,1.049013 -2.22767,1.414905 -0.47858,0.168668 -1.84456,0.353726 -2.4159,0.353726 -0.57135,0 -1.93733,-0.185059 -2.41591,-0.353727 -1.03818,-0.365892 -1.46292,-0.652441 -2.22766,-1.414904 -0.84209,-0.839576 -1.29841,-2.035975 -1.48512,-3.183536 -0.17166,-1.055109 0.37128,-3.183536 0.37128,-3.183536 m 4.82661,-2.122358 c 0,0 -1.52881,1.745204 -2.59894,2.122358 -0.69643,0.245448 -1.5584,0.30646 -2.22767,0 -0.71423,-0.327051 -1.32906,-1.028431 -1.48511,-1.768631 -0.17743,-0.841581 0.2073,-1.529325 0.91624,-2.050581 0.76674,-0.563756 1.70542,-0.616723 2.42526,-1.132956 0.93281,-0.668963 1.08012,-1.998936 1.85639,-2.829809 0.52688,-0.563939 2.04463,-1.414905 2.04463,-1.414905 0,0 1.51774,0.850966 2.04462,1.414905 0.77627,0.830873 0.92358,2.160847 1.85639,2.82981 0.71984,0.516232 1.68334,0.54353 2.45008,1.085677 0.71847,0.508023 1.06885,1.256279 0.89142,2.097859 -0.15605,0.740201 -0.77087,1.44158 -1.48511,1.768631 -0.66927,0.30646 -1.53123,0.245448 -2.22767,0 -1.07013,-0.377153 -2.59894,-2.122357 -2.59894,-2.122357"
-       id="path4505-6"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     transform="translate(261.90088,40.921537)"
+     id="g4626">
     <g
-       id="g4565"
-       transform="matrix(0.37127797,0,0,0.35372622,176.72956,39.358074)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <g
-         id="g4553"
-         transform="translate(0,-1)"
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1">
-        <path
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664"
-           id="path3411-7"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285"
-           id="path3413-5"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <g
-         id="g4557"
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1">
-        <path
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658"
-           id="path3411-3"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075"
-           id="path3413-56"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </g>
-    <g
-       id="g4636"
-       transform="matrix(0.37127797,0,0,0.35372622,176.92563,38.650622)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <ellipse
-         cx="-30.836912"
-         cy="14.612609"
-         id="circle3409-2"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <ellipse
-         cx="-23.593306"
-         cy="14.699166"
-         id="ellipse4229-9"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="g4632"
-       transform="matrix(0.37127797,0,0,0.35372622,176.96142,38.650622)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+       transform="scale(1.5)"
+       id="g4624">
       <path
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25"
-         id="path4303-1"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25"
-         id="path4303-1-2"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4618"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4622">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4620">0</tspan>
+      </text>
     </g>
-    <path
-       d="m 167.72688,38.606235 c -0.51355,0.487351 -0.73647,0.882428 -0.91229,0.882428 -0.24578,0 -0.47204,-0.395077 -0.91229,-0.882428 -0.36084,-0.399437 0.40844,-0.882428 0.91229,-0.882428 0.50385,0 1.3103,0.504726 0.91229,0.882428 z"
-       id="path4227-7"
-       style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.80251253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4653"
-       d="m 167.04984,55.935948 c 0,0 0.26819,1.158553 2.03989,1.361113 1.77169,0.202559 4.37064,-1.401457 5.48447,-3.523814 1.11384,-2.122358 0.8911,-4.261654 1.11384,-6.720799" />
+  </g>
+  <g
+     transform="translate(261.90088,72.421537)"
+     id="g4644">
+    <g
+       transform="scale(1.5)"
+       id="g4642">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4628"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4632">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4630">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4636">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4634" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4640">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4638" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(347.40088,72.421537)"
+     id="g4654">
+    <g
+       transform="scale(1.5)"
+       id="g4652">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4646"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4650">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4648">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(347.40088,103.92154)"
+     id="g4664">
+    <g
+       transform="scale(1.5)"
+       id="g4662">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4656"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4660">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4658">12</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,72.421537)"
+     id="g4678">
+    <g
+       transform="scale(1.5)"
+       id="g4676">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4666"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4670">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4668">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4674">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan4672" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(98.999997,72.421537)"
+     id="g4688">
+    <g
+       transform="scale(1.5)"
+       id="g4686">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4680"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4684">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4682">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,166.92154)"
+     id="g4702">
+    <g
+       transform="scale(1.5)"
+       id="g4700">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4690"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4694">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4692">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4698">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan4696" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(98.999997,166.92154)"
+     id="g4712">
+    <g
+       transform="scale(1.5)"
+       id="g4710">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4704"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4708">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4706">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,261.42154)"
+     id="g4726">
+    <g
+       transform="scale(1.5)"
+       id="g4724">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4714"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4718">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4716">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4722">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan4720" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(98.999997,261.42154)"
+     id="g4736">
+    <g
+       transform="scale(1.5)"
+       id="g4734">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4728"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4732">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4730">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,355.92154)"
+     id="g4750">
+    <g
+       transform="scale(1.5)"
+       id="g4748">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4738"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4742">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4740">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4746">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan4744" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(98.999997,355.92154)"
+     id="g4760">
+    <g
+       transform="scale(1.5)"
+       id="g4758">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4752"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4756">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4754">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,103.92154)"
+     id="g4770">
+    <g
+       transform="scale(1.5)"
+       id="g4768">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4762"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4766">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan4764">chunk</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,198.42154)"
+     id="g4780">
+    <g
+       transform="scale(1.5)"
+       id="g4778">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4772"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4776">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan4774">chunk1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,292.92154)"
+     id="g4790">
+    <g
+       transform="scale(1.5)"
+       id="g4788">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4782"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4786">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan4784">chunk2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.499997,387.42154)"
+     id="g4800">
+    <g
+       transform="scale(1.5)"
+       id="g4798">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4792"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4796">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan4794">chunk3</tspan>
+      </text>
+    </g>
   </g>
 </svg>

--- a/guide/transform6.svg
+++ b/guide/transform6.svg
@@ -5,15 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   width="221.82669mm"
-   height="202.63556mm"
-   viewBox="0 0 786.00008 718.00001"
-   id="svg5922"
-   version="1.1">
-  <defs
-     id="defs5924" />
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="626.72119"
+   height="540.5"
+   version="1.1"
+   id="svg6134"
+   sodipodi:docname="transform6.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata5927">
+     id="metadata6140">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,902 +25,1374 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <text
-     x="921.28571"
-     y="28.036421"
-     id="text3033"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1023.2857"
-       y="50.536419"
-       id="tspan3035" />
-  </text>
-  <text
-     x="939.28571"
-     y="93.000046"
-     id="text3107"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1033.2858"
-       y="115.50005"
-       id="tspan3109" />
-  </text>
-  <text
-     x="921.28571"
-     y="112.03642"
-     id="text3033-0"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1023.2857"
-       y="134.53642"
-       id="tspan3035-1" />
-  </text>
-  <text
-     x="921.28571"
-     y="196.03642"
-     id="text3033-1"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1023.2857"
-       y="218.53642"
-       id="tspan3035-8" />
-  </text>
-  <text
-     x="921.28571"
-     y="280.03641"
-     id="text3033-0-9"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000">
-    <tspan
-       x="1023.2857"
-       y="302.53641"
-       id="tspan3035-1-5" />
-  </text>
-  <path
-     d="M 1,17 1,9 C 1,4.81121 4.81121,1 9,1 l 8,0 0,4 20,0 0,-4 18,0 39.99999,0 8,0 c 4.1888,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.8112,8 -8,8 l -8,0 L 55,41 l -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 C 18.07773,45.78014 17,48.38201 17,51 l 0,8 0,596 0,8 c 0,2.618 1.07773,5.2199 2.92893,7.0711 1.8512,1.8512 4.53124,3.5639 7.07107,2.9289 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.9841 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z"
-     id="path3035-8"
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="-4.4335939e-06"
-     y="-1.7382812e-05"
-     id="text3037-5"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="7.9999957"
-       y="30.499983"
-       id="tspan3039-2">repeat</tspan>
-  </text>
-  <path
-     d="m 112.99999,1.00001 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="143.00006"
-     y="1.9999826"
-     id="text23-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="163.00006"
-       y="27.999983"
-       id="tspan25-7">4</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035"
-     d="m 401,17.00001 0,-8 c 0,-4.1887902 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 116,0 8,0 c 4.18879,0 9.01593,3.9362768 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -116,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 C 418.07773,45.780143 417,48.382016 417,51.00001 l 0,8 0,596 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53125,2.29397 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z" />
-  <text
-     y="9.9999997e-06"
-     x="400"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037">
-    <tspan
-       id="tspan3039"
-       y="30.50001"
-       x="408">duplicate notes</tspan>
-  </text>
-  <path
-     d="m 589,1.00001 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8-0"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="619.00006"
-     y="1.9999926"
-     id="text23-0-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="639.00006"
-       y="27.999992"
-       id="tspan25-7-3">4</tspan>
-  </text>
-  <path
-     d="m 437.00001,353 0,-8.00002 a 8.0000007,8.0000006 0 0 1 8,-7.99999 l 8,0 0,4 20,0 0,-4 59.99999,0 8.00001,0 a 8.0000007,8.0000006 0 0 1 8,7.99999 l 0,8.00002 -8,0 0,-6.00002 -8.00001,0 0,20.00002 8.00001,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00001,0 0,19.99999 8.00001,0 0,-6 8,0 0,8 a 8.0000007,8.0000006 0 0 1 -8,8 L 533,419 l -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000007,8.0000006 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3194-2"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196-91"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436"
-     y="336">
-    <tspan
-       x="530"
-       y="385.00003"
-       id="tspan3198-2">pitch</tspan>
-  </text>
-  <text
-     id="text3200-7"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436"
-     y="338">
-    <tspan
-       x="530"
-       y="360.49997"
-       id="tspan3202-0">name</tspan>
-  </text>
-  <text
-     id="text3204-93"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436"
-     y="340">
-    <tspan
-       x="530"
-       y="404.5"
-       id="tspan3206-6">octave</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-0"
-     d="m 551.00001,336.99999 119.99999,0 0,40.00002 -119.99999,0 0,-16.00001 0,-2 -12,0 0,6 -4.00001,0 0,-16.00002 4.00001,0 0,6.00002 12,0 0,-2 z" />
-  <text
-     x="580"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-6"
-     y="336">
-    <tspan
-       id="tspan25-2"
-       y="361.99997"
-       x="600">re</tspan>
-  </text>
-  <path
-     d="M 551.00001,379 671,379 l 0,40 -119.99999,0 0,-16 0,-2 -12,0 0,6 -4.00001,0 0,-16 4.00001,0 0,6 12,0 0,-2 z"
-     id="path21-6-6"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="586"
-     y="378.00003">
-    <tspan
-       x="606"
-       y="404"
-       id="tspan25-8-8">5</tspan>
-  </text>
-  <path
-     d="m 419,269.00001 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8.00001,0 0,4 20,0 0,-4 18,0 59.99999,0 8.00001,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8.00001,0 0,20 8.00001,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8.00001,0 -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,92.00001 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07161 -8,8.00001 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 c -4.41828,0 -8,-3.58173 -8,-8.00001 l 0,-8 z"
-     id="path3035-5"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-3"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="250"
-     x="416">
-    <tspan
-       x="424"
-       y="280.5"
-       id="tspan3039-5">note value</tspan>
-  </text>
-  <path
-     d="m 665,295.00001 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-6-1-7"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="696"
-     y="294">
-    <tspan
-       x="716"
-       y="320"
-       id="tspan25-8-5-2">4</tspan>
-  </text>
-  <path
-     d="m 551.00001,269.00001 0,-8 a 8.0000007,8.0000006 0 0 1 8,-8 l 8,0 20,0 59.99999,0 8,0 a 8.0000007,8.0000006 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8.0000007,8.0000006 0 0 1 -8,8 l -8,0 -59.99999,0 -20,0 -8,0 a 8.0000007,8.0000006 0 0 1 -8,-8 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.00001,0 0,-16 4.00001,0 0,6 12,0 0,-2 z"
-     id="path3798-4-4-5"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="251.99998"
-     id="text3800-3-2-0"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     x="526">
-    <tspan
-       x="636"
-       y="301"
-       id="tspan3802-6-2-5">/</tspan>
-  </text>
-  <path
-     d="m 665,253 h 120 v 40 H 665 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-8-2-1-0-6"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="697"
-     y="254"
-     id="text23-0-1-0-1-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="717"
-       y="280.00003"
-       id="tspan25-7-0-5-2-5">1</tspan>
-  </text>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124"
-     d="m 437.00001,311.00001 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 59.99999,0 8.00001,0 c 4.41828,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8.00001,0 -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z" />
-  <text
-     id="text6137"
-     y="321.9231"
-     x="518.823"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="321.9231"
-       x="518.823"
-       id="tspan6139">↓</tspan></text>
-  <path
-     d="m 437.00001,562.99999 0,-8.00001 a 8.0000014,8.0000012 0 0 1 8,-8 l 8,0 0,4 20.00001,0 0,-4 59.99998,0 8.00002,0 a 8.0000014,8.0000012 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8.00002,0 0,20.00001 8.00002,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00002,0 0,19.99999 8.00002,0 0,-6 8,0 0,8 a 8.0000014,8.0000012 0 0 1 -8,8 l -8.00002,0 -59.99998,0 -2.00001,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000014,8.0000012 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3194-2-1"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196-91-5"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436"
-     y="546">
-    <tspan
-       x="530"
-       y="595"
-       id="tspan3198-2-5">pitch</tspan>
-  </text>
-  <text
-     id="text3200-7-4"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436"
-     y="548">
-    <tspan
-       x="530"
-       y="570.5"
-       id="tspan3202-0-7">name</tspan>
-  </text>
-  <text
-     id="text3204-93-6"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436"
-     y="550">
-    <tspan
-       x="530"
-       y="614.5"
-       id="tspan3206-6-5">octave</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-0-6"
-     d="m 551.00002,546.99998 119.99998,0 0,40.00002 -119.99998,0 0,-16.00001 0,-2 -12,0 0,6 -4.00002,0 0,-16.00001 4.00002,0 0,6.00001 12,0 0,-2 z" />
-  <text
-     x="576.00006"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-6-9"
-     y="546">
-    <tspan
-       id="tspan25-2-3"
-       y="572"
-       x="596.00006">sol</tspan>
-  </text>
-  <path
-     d="m 551.00002,588.99999 119.99998,0 0,40 -119.99998,0 0,-16 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z"
-     id="path21-6-6-7"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-1-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="586.00006"
-     y="588">
-    <tspan
-       x="606.00006"
-       y="614"
-       id="tspan25-8-8-5">5</tspan>
-  </text>
-  <path
-     d="m 419,478.99999 0,-8 c 0,-4.41828 3.58173,-8 8.00001,-8 l 8,0 0,4 20,0 0,-4 18.00001,0 59.99998,0 8.00002,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8.00002,0 -59.99998,0 -2.00001,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,92.00002 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20.00001,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07162 -8,8.00002 l -8,0 -18.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 C 422.58173,671.00002 419,667.41828 419,663 l 0,-8 z"
-     id="path3035-5-2"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-3-5"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="459.99997"
-     x="416">
-    <tspan
-       x="424"
-       y="490.5"
-       id="tspan3039-5-4">note value</tspan>
-  </text>
-  <path
-     d="m 665,504.99999 120.0001,0 0,40.00001 -120.0001,0 0,-16.00001 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-6-1-7-7"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-9-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="696"
-     y="504">
-    <tspan
-       x="716"
-       y="530"
-       id="tspan25-8-5-2-4">2</tspan>
-  </text>
-  <path
-     d="m 551.00002,478.99999 0,-8 a 8.0000014,8.0000012 0 0 1 8,-8 l 8,0 20,0 59.99998,0 8,0 a 8.0000014,8.0000012 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 A 8.0000014,8.0000012 0 0 1 655,545 l -8,0 -59.99998,0 -20,0 -8,0 a 8.0000014,8.0000012 0 0 1 -8,-8.00001 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z"
-     id="path3798-4-4-5-3"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="461.99997"
-     id="text3800-3-2-0-0"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     x="526.00006">
-    <tspan
-       x="636"
-       y="511"
-       id="tspan3802-6-2-5-7">/</tspan>
-  </text>
-  <path
-     d="m 665,462.99997 h 120 v 40 H 665 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-8-2-1-0-6-6"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="697"
-     y="463.99997"
-     id="text23-0-1-0-1-0-8"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="717"
-       y="490"
-       id="tspan25-7-0-5-2-5-8">1</tspan>
-  </text>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-4"
-     d="m 437.00001,520.99999 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20.00001,0 0,-4 59.99998,0 8.00002,0 c 4.41828,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41829 -3.71364,6.92842 -8,8.00001 L 533,545 l -59.99998,0 -2.00001,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8.00001 l 0,-8 0,0 z" />
-  <text
-     id="text6137-3"
-     y="531.9231"
-     x="518.823"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="531.9231"
-       x="518.823"
-       id="tspan6139-1">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-0-2"
-     d="m 551,126.99999 h 120 v 40.00002 H 551 V 151 149 h -12 v 6 h -4 v -16.00002 h 4 V 145 h 12 v -2 z" />
-  <text
-     x="573.99994"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-6-91"
-     y="126">
-    <tspan
-       id="tspan25-2-2"
-       y="151.99997"
-       x="593.99994">sol</tspan>
-  </text>
-  <path
-     d="m 551,169 h 120 v 40 H 551 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-6-70"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-1-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="585.99994"
-     y="168.00003">
-    <tspan
-       x="605.99994"
-       y="194"
-       id="tspan25-8-8-3">5</tspan>
-  </text>
-  <path
-     d="m 665,85.00001 h 120 v 40 H 665 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-1-7-2"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-9-6"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="695.99994"
-     y="84.000031">
-    <tspan
-       x="715.99994"
-       y="110"
-       id="tspan25-8-5-2-1">4</tspan>
-  </text>
-  <path
-     d="m 551,59.00001 v -8 a 8.0000007,8.0000006 0 0 1 8,-8 h 8 20 60 8 a 8.0000007,8.0000006 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8.0000007,8.0000006 0 0 1 -8,8 h -8 -60 -20 -8 a 8.0000007,8.0000006 0 0 1 -8,-8 v -8 -42 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 z"
-     id="path3798-4-4-5-8"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="42.000004"
-     id="text3800-3-2-0-7"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     x="525.99994">
-    <tspan
-       x="635.99994"
-       y="91"
-       id="tspan3802-6-2-5-9">/</tspan>
-  </text>
-  <path
-     d="M 665,43 H 785 V 83 H 665 V 67 65 h -12 v 6 h -4 V 55 h 4 v 6 h 12 v -2 z"
-     id="path21-8-2-1-0-6-0"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="697"
-     y="44"
-     id="text23-0-1-0-1-0-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="717"
-       y="70.000031"
-       id="tspan25-7-0-5-2-5-3">1</tspan>
-  </text>
-  <path
-     d="m 437,143 v -8.00002 a 8.0000007,8.0000006 0 0 1 8,-7.99999 h 8 v 4 h 20 v -4 h 60 8 a 8.0000007,8.0000006 0 0 1 8,7.99999 V 143 h -8 v -6.00002 h -8 V 157 h 8 v -6 h 8 v 34 h -8 v -5.99999 h -8 V 199 h 8 v -6 h 8 v 8 a 8.0000007,8.0000006 0 0 1 -8,8 h -8 -60 -2 v 4 h -16 v -4 h -2 -8 a 8.0000007,8.0000006 0 0 1 -8,-8 v -8 -42 z"
-     id="path3194-2-3"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196-91-6"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436.00006"
-     y="126">
-    <tspan
-       x="529.99994"
-       y="175.00003"
-       id="tspan3198-2-7">pitch</tspan>
-  </text>
-  <text
-     id="text3200-7-5"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436.00006"
-     y="128.00003">
-    <tspan
-       x="529.99994"
-       y="150.49997"
-       id="tspan3202-0-3">name</tspan>
-  </text>
-  <text
-     id="text3204-93-5"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436.00006"
-     y="130">
-    <tspan
-       x="529.99994"
-       y="194.5"
-       id="tspan3206-6-6">octave</tspan>
-  </text>
-  <path
-     d="m 419,59.00001 v -8 c 0,-4.41828 3.5817,-8 8,-8 h 8 v 4 h 20 v -4 h 18 60 8 c 4.4183,0 9.0716,3.71364 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41828 -3.5817,8 -8,8 h -8 -60 -2 v 4 h -16 v -4 h -2 -8 c -5.5229,0 -10,4.47715 -10,10 v 8 92.00001 7.99999 c 0,5.52285 4.642,11.3395 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.41828 -3.7137,9.07161 -8,8.00001 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.4183,0 -8,-3.58173 -8,-8.00001 v -8 z"
-     id="path3035-5-6"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-3-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="40.000004"
-     x="416.00006">
-    <tspan
-       x="424.00006"
-       y="70.500031"
-       id="tspan3039-5-6">note value</tspan>
-  </text>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-7"
-     d="m 437,101.00001 v -8 c 0,-4.41828 3.5817,-8 8,-8 h 8 v 4 h 20 v -4 h 60 8 c 4.4183,0 8,3.58172 8,8 v 8 8 8 c 0,4.41828 -3.7137,6.92841 -8,8 h -8 -60 -2 v 4 h -16 v -4 h -2 -8 c -4.4183,0 -8,-3.58172 -8,-8 v -8 0 z" />
-  <text
-     id="text6137-5"
-     y="111.92313"
-     x="518.82294"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="111.92313"
-       x="518.82294"
-       id="tspan6139-9">↓</tspan></text>
-  <path
-     d="m 37.00001,353 0,-8.00002 a 8.0000007,8.0000006 0 0 1 8,-7.99999 l 8,0 0,4 20,0 0,-4 59.99999,0 8.00001,0 a 8.0000007,8.0000006 0 0 1 8,7.99999 l 0,8.00002 -8,0 0,-6.00002 -8.00001,0 0,20.00002 8.00001,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00001,0 0,19.99999 8.00001,0 0,-6 8,0 0,8 a 8.0000007,8.0000006 0 0 1 -8,8 L 133,419 l -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000007,8.0000006 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3194-2-2"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196-91-2"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="35.999989"
-     y="336">
-    <tspan
-       x="129.99998"
-       y="385"
-       id="tspan3198-2-8">pitch</tspan>
-  </text>
-  <text
-     id="text3200-7-9"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="35.999989"
-     y="338">
-    <tspan
-       x="129.99998"
-       y="360.49994"
-       id="tspan3202-0-73">name</tspan>
-  </text>
-  <text
-     id="text3204-93-61"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="35.999989"
-     y="340">
-    <tspan
-       x="129.99998"
-       y="404.5"
-       id="tspan3206-6-2">octave</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-0-9"
-     d="m 151.00001,336.99999 119.99999,0 0,40.00002 -119.99999,0 0,-16.00001 0,-2 -12,0 0,6 -4.00001,0 0,-16.00002 4.00001,0 0,6.00002 12,0 0,-2 z" />
-  <text
-     x="179.99998"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-6-3"
-     y="336">
-    <tspan
-       id="tspan25-2-1"
-       y="361.99994"
-       x="199.99998">re</tspan>
-  </text>
-  <path
-     d="M 151.00001,379 271,379 l 0,40 -119.99999,0 0,-16 0,-2 -12,0 0,6 -4.00001,0 0,-16 4.00001,0 0,6 12,0 0,-2 z"
-     id="path21-6-6-9"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-1-47"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="185.99998"
-     y="378">
-    <tspan
-       x="205.99998"
-       y="404"
-       id="tspan25-8-8-8">5</tspan>
-  </text>
-  <path
-     d="m 19,269.00001 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8.00001,0 0,4 20,0 0,-4 18,0 59.99999,0 8.00001,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8.00001,0 0,20 8.00001,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8.00001,0 -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,92.00001 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07161 -8,8.00001 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.00001,0 c -4.41828,0 -8,-3.58173 -8,-8.00001 l 0,-8 z"
-     id="path3035-5-4"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-3-50"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="250.00002"
-     x="15.999989">
-    <tspan
-       x="23.999989"
-       y="280.5"
-       id="tspan3039-5-3">note value</tspan>
-  </text>
-  <path
-     d="m 265,295.00001 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-6-1-7-6"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-9-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="296"
-     y="294">
-    <tspan
-       x="316"
-       y="320"
-       id="tspan25-8-5-2-0">4</tspan>
-  </text>
-  <path
-     d="m 151.00001,269.00001 0,-8 a 8.0000007,8.0000006 0 0 1 8,-8 l 8,0 20,0 59.99999,0 8,0 a 8.0000007,8.0000006 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8.0000007,8.0000006 0 0 1 -8,8 l -8,0 -59.99999,0 -20,0 -8,0 a 8.0000007,8.0000006 0 0 1 -8,-8 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.00001,0 0,-16 4.00001,0 0,6 12,0 0,-2 z"
-     id="path3798-4-4-5-6"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="252.00002"
-     id="text3800-3-2-0-3"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     x="125.99999">
-    <tspan
-       x="235.99998"
-       y="301"
-       id="tspan3802-6-2-5-2">/</tspan>
-  </text>
-  <path
-     d="m 265,253 h 120 v 40 H 265 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-8-2-1-0-6-61"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="297"
-     y="254"
-     id="text23-0-1-0-1-0-5"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="317"
-       y="280.00003"
-       id="tspan25-7-0-5-2-5-5">1</tspan>
-  </text>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-47"
-     d="m 37.00001,311.00001 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 59.99999,0 8.00001,0 c 4.41828,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8.00001,0 -59.99999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z" />
-  <text
-     id="text6137-6"
-     y="321.9231"
-     x="118.82299"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="321.9231"
-       x="118.82299"
-       id="tspan6139-5">↓</tspan></text>
-  <path
-     d="m 37.00001,562.99999 0,-8.00001 a 8.0000014,8.0000012 0 0 1 8,-8 l 8,0 0,4 20.00001,0 0,-4 59.99998,0 8.00002,0 a 8.0000014,8.0000012 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8.00002,0 0,20.00001 8.00002,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00002,0 0,19.99999 8.00002,0 0,-6 8,0 0,8 a 8.0000014,8.0000012 0 0 1 -8,8 l -8.00002,0 -59.99998,0 -2.00001,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000014,8.0000012 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z"
-     id="path3194-2-1-6"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196-91-5-9"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="35.999989"
-     y="546">
-    <tspan
-       x="129.99998"
-       y="595"
-       id="tspan3198-2-5-3">pitch</tspan>
-  </text>
-  <text
-     id="text3200-7-4-7"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="35.999989"
-     y="548">
-    <tspan
-       x="129.99998"
-       y="570.5"
-       id="tspan3202-0-7-4">name</tspan>
-  </text>
-  <text
-     id="text3204-93-6-5"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="35.999989"
-     y="550">
-    <tspan
-       x="129.99998"
-       y="614.5"
-       id="tspan3206-6-5-2">octave</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-0-6-5"
-     d="m 151.00002,546.99998 119.99998,0 0,40.00002 -119.99998,0 0,-16.00001 0,-2 -12,0 0,6 -4.00002,0 0,-16.00001 4.00002,0 0,6.00001 12,0 0,-2 z" />
-  <text
-     x="176.00005"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-6-9-4"
-     y="546">
-    <tspan
-       id="tspan25-2-3-7"
-       y="572"
-       x="196.00005">sol</tspan>
-  </text>
-  <path
-     d="m 151.00002,588.99999 119.99998,0 0,40 -119.99998,0 0,-16 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z"
-     id="path21-6-6-7-4"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-1-4-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="186.00005"
-     y="588">
-    <tspan
-       x="206.00005"
-       y="614"
-       id="tspan25-8-8-5-3">5</tspan>
-  </text>
-  <path
-     d="m 19,478.99999 0,-8 c 0,-4.41828 3.58173,-8 8.00001,-8 l 8,0 0,4 20,0 0,-4 18.00001,0 59.99998,0 8.00002,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8.00002,0 -59.99998,0 -2.00001,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,92.00002 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20.00001,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07162 -8,8.00002 l -8,0 -18.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 C 22.58173,671.00002 19,667.41828 19,663 l 0,-8 z"
-     id="path3035-5-2-0"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-3-5-7"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="459.99994"
-     x="15.999989">
-    <tspan
-       x="23.999989"
-       y="490.5"
-       id="tspan3039-5-4-8">note value</tspan>
-  </text>
-  <path
-     d="m 265,504.99999 120.0001,0 0,40.00001 -120.0001,0 0,-16.00001 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-6-1-7-7-6"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-9-4-8"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="296"
-     y="504">
-    <tspan
-       x="316"
-       y="530"
-       id="tspan25-8-5-2-4-8">2</tspan>
-  </text>
-  <path
-     d="m 151.00002,478.99999 0,-8 a 8.0000014,8.0000012 0 0 1 8,-8 l 8,0 20,0 59.99998,0 8,0 a 8.0000014,8.0000012 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 A 8.0000014,8.0000012 0 0 1 255,545 l -8,0 -59.99998,0 -20,0 -8,0 a 8.0000014,8.0000012 0 0 1 -8,-8.00001 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z"
-     id="path3798-4-4-5-3-4"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="461.99994"
-     id="text3800-3-2-0-0-3"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     x="126.00005">
-    <tspan
-       x="235.99998"
-       y="511"
-       id="tspan3802-6-2-5-7-1">/</tspan>
-  </text>
-  <path
-     d="m 265,462.99997 h 120 v 40 H 265 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-8-2-1-0-6-6-9"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="297"
-     y="463.99997"
-     id="text23-0-1-0-1-0-8-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="317"
-       y="490"
-       id="tspan25-7-0-5-2-5-8-0">1</tspan>
-  </text>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-4-6"
-     d="m 37.00001,520.99999 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20.00001,0 0,-4 59.99998,0 8.00002,0 c 4.41828,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41829 -3.71364,6.92842 -8,8.00001 L 133,545 l -59.99998,0 -2.00001,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8.00001 l 0,-8 0,0 z" />
-  <text
-     id="text6137-3-8"
-     y="531.9231"
-     x="118.82299"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="531.9231"
-       x="118.82299"
-       id="tspan6139-1-9">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-0-2-6"
-     d="m 151,126.99999 h 120 v 40.00002 H 151 V 151 149 h -12 v 6 h -4 v -16.00002 h 4 V 145 h 12 v -2 z" />
-  <text
-     x="173.99992"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-6-91-6"
-     y="126">
-    <tspan
-       id="tspan25-2-2-4"
-       y="151.99997"
-       x="193.99992">sol</tspan>
-  </text>
-  <path
-     d="m 151,169 h 120 v 40 H 151 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-6-70-9"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-1-9-5"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="185.99992"
-     y="168.00003">
-    <tspan
-       x="205.99992"
-       y="194"
-       id="tspan25-8-8-3-0">5</tspan>
-  </text>
-  <path
-     d="m 265,85.00001 h 120 v 40 H 265 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-6-1-7-2-4"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-9-6-8"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="295.99994"
-     y="84.000031">
-    <tspan
-       x="315.99994"
-       y="110"
-       id="tspan25-8-5-2-1-7">4</tspan>
-  </text>
-  <path
-     d="m 151,59.00001 v -8 a 8.0000007,8.0000006 0 0 1 8,-8 h 8 20 60 8 a 8.0000007,8.0000006 0 0 1 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 34 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 a 8.0000007,8.0000006 0 0 1 -8,8 h -8 -60 -20 -8 a 8.0000007,8.0000006 0 0 1 -8,-8 v -8 -42 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 z"
-     id="path3798-4-4-5-8-1"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="42.000004"
-     id="text3800-3-2-0-7-7"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     x="125.99992">
-    <tspan
-       x="235.99992"
-       y="91"
-       id="tspan3802-6-2-5-9-2">/</tspan>
-  </text>
-  <path
-     d="M 265,43 H 385 V 83 H 265 V 67 65 h -12 v 6 h -4 V 55 h 4 v 6 h 12 v -2 z"
-     id="path21-8-2-1-0-6-0-2"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="297"
-     y="44"
-     id="text23-0-1-0-1-0-2-2"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="317"
-       y="70.000031"
-       id="tspan25-7-0-5-2-5-3-6">1</tspan>
-  </text>
-  <path
-     d="m 37,143 v -8.00002 a 8.0000007,8.0000006 0 0 1 8,-7.99999 h 8 v 4 h 20 v -4 h 60 8 a 8.0000007,8.0000006 0 0 1 8,7.99999 V 143 h -8 v -6.00002 h -8 V 157 h 8 v -6 h 8 v 34 h -8 v -5.99999 h -8 V 199 h 8 v -6 h 8 v 8 a 8.0000007,8.0000006 0 0 1 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 a 8.0000007,8.0000006 0 0 1 -8,-8 v -8 -42 z"
-     id="path3194-2-3-0"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3196-91-6-6"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="36.00005"
-     y="126">
-    <tspan
-       x="129.99992"
-       y="175.00003"
-       id="tspan3198-2-7-1">pitch</tspan>
-  </text>
-  <text
-     id="text3200-7-5-5"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="36.00005"
-     y="128.00003">
-    <tspan
-       x="129.99992"
-       y="150.49997"
-       id="tspan3202-0-3-9">name</tspan>
-  </text>
-  <text
-     id="text3204-93-5-4"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="36.00005"
-     y="130">
-    <tspan
-       x="129.99992"
-       y="194.5"
-       id="tspan3206-6-6-9">octave</tspan>
-  </text>
-  <path
-     d="m 19,59.00001 v -8 c 0,-4.41828 3.5817,-8 8,-8 h 8 v 4 h 20 v -4 h 18 60 8 c 4.4183,0 9.0716,3.71364 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.41828 -3.5817,8 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 c -5.5229,0 -10,4.47715 -10,10 v 8 92.00001 7.99999 c 0,5.52285 4.642,11.3395 10,10 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.41828 -3.7137,9.07161 -8,8.00001 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.4183,0 -8,-3.58173 -8,-8.00001 v -8 z"
-     id="path3035-5-6-0"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-3-0-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="40.000004"
-     x="16.000048">
-    <tspan
-       x="24.000048"
-       y="70.500031"
-       id="tspan3039-5-6-1">note value</tspan>
-  </text>
-  <path
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3124-7-7"
-     d="m 37,101.00001 v -8 c 0,-4.41828 3.5817,-8 8,-8 h 8 v 4 h 20 v -4 h 60 8 c 4.4183,0 8,3.58172 8,8 v 8 8 8 c 0,4.41828 -3.7137,6.92841 -8,8 h -8 -60 -2 v 4 H 55 v -4 h -2 -8 c -4.4183,0 -8,-3.58172 -8,-8 v -8 0 z" />
-  <text
-     id="text6137-5-7"
-     y="111.92313"
-     x="118.82292"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="font-size:22.5px"
-       y="111.92313"
-       x="118.82292"
-       id="tspan6139-9-1">↓</tspan></text>
+  <defs
+     id="defs6138" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="748"
+     inkscape:window-height="480"
+     id="namedview6136"
+     showgrid="false"
+     inkscape:zoom="0.2079063"
+     inkscape:cx="570"
+     inkscape:cy="280.5"
+     inkscape:window-x="0"
+     inkscape:window-y="282"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6134" />
+  <g
+     transform="translate(328)"
+     id="g5498">
+    <g
+       transform="scale(1.5)"
+       id="g5496">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 30.029297 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 294 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5486"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5490">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5488">duplicate</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5494">
+        <tspan
+           x="55.362629"
+           y="11.25"
+           id="tspan5492" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(415.04395)"
+     id="g5508">
+    <g
+       transform="scale(1.5)"
+       id="g5506">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5500"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5504">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5502">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(341.5,31.5)"
+     id="g5522">
+    <g
+       transform="scale(1.5)"
+       id="g5520">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5510"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5514">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5512">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5518">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan5516" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(437.72119,31.5)"
+     id="g5540">
+    <g
+       transform="scale(1.5)"
+       id="g5538">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5524"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5528">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5526">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5532">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5530" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5536">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5534" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,31.5)"
+     id="g5550">
+    <g
+       transform="scale(1.5)"
+       id="g5548">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5542"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5546">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5544">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,63)"
+     id="g5560">
+    <g
+       transform="scale(1.5)"
+       id="g5558">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5552"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5556">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5554">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,63)"
+     id="g5570">
+    <g
+       transform="scale(1.5)"
+       id="g5568">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5562"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5566">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan5564">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,94.5)"
+     id="g5588">
+    <g
+       transform="scale(1.5)"
+       id="g5586">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5572"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5576">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan5574">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5580">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan5578">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5584">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan5582">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,94.5)"
+     id="g5598">
+    <g
+       transform="scale(1.5)"
+       id="g5596">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5590"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5594">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5592">sol</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,126)"
+     id="g5608">
+    <g
+       transform="scale(1.5)"
+       id="g5606">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5600"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5604">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5602">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(341.5,189)"
+     id="g5622">
+    <g
+       transform="scale(1.5)"
+       id="g5620">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5610"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5614">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5612">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5618">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan5616" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(437.72119,189)"
+     id="g5640">
+    <g
+       transform="scale(1.5)"
+       id="g5638">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5624"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5628">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5626">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5632">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5630" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5636">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5634" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,189)"
+     id="g5650">
+    <g
+       transform="scale(1.5)"
+       id="g5648">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5642"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5646">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5644">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,220.5)"
+     id="g5660">
+    <g
+       transform="scale(1.5)"
+       id="g5658">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5652"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5656">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5654">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,220.5)"
+     id="g5670">
+    <g
+       transform="scale(1.5)"
+       id="g5668">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5662"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5666">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan5664">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,252)"
+     id="g5688">
+    <g
+       transform="scale(1.5)"
+       id="g5686">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5672"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5676">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan5674">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5680">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan5678">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5684">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan5682">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,252)"
+     id="g5698">
+    <g
+       transform="scale(1.5)"
+       id="g5696">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5690"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5694">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5692">re</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,283.5)"
+     id="g5708">
+    <g
+       transform="scale(1.5)"
+       id="g5706">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5700"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5704">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5702">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(341.5,346.5)"
+     id="g5722">
+    <g
+       transform="scale(1.5)"
+       id="g5720">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5710"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5714">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5712">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5718">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan5716" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(437.72119,346.5)"
+     id="g5740">
+    <g
+       transform="scale(1.5)"
+       id="g5738">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5724"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5728">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5726">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5732">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5730" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5736">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5734" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,346.5)"
+     id="g5750">
+    <g
+       transform="scale(1.5)"
+       id="g5748">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5742"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5746">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5744">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,378)"
+     id="g5760">
+    <g
+       transform="scale(1.5)"
+       id="g5758">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5752"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5756">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5754">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,378)"
+     id="g5770">
+    <g
+       transform="scale(1.5)"
+       id="g5768">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5762"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5766">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan5764">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,409.5)"
+     id="g5788">
+    <g
+       transform="scale(1.5)"
+       id="g5786">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5772"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5776">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan5774">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5780">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan5778">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5784">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan5782">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,409.5)"
+     id="g5798">
+    <g
+       transform="scale(1.5)"
+       id="g5796">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5790"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5794">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5792">sol</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,441)"
+     id="g5808">
+    <g
+       transform="scale(1.5)"
+       id="g5806">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5800"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5804">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5802">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(0,2)"
+     id="g5822">
+    <g
+       transform="scale(1.5)"
+       id="g5820">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 294 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5810"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5814">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5812">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5818">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan5816" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(72,2)"
+     id="g5832">
+    <g
+       transform="scale(1.5)"
+       id="g5830">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5824"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5828">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5826">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,33.5)"
+     id="g5846">
+    <g
+       transform="scale(1.5)"
+       id="g5844">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5834"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5838">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5836">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5842">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan5840" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(109.72119,33.5)"
+     id="g5864">
+    <g
+       transform="scale(1.5)"
+       id="g5862">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5848"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5852">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5850">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5856">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5854" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5860">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5858" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,33.5)"
+     id="g5874">
+    <g
+       transform="scale(1.5)"
+       id="g5872">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5866"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5870">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5868">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,65)"
+     id="g5884">
+    <g
+       transform="scale(1.5)"
+       id="g5882">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5876"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5880">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5878">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,65)"
+     id="g5894">
+    <g
+       transform="scale(1.5)"
+       id="g5892">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5886"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5890">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan5888">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,96.5)"
+     id="g5912">
+    <g
+       transform="scale(1.5)"
+       id="g5910">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5896"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5900">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan5898">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5904">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan5902">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5908">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan5906">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,96.5)"
+     id="g5922">
+    <g
+       transform="scale(1.5)"
+       id="g5920">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5914"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5918">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5916">sol</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,128)"
+     id="g5932">
+    <g
+       transform="scale(1.5)"
+       id="g5930">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5924"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5928">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5926">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,191)"
+     id="g5946">
+    <g
+       transform="scale(1.5)"
+       id="g5944">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5934"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5938">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5936">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5942">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan5940" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(109.72119,191)"
+     id="g5964">
+    <g
+       transform="scale(1.5)"
+       id="g5962">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5948"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5952">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5950">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5956">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5954" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5960">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5958" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,191)"
+     id="g5974">
+    <g
+       transform="scale(1.5)"
+       id="g5972">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5966"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5970">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5968">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,222.5)"
+     id="g5984">
+    <g
+       transform="scale(1.5)"
+       id="g5982">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5976"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5980">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5978">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,222.5)"
+     id="g5994">
+    <g
+       transform="scale(1.5)"
+       id="g5992">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5986"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5990">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan5988">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,254)"
+     id="g6012">
+    <g
+       transform="scale(1.5)"
+       id="g6010">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5996"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6000">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan5998">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6004">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan6002">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6008">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan6006">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,254)"
+     id="g6022">
+    <g
+       transform="scale(1.5)"
+       id="g6020">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6014"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6018">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6016">re</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,285.5)"
+     id="g6032">
+    <g
+       transform="scale(1.5)"
+       id="g6030">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6024"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6028">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6026">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,348.5)"
+     id="g6046">
+    <g
+       transform="scale(1.5)"
+       id="g6044">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6034"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6038">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan6036">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6042">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan6040" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(109.72119,348.5)"
+     id="g6064">
+    <g
+       transform="scale(1.5)"
+       id="g6062">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6048"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6052">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan6050">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6056">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan6054" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6060">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan6058" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,348.5)"
+     id="g6074">
+    <g
+       transform="scale(1.5)"
+       id="g6072">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6066"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6070">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6068">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(195.22119,380)"
+     id="g6084">
+    <g
+       transform="scale(1.5)"
+       id="g6082">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6076"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6080">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6078">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,380)"
+     id="g6094">
+    <g
+       transform="scale(1.5)"
+       id="g6092">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6086"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6090">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan6088">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,411.5)"
+     id="g6112">
+    <g
+       transform="scale(1.5)"
+       id="g6110">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6096"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6100">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan6098">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6104">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan6102">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6108">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan6106">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,411.5)"
+     id="g6122">
+    <g
+       transform="scale(1.5)"
+       id="g6120">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6114"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6118">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6116">sol</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(100.5,443)"
+     id="g6132">
+    <g
+       transform="scale(1.5)"
+       id="g6130">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6124"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6128">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6126">5</tspan>
+      </text>
+    </g>
+  </g>
 </svg>

--- a/guide/transform8.svg
+++ b/guide/transform8.svg
@@ -5,15 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="626.72119"
+   height="824.5"
    version="1.1"
-   id="svg5587"
-   viewBox="0 0 806.00012 1069.9999"
-   height="301.97775mm"
-   width="227.47115mm">
-  <defs
-     id="defs5589" />
+   id="svg8114"
+   sodipodi:docname="transform8.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata5592">
+     id="metadata8120">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,1295 +25,2047 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <path
-     d="m 421.00004,537.00002 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 60,0 8,0 c 4.4183,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41827 -3.5817,8 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52284,0 -10,4.47715 -10,10 l 0,8 0,427.99998 0,8 c 0,5.5229 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.4183 -3.71364,9.0716 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.5817 -8,-8 l 0,-8 z"
-     id="path3035-8-1-5-4"
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-0-1-8-8"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="520.00006"
-     x="420.00003">
-    <tspan
-       x="428.00003"
-       y="550.50006"
-       id="tspan3039-6-1-0-8">slur</tspan>
-  </text>
-  <path
-     d="m 553.00004,1.0000195 120,0 0,40.0000005 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-6-1-0-1-8-3"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-5-8-1-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="588.52289"
-     y="2.9530866">
-    <tspan
-       x="608.52289"
-       y="28.953087"
-       id="tspan25-8-5-1-3-7-2">5</tspan>
-  </text>
-  <path
-     d="m 0.99996948,537.00002 0,-8 c 0,-4.41828 3.58172002,-8 8.00000002,-8 l 8.0000005,0 0,4 20,0 0,-4 18,0 60,0 8,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41827 -3.58172,8 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52284,0 -10,4.47715 -10,10 l 0,8 0,427.99998 0,8 c 0,5.5229 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.4183 -3.71364,9.0716 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.0000005,0 c -4.41828,0 -8.00000002,-3.5817 -8.00000002,-8 l 0,-8 z"
-     id="path3035-8-1-5-4-4"
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-0-1-8-8-8"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="520.00006"
-     x="-3.0507907e-05">
-    <tspan
-       x="7.9999695"
-       y="550.50006"
-       id="tspan3039-6-1-0-8-9">staccato</tspan>
-  </text>
-  <path
-     d="m 457.00005,310.99993 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20.00001,0 0,-4 60,0 8.00002,0 c 4.41828,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41829 -3.71364,6.92842 -8,8.00001 l -8.00002,0 -60,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8.00001 l 0,-8 0,0 z"
-     id="path3124-4-8"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <path
-     d="m 421.00004,17.00001 0,-8.00001 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 60,0 8,0 c 4.41828,0 8,3.58172 8,8 l 0,8.00001 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41827 -3.58172,8 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52284,0 -10,4.47715 -10,10 l 0,8 0,386.00001 0,8 c 0,5.52284 4.64205,11.33949 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41827 -3.71364,9.0716 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58173 -8,-8 l 0,-8 z"
-     id="path3035-8-1-5-4-2"
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-0-1-8-8-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="-1.4889414e-05"
-     x="420.00003">
-    <tspan
-       x="428.00003"
-       y="30.499985"
-       id="tspan3039-6-1-0-8-5">crescendo</tspan>
-  </text>
-  <path
-     d="m 1.0000305,17.00001 0,-8.00001 c 0,-4.41828 3.58172,-8 8,-8 l 8.0000005,0 0,4 20,0 0,-4 18,0 71.999999,0 8,0 c 4.41828,0 9.07159,3.7136385 8,8 l 0,8.00001 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41827 -3.58172,8 -8,8 l -8,0 -71.999999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52284,0 -10,4.47715 -10,10 l 0,8 0,386.00001 0,8 c 0,5.52284 4.64205,11.33949 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41827 -3.71364,9.0716 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8.0000005,0 c -4.41828,0 -8,-3.58173 -8,-8 l 0,-8 z"
-     id="path3035-8-1-5-4-4-1"
-     style="fill:#1d8989;fill-opacity:1;stroke:#005459;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3037-0-1-8-8-8-7"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     y="-1.4889414e-05"
-     x="3.0527255e-05">
-    <tspan
-       x="8.0000305"
-       y="30.499985"
-       id="tspan3039-6-1-0-8-9-8">set volume</tspan>
-  </text>
-  <path
-     d="m 145.00003,1 120,0 0,40.00001 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-6-1-0-1-8-3-2-3"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text23-9-82-5-8-1-1-2-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="174.52283"
-     y="2.9530492">
-    <tspan
-       x="194.52283"
-       y="28.953049"
-       id="tspan25-8-5-1-3-7-2-3-1">50</tspan>
-  </text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2"
-     d="m 37.000002,142.99994 0,-8.00002 a 8.0000015,8.0000011 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60.000008,0 8.00001,0 a 8.0000015,8.0000011 0 0 1 8,8 l 0,8.00002 -8,0 0,-6.00002 -8.00001,0 0,20.00002 8.00001,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00001,0 0,19.99999 8.00001,0 0,-6 8,0 0,8 a 8.0000015,8.0000011 0 0 1 -8,8 l -8.00001,0 -60.000008,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000015,8.0000011 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z" />
-  <text
-     y="125.99992"
-     x="36"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91">
-    <tspan
-       id="tspan3198-2"
-       y="174.99994"
-       x="130.00002">pitch</tspan>
-  </text>
-  <text
-     y="127.99992"
-     x="36"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7">
-    <tspan
-       id="tspan3202-0"
-       y="150.49991"
-       x="130.00002">name</tspan>
-  </text>
-  <text
-     y="129.99994"
-     x="36"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93">
-    <tspan
-       id="tspan3206-6"
-       y="194.49992"
-       x="130.00002">octave</tspan>
-  </text>
-  <path
-     d="m 151.00002,126.99992 120.00003,0 0,40.00003 -120.00003,0 0,-16.00001 0,-2 -12,0 0,6 -4.00001,0 0,-16.00002 4.00001,0 0,6.00002 12,0 0,-2 z"
-     id="path21-0"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="125.99992"
-     id="text23-6"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="180.00003">
-    <tspan
-       x="200.00003"
-       y="151.99991"
-       id="tspan25-2">re</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6"
-     d="m 151.00002,168.99994 120.00003,0 0,40 -120.00003,0 0,-16 0,-2 -12,0 0,6 -4.00001,0 0,-16 4.00001,0 0,6 12,0 0,-2 z" />
-  <text
-     y="167.99995"
-     x="186.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1">
-    <tspan
-       id="tspan25-8-8"
-       y="193.99992"
-       x="206.00003">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5"
-     d="m 19.000002,58.999939 0,-8.00001 c 0,-4.418281 3.58172,-8.000001 8,-8.000001 l 8,0 0,4 20,0 0,-4 18,0 60.000008,0 8.00001,0 c 4.41828,0 9.07159,3.71364 8,8.000001 l 0,8.00001 -8,0 0,-6 -8.00001,0 0,20.000001 8.00001,0 0,-6 8,0 0,8 c 0,4.418281 -3.58172,8.000001 -8,8.000001 l -8.00001,0 -60.000008,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,7.999999 0,92.00002 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07161 -8,8.00001 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58173 -8,-8.00001 l 0,-8 z" />
-  <text
-     x="15.999999"
-     y="39.999931"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3">
-    <tspan
-       id="tspan3039-5"
-       y="70.499939"
-       x="24">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7"
-     d="m 265.00005,84.999941 120.00002,0 0,39.999999 -120.00002,0 0,-16 0,-2 -12.00001,0 0,6 -4.00001,0 0,-15.999999 4.00001,0 0,5.999999 12.00001,0 0,-2 z" />
-  <text
-     y="83.999939"
-     x="296.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9">
-    <tspan
-       id="tspan25-8-5-2"
-       y="109.99992"
-       x="316.00003">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5"
-     d="m 151.00002,58.999939 0,-8.00001 a 8.0000015,8.0000011 0 0 1 8,-8.000001 l 8.00001,0 20,0 60,0 8.00001,0 a 8.0000015,8.0000011 0 0 1 8.00001,8.000001 l 0,8.00001 -8.00001,0 0,-6 -8.00001,0 0,20.000001 8.00001,0 0,-6 8.00001,0 0,34 -8.00001,0 0,-5.999998 -8.00001,0 0,19.999998 8.00001,0 0,-6 8.00001,0 0,8 a 8.0000015,8.0000011 0 0 1 -8.00001,8 l -8.00001,0 -60,0 -20,0 -8.00001,0 a 8.0000015,8.0000011 0 0 1 -8,-8 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.00001,0 0,-16.000001 4.00001,0 0,6 12,0 0,-2 z" />
-  <text
-     x="126.00007"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0"
-     y="41.999901">
-    <tspan
-       id="tspan3802-6-2-5"
-       y="90.999924"
-       x="236.00003">/</tspan>
-  </text>
+  <defs
+     id="defs8118" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="699"
+     inkscape:window-height="480"
+     id="namedview8116"
+     showgrid="false"
+     inkscape:zoom="0.2079063"
+     inkscape:cx="565"
+     inkscape:cy="560.04057"
+     inkscape:window-x="0"
+     inkscape:window-y="282"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8114" />
   <g
-     id="g5147"
-     transform="translate(18.000002,-7.9462842e-5)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5">1</tspan>
-    </text>
+     transform="translate(0,31.5)"
+     id="g7154">
+    <g
+       transform="scale(1.5)"
+       id="g7152">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7142"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7146">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7144">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7150">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan7148" />
+      </text>
+    </g>
   </g>
-  <path
-     d="m 37.000002,100.99994 0,-7.999999 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 60.000008,0 8.00001,0 c 4.41828,0 8,3.58172 8,8 l 0,7.999999 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8.00001,0 -60.000008,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z"
-     id="path3124"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="118.82301"
-     y="111.92306"
-     id="text6137"><tspan
-       id="tspan6139"
-       x="118.82301"
-       y="111.92306"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-1"
-     d="m 37.000002,352.99994 0,-8.00001 a 8.0000022,8.0000017 0 0 1 8,-8 l 8,0 0,4 20.00001,0 0,-4 59.999998,0 8.00002,0 a 8.0000022,8.0000017 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8.00002,0 0,20.00001 8.00002,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00002,0 0,20 8.00002,0 0,-6.00001 8,0 0,8.00001 a 8.0000022,8.0000017 0 0 1 -8,8 l -8.00002,0 -59.999998,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 a 8.0000022,8.0000017 0 0 1 -8,-8 l 0,-8.00001 0,-42 0,-8 z" />
-  <text
-     y="335.99997"
-     x="36"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-5">
-    <tspan
-       id="tspan3198-2-5"
-       y="384.99997"
-       x="130.00002">pitch</tspan>
-  </text>
-  <text
-     y="338"
-     x="36"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-4">
-    <tspan
-       id="tspan3202-0-7"
-       y="360.49994"
-       x="130.00002">name</tspan>
-  </text>
-  <text
-     y="340"
-     x="36"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-6">
-    <tspan
-       id="tspan3206-6-5"
-       y="404.49994"
-       x="130.00002">octave</tspan>
-  </text>
-  <path
-     d="m 151.00003,336.99993 120.00004,0 0,40.00002 -120.00004,0 0,-16.00001 0,-2 -12,0 0,6 -4.00002,0 0,-16.00001 4.00002,0 0,6.00001 12,0 0,-2 z"
-     id="path21-0-6"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="335.99997"
-     id="text23-6-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="180.00009">
-    <tspan
-       x="200.00009"
-       y="361.99994"
-       id="tspan25-2-3">mi</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-7"
-     d="m 151.00003,378.99994 120.00004,0 0,40.00001 -120.00004,0 0,-16.00001 0,-2 -12,0 0,6.00001 -4.00002,0 0,-16.00001 4.00002,0 0,6 12,0 0,-2 z" />
-  <text
-     y="377.99997"
-     x="186.00009"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-4">
-    <tspan
-       id="tspan25-8-8-5"
-       y="403.99994"
-       x="206.00009">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-2"
-     d="m 19.000002,268.99994 0,-8 c 0,-4.41829 3.58172,-8.00001 8,-8.00001 l 8,0 0,4 20,0 0,-4 18.00001,0 59.999998,0 8.00002,0 c 4.41828,0 9.07159,3.71364 8,8.00001 l 0,8 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8.00002,0 -59.999998,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,92.00002 0,8 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20.00001,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07162 -8,8.00002 l -8,0 -18.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58174 -8,-8.00002 l 0,-8 z" />
-  <text
-     x="15.999999"
-     y="249.99992"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-5">
-    <tspan
-       id="tspan3039-5-4"
-       y="280.49997"
-       x="24">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-7"
-     d="m 265.00007,294.99994 120.00003,0 0,40.00001 -120.00003,0 0,-16.00001 0,-2 -12.00001,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12.00001,0 0,-2 z" />
-  <text
-     y="293.99997"
-     x="296.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-4">
-    <tspan
-       id="tspan25-8-5-2-4"
-       y="319.99997"
-       x="316.00003">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-3"
-     d="m 151.00003,268.99994 0,-8 a 8.0000022,8.0000017 0 0 1 8,-8.00001 l 8.00001,0 20,0 60,0 8.00002,0 a 8.0000022,8.0000017 0 0 1 8.00001,8.00001 l 0,8 -8.00001,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8.00001,0 0,34 -8.00001,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8.00001,0 0,8 a 8.0000022,8.0000017 0 0 1 -8.00001,8.00001 l -8.00002,0 -60,0 -20,0 -8.00001,0 a 8.0000022,8.0000017 0 0 1 -8,-8.00001 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z" />
-  <text
-     x="126.00007"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-0"
-     y="251.99989">
-    <tspan
-       id="tspan3802-6-2-5-7"
-       y="300.99997"
-       x="236.00003">/</tspan>
-  </text>
   <g
-     id="g5147-8"
-     transform="translate(17.999992,209.99991)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-6"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-8"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-8">1</tspan>
-    </text>
+     transform="translate(96.22119,31.5)"
+     id="g7172">
+    <g
+       transform="scale(1.5)"
+       id="g7170">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7156"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7160">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7158">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7164">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7162" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7168">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7166" />
+      </text>
+    </g>
   </g>
-  <path
-     d="m 37.000002,310.99994 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20.00001,0 0,-4 59.999998,0 8.00002,0 c 4.41828,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41829 -3.71364,6.92842 -8,8.00001 l -8.00002,0 -59.999998,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8.00001 l 0,-8 0,0 z"
-     id="path3124-4"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="118.82307"
-     y="321.9231"
-     id="text6137-3"><tspan
-       id="tspan6139-1"
-       x="118.82307"
-       y="321.9231"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-5"
-     d="m 457.00005,142.99993 0,-8.00003 a 8.0000015,8.0000011 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60.00001,0 8.00001,0 a 8.0000015,8.0000011 0 0 1 8,8 l 0,8.00003 -8,0 0,-6.00003 -8.00001,0 0,20.00003 8.00001,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00001,0 0,19.99999 8.00001,0 0,-6 8,0 0,8 a 8.0000015,8.0000011 0 0 1 -8,8 l -8.00001,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000015,8.0000011 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z" />
-  <text
-     y="125.99991"
-     x="456.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-52">
-    <tspan
-       id="tspan3198-2-9"
-       y="174.99994"
-       x="550.00006">pitch</tspan>
-  </text>
-  <text
-     y="127.99991"
-     x="456.00003"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-0">
-    <tspan
-       id="tspan3202-0-2"
-       y="150.49989"
-       x="550.00006">name</tspan>
-  </text>
-  <text
-     y="129.99992"
-     x="456.00003"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-8">
-    <tspan
-       id="tspan3206-6-3"
-       y="194.49991"
-       x="550.00006">octave</tspan>
-  </text>
-  <path
-     d="m 571.00007,126.9999 120.00002,0 0,40.00004 -120.00002,0 0,-16.00001 0,-2 -12,0 0,6 -4.00001,0 0,-16.00003 4.00001,0 0,6.00003 12,0 0,-2 z"
-     id="path21-0-8"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="125.99991"
-     id="text23-6-0"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="600.00006">
-    <tspan
-       x="620.00006"
-       y="151.99989"
-       id="tspan25-2-4">re</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-0"
-     d="m 571.00007,168.99993 120.00002,0 0,40 -120.00002,0 0,-16 0,-2 -12,0 0,6 -4.00001,0 0,-16 4.00001,0 0,6 12,0 0,-2 z" />
-  <text
-     y="167.99994"
-     x="606.00006"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-9">
-    <tspan
-       id="tspan25-8-8-1"
-       y="193.99991"
-       x="626.00006">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-9"
-     d="m 439.00005,58.999921 0,-8.00001 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 60.00001,0 8.00001,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8.00001 -8,0 0,-6 -8.00001,0 0,20 8.00001,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8.00001,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,7.999999 0,92.00003 0,7.99999 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07161 -8,8.00001 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58173 -8,-8.00001 l 0,-8 z" />
-  <text
-     x="436.00003"
-     y="39.999928"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-6">
-    <tspan
-       id="tspan3039-5-2"
-       y="70.499931"
-       x="444.00003">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-5"
-     d="m 685.00009,84.999921 120.00002,0 0,39.999999 -120.00002,0 0,-16 0,-2 -12.00001,0 0,6 -4.00001,0 0,-15.999999 4.00001,0 0,5.999999 12.00001,0 0,-2 z" />
-  <text
-     y="83.999931"
-     x="716.00012"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-44">
-    <tspan
-       id="tspan25-8-5-2-9"
-       y="109.99991"
-       x="736.00012">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-9"
-     d="m 571.00007,58.999921 0,-8.00001 a 8.0000015,8.0000011 0 0 1 8,-8 l 8,0 20,0 60,0 8.00001,0 a 8.0000015,8.0000011 0 0 1 8.00001,8 l 0,8.00001 -8.00001,0 0,-6 -8.00001,0 0,20 8.00001,0 0,-6 8.00001,0 0,33.999999 -8.00001,0 0,-5.999999 -8.00001,0 0,19.999999 8.00001,0 0,-6 8.00001,0 0,8 a 8.0000015,8.0000011 0 0 1 -8.00001,8 l -8.00001,0 -60,0 -20,0 -8,0 a 8.0000015,8.0000011 0 0 1 -8,-8 l 0,-8 0,-41.999999 0,-2 -12,0 0,6 -4.00001,0 0,-16 4.00001,0 0,6 12,0 0,-2 z" />
-  <text
-     x="546.00012"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-3"
-     y="41.999897">
-    <tspan
-       id="tspan3802-6-2-5-6"
-       y="90.999908"
-       x="656.00006">/</tspan>
-  </text>
   <g
-     id="g5147-0"
-     transform="translate(438.00005,-9.9437158e-5)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-5"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-0"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-2">1</tspan>
-    </text>
+     transform="translate(181.72119,31.5)"
+     id="g7182">
+    <g
+       transform="scale(1.5)"
+       id="g7180">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7174"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7178">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7176">1</tspan>
+      </text>
+    </g>
   </g>
-  <path
-     d="m 457.00005,100.99992 0,-7.999999 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 60.00001,0 8.00001,0 c 4.41828,0 8,3.58172 8,8 l 0,7.999999 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8.00001,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z"
-     id="path3124-9"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="538.82306"
-     y="111.92305"
-     id="text6137-4"><tspan
-       id="tspan6139-3"
-       x="538.82306"
-       y="111.92305"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-1-5"
-     d="m 457.00005,352.99993 0,-8.00001 a 8.0000022,8.0000017 0 0 1 8,-8 l 8,0 0,4 20.00001,0 0,-4 60,0 8.00002,0 a 8.0000022,8.0000017 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8.00002,0 0,20.00001 8.00002,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.00002,0 0,20 8.00002,0 0,-6.00001 8,0 0,8.00001 a 8.0000022,8.0000017 0 0 1 -8,8 l -8.00002,0 -60,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 a 8.0000022,8.0000017 0 0 1 -8,-8 l 0,-8.00001 0,-42 0,-8 z" />
-  <text
-     y="335.99994"
-     x="456.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-5-1">
-    <tspan
-       id="tspan3198-2-5-7"
-       y="384.99997"
-       x="550.00006">pitch</tspan>
-  </text>
-  <text
-     y="337.99997"
-     x="456.00003"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-4-4">
-    <tspan
-       id="tspan3202-0-7-3"
-       y="360.49994"
-       x="550.00006">name</tspan>
-  </text>
-  <text
-     y="339.99997"
-     x="456.00003"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-6-1">
-    <tspan
-       id="tspan3206-6-5-4"
-       y="404.49994"
-       x="550.00006">octave</tspan>
-  </text>
-  <path
-     d="m 571.00008,336.99992 120.00003,0 0,40.00002 -120.00003,0 0,-16.00001 0,-2 -12,0 0,6 -4.00002,0 0,-16.00001 4.00002,0 0,6.00001 12,0 0,-2 z"
-     id="path21-0-6-6"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="335.99994"
-     id="text23-6-9-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="600.00012">
-    <tspan
-       x="620.00012"
-       y="361.99994"
-       id="tspan25-2-3-4">mi</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-7-2"
-     d="m 571.00008,378.99993 120.00003,0 0,40.00001 -120.00003,0 0,-16.00001 0,-2 -12,0 0,6.00001 -4.00002,0 0,-16.00001 4.00002,0 0,6 12,0 0,-2 z" />
-  <text
-     y="377.99997"
-     x="606.00012"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-4-2">
-    <tspan
-       id="tspan25-8-8-5-6"
-       y="403.99994"
-       x="626.00012">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-2-4"
-     d="m 439.00005,268.99993 0,-8 c 0,-4.41829 3.58172,-8.00001 8,-8.00001 l 8,0 0,4 20,0 0,-4 18.00001,0 60,0 8.00002,0 c 4.41828,0 9.07159,3.71364 8,8.00001 l 0,8 -8,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8,0 0,8 c 0,4.41828 -3.58172,8 -8,8 l -8.00002,0 -60,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 c -5.52285,0 -10,4.47715 -10,10 l 0,8 0,92.00002 0,8 c 0,5.52285 4.64205,11.3395 10,10 l 8,0 0,4 20.00001,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.71364,9.07162 -8,8.00002 l -8,0 -18.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58174 -8,-8.00002 l 0,-8 z" />
-  <text
-     x="436.00003"
-     y="249.99991"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-5-1">
-    <tspan
-       id="tspan3039-5-4-2"
-       y="280.49994"
-       x="444.00003">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-7-8"
-     d="m 685.00011,294.99993 120.00003,0 0,40.00001 -120.00003,0 0,-16.00001 0,-2 -12.00001,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12.00001,0 0,-2 z" />
-  <text
-     y="293.99994"
-     x="716.00012"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-4-8">
-    <tspan
-       id="tspan25-8-5-2-4-9"
-       y="319.99994"
-       x="736.00012">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-3-2"
-     d="m 571.00008,268.99993 0,-8 a 8.0000022,8.0000017 0 0 1 8,-8.00001 l 8,0 20,0 60,0 8.00002,0 a 8.0000022,8.0000017 0 0 1 8.00001,8.00001 l 0,8 -8.00001,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8.00001,0 0,34 -8.00001,0 0,-6 -8.00002,0 0,20 8.00002,0 0,-6 8.00001,0 0,8 a 8.0000022,8.0000017 0 0 1 -8.00001,8.00001 l -8.00002,0 -60,0 -20,0 -8,0 a 8.0000022,8.0000017 0 0 1 -8,-8.00001 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.00002,0 0,-16 4.00002,0 0,6 12,0 0,-2 z" />
-  <text
-     x="546.00012"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-0-8"
-     y="251.99988">
-    <tspan
-       id="tspan3802-6-2-5-7-8"
-       y="300.99994"
-       x="656.00006">/</tspan>
-  </text>
   <g
-     id="g5147-8-8"
-     transform="translate(438.00004,209.9999)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-6-6"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-8-8"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-8-3">1</tspan>
-    </text>
+     transform="translate(181.72119,63)"
+     id="g7192">
+    <g
+       transform="scale(1.5)"
+       id="g7190">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7184"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7188">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7186">8</tspan>
+      </text>
+    </g>
   </g>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="538.82312"
-     y="321.9231"
-     id="text6137-3-3"><tspan
-       id="tspan6139-1-3"
-       x="538.82312"
-       y="321.9231"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-3"
-     d="m 247.00004,563.00001 120.00003,0 0,39.99999 -120.00003,0 0,-16 0,-2 -12,0 0,6 -4.00001,0 0,-15.99999 4.00001,0 0,5.99999 12,0 0,-2 z" />
-  <text
-     y="588"
-     x="292"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-1">32</text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-0"
-     d="m 133.00002,537 0,-8.00001 a 8.0000015,8.0000011 0 0 1 8,-8 l 8,0 20.00001,0 60,0 8.00001,0 a 8.0000015,8.0000011 0 0 1 8,8 l 0,8.00001 -8,0 0,-6 -8.00001,0 0,20.00001 8.00001,0 0,-6 8,0 0,33.99999 -8,0 0,-5.99999 -8.00001,0 0,19.99999 8.00001,0 0,-6 8,0 0,8 a 8.0000015,8.0000011 0 0 1 -8,8 l -8.00001,0 -60,0 -20.00001,0 -8,0 a 8.0000015,8.0000011 0 0 1 -8,-8 l 0,-8 0,-41.99999 0,-2 -12,0 0,6 -4.00001,0 0,-16.00001 4.00001,0 0,6 12,0 0,-2 z" />
-  <text
-     x="108.00008"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-3-3"
-     y="519.99994">
-    <tspan
-       id="tspan3802-6-2-5-4"
-       y="569"
-       x="218.00003">/</tspan>
-  </text>
   <g
-     id="g5147-0-8"
-     transform="translate(1.9121857e-6,477.99999)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-3"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-9"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-1">1</tspan>
-    </text>
+     transform="translate(13.5,63)"
+     id="g7202">
+    <g
+       transform="scale(1.5)"
+       id="g7200">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7194"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7198">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7196">↓</tspan>
+      </text>
+    </g>
   </g>
-  <path
-     d="m 19.000002,579 0,-7.99999 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 60.000008,0 8.00001,0 c 4.41828,0 8,3.58172 8,8 l 0,7.99999 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8.00001,0 -60.000008,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z"
-     id="path3124-9-0"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="100.82299"
-     y="589.9231"
-     id="text6137-6"><tspan
-       id="tspan6139-9"
-       x="100.82299"
-       y="589.9231"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-3-4"
-     d="m 667.00011,563.00002 120.00005,0 0,39.99999 -120.00005,0 0,-16 0,-2 -12,0 0,6 -4.00001,0 0,-15.99999 4.00001,0 0,5.99999 12,0 0,-2 z" />
-  <text
-     y="562"
-     x="694.00006"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-1-7">
-    <tspan
-       id="tspan25-8-5-2-1-6"
-       y="588"
-       x="714.00018">16</tspan>
-    <tspan
-       id="tspan12402-8"
-       y="588"
-       x="714.00018" />
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-0-9"
-     d="m 553.00008,537.00001 0,-8.00001 a 8.0000023,8.0000016 0 0 1 8,-8 l 8,0 20.00002,0 60,0 8.00001,0 a 8.0000023,8.0000016 0 0 1 8,8 l 0,8.00001 -8,0 0,-6 -8.00001,0 0,20.00001 8.00001,0 0,-6 8,0 0,33.99999 -8,0 0,-5.99999 -8.00001,0 0,19.99999 8.00001,0 0,-6 8,0 0,8 a 8.0000023,8.0000016 0 0 1 -8,8 l -8.00001,0 -60,0 -20.00002,0 -8,0 a 8.0000023,8.0000016 0 0 1 -8,-8 l 0,-8 0,-41.99999 0,-2 -12,0 0,6 -4.00001,0 0,-16.00001 4.00001,0 0,6 12,0 0,-2 z" />
-  <text
-     x="528.00018"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-3-3-0"
-     y="520">
-    <tspan
-       id="tspan3802-6-2-5-4-6"
-       y="569"
-       x="638.00012">/</tspan>
-  </text>
   <g
-     id="g5147-0-8-8"
-     transform="translate(420.00005,477.99997)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-3-7"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-9-9"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-1-0">1</tspan>
-    </text>
+     transform="translate(13.5,94.5)"
+     id="g7220">
+    <g
+       transform="scale(1.5)"
+       id="g7218">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7204"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7208">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan7206">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7212">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan7210">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7216">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan7214">octave</tspan>
+      </text>
+    </g>
   </g>
-  <path
-     d="m 439.00005,579.00001 0,-7.99999 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20.00001,0 0,-4 60.00001,0 8.00001,0 c 4.41828,0 8,3.58172 8,8 l 0,7.99999 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8.00001,0 -60.00001,0 -2,0 0,4 -16.00001,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z"
-     id="path3124-9-0-3"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="520.82306"
-     y="589.9231"
-     id="text6137-6-3"><tspan
-       id="tspan6139-9-3"
-       x="520.82306"
-       y="589.9231"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-3"
-     d="m 37.000002,704.99996 0,-8.00001 a 8.0000015,8.0000011 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60.000008,0 8,0 a 8.0000015,8.0000011 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8,0 0,20.00001 8,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8,0 0,19.99999 8,0 0,-6 8,0 0,8 a 8.0000015,8.0000011 0 0 1 -8,8 l -8,0 -60.000008,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000015,8.0000011 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z" />
-  <text
-     y="687.99994"
-     x="35.999996"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-3">
-    <tspan
-       id="tspan3198-2-8"
-       y="737"
-       x="130.00006">pitch</tspan>
-  </text>
-  <text
-     y="690"
-     x="35.999996"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-0-7">
-    <tspan
-       id="tspan3202-0-5"
-       y="712.49994"
-       x="130.00006">name</tspan>
-  </text>
-  <text
-     y="692"
-     x="35.999996"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-66">
-    <tspan
-       id="tspan3206-6-4"
-       y="756.49994"
-       x="130.00006">octave</tspan>
-  </text>
-  <path
-     d="m 151.00001,688.99995 120.00012,0 0,40.00002 -120.00012,0 0,-16.00001 0,-2 -12,0 0,6 -4,0 0,-16.00001 4,0 0,6.00001 12,0 0,-2 z"
-     id="path21-0-0"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="687.99994"
-     id="text23-6-0-3"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="180.00006">
-    <tspan
-       x="200.00006"
-       y="713.99994"
-       id="tspan25-2-4-2">re</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-6"
-     d="m 151.00001,730.99996 120.00012,0 0,40 -120.00012,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     y="730"
-     x="186.00006"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-2">
-    <tspan
-       id="tspan25-8-8-6"
-       y="755.99994"
-       x="206.00006">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-7"
-     d="m 19.000002,620.99997 0,-8.00002 c 0,-4.41828 3.5818,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 60.000008,0 8,0 c 4.4183,0 9.0716,3.71364 8,8 l 0,8.00002 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41828 -3.5817,8 -8,8 l -8,0 -60.000008,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.5228,0 -10,4.47715 -10,10 l 0,7.99999 0,92.00002 0,7.99999 c 0,5.52285 4.6421,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16.00001,0 0,12 0,12 0,8 c 0,4.41828 -3.7136,9.07161 -8.00001,8.00001 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.4182,0 -8,-3.58173 -8,-8.00001 l 0,-8 z" />
-  <text
-     x="15.999998"
-     y="602"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-56">
-    <tspan
-       id="tspan3039-5-9"
-       y="632.5"
-       x="23.999998">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-8"
-     d="m 265.00013,646.99997 120.00004,0 0,40 -120.00004,0 0,-16.00001 0,-2 -12.00001,0 0,6 -4.0001,0 0,-15.99999 4.0001,0 0,5.99999 12.00001,0 0,-2 z" />
-  <text
-     y="646"
-     x="296.00006"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-7">
-    <tspan
-       id="tspan25-8-5-2-2"
-       y="671.99994"
-       x="316.00006">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-8"
-     d="m 151.00001,620.99997 0,-8.00002 a 8.0000015,8.0000011 0 0 1 8,-8 l 8.00001,0 20,0 60,0 8.0001,0 a 8.0000015,8.0000011 0 0 1 8.00001,8 l 0,8.00002 -8.00001,0 0,-6 -8.0001,0 0,20 8.0001,0 0,-6 8.00001,0 0,33.99999 -8.00001,0 0,-5.99999 -8.0001,0 0,19.99999 8.0001,0 0,-6 8.00001,0 0,8 a 8.0000015,8.0000011 0 0 1 -8.00001,8.00001 l -8.0001,0 -60,0 -20,0 -8.00001,0 a 8.0000015,8.0000011 0 0 1 -8,-8.00001 l 0,-8 0,-41.99999 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     x="126.00012"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-2"
-     y="603.99994">
-    <tspan
-       id="tspan3802-6-2-5-9"
-       y="652.99994"
-       x="236.00006">/</tspan>
-  </text>
   <g
-     id="g5147-9"
-     transform="translate(18.000002,561.99994)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-60"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-2"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-7">1</tspan>
-    </text>
+     transform="translate(87,94.5)"
+     id="g7230">
+    <g
+       transform="scale(1.5)"
+       id="g7228">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7222"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7226">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7224">re</tspan>
+      </text>
+    </g>
   </g>
-  <path
-     d="m 37.000002,662.99996 0,-7.99999 c 0,-4.41828 3.5818,-8 8,-8 l 8,0 0,4 20,0 0,-4 60.000008,0 8,0 c 4.4183,0 8,3.58172 8,8 l 0,7.99999 0,8 0,8 c 0,4.41828 -3.7136,6.92842 -8,8.00001 l -8,0 -60.000008,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.4182,0 -8,-3.58173 -8,-8.00001 l 0,-8 0,0 z"
-     id="path3124-6"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="118.82306"
-     y="673.9231"
-     id="text6137-1"><tspan
-       id="tspan6139-3-6"
-       x="118.82306"
-       y="673.9231"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-1-2"
-     d="m 37.000002,914.99992 0,-8 a 8.0000022,8.0000017 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60.000008,0 8.0001,0 a 8.0000022,8.0000017 0 0 1 8,8 l 0,8 -8,0 0,-6 -8.0001,0 0,20 8.0001,0 0,-6 8,0 0,34 -8,0 0,-5.9999 -8.0001,0 0,20 8.0001,0 0,-6.0001 8,0 0,8.0001 a 8.0000022,8.0000017 0 0 1 -8,8 l -8.0001,0 -60.000008,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000022,8.0000017 0 0 1 -8,-8 l 0,-8.0001 0,-42 0,-8 z" />
-  <text
-     y="898"
-     x="35.999996"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-5-1-5">
-    <tspan
-       id="tspan3198-2-5-5"
-       y="947"
-       x="130.00006">pitch</tspan>
-  </text>
-  <text
-     y="900"
-     x="35.999996"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-4-9">
-    <tspan
-       id="tspan3202-0-7-9"
-       y="922.5"
-       x="130.00006">name</tspan>
-  </text>
-  <text
-     y="902"
-     x="35.999996"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-6-1-2">
-    <tspan
-       id="tspan3206-6-5-4-6"
-       y="966.5"
-       x="130.00006">octave</tspan>
-  </text>
-  <path
-     d="m 151.00011,898.99992 120.00002,0 0,40.0001 -120.00002,0 0,-16 0,-2 -12,0 0,6 -4.0001,0 0,-16.0001 4.0001,0 0,6.0001 12,0 0,-2 z"
-     id="path21-0-6-9"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="898"
-     id="text23-6-9-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="180.00018">
-    <tspan
-       x="200.00018"
-       y="924"
-       id="tspan25-2-3-0">mi</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-7-7"
-     d="m 151.00011,940.99992 120.00002,0 0,40.0001 -120.00002,0 0,-16.0001 0,-2 -12,0 0,6.0001 -4.0001,0 0,-16.0001 4.0001,0 0,6 12,0 0,-2 z" />
-  <text
-     y="940"
-     x="186.00018"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-4-5">
-    <tspan
-       id="tspan25-8-8-5-8"
-       y="966"
-       x="206.00018">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-2-7"
-     d="m 19.000002,830.99996 0,-8 c 0,-4.41829 3.5818,-8.00001 8,-8.00001 l 8,0 0,4 20,0 0,-4 18,0 60.000008,0 8.0001,0 c 4.4182,0 9.0715,3.71364 8,8.00001 l 0,8 -8,0 0,-6 -8.0001,0 0,20 8.0001,0 0,-6 8,0 0,8 c 0,4.41828 -3.5818,8 -8,8 l -8.0001,0 -60.000008,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.5228,0 -10,4.47715 -10,10 l 0,7.99996 0,92.0001 0,8 c 0,5.5228 4.6421,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16.00001,0 0,12 0,11.99998 0,8 c 0,4.4182 -3.7136,9.0716 -8.00001,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.4182,0 -8,-3.5818 -8,-8 l 0,-8 z" />
-  <text
-     x="15.999998"
-     y="811.99994"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-5-0">
-    <tspan
-       id="tspan3039-5-4-4"
-       y="842.5"
-       x="23.999998">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-7-8-5"
-     d="m 265.00013,856.99996 120.00004,0 0,40.00006 -120.00004,0 0,-16.0001 0,-2 -12.00001,0 0,6 -4,0 0,-16 4,0 0,6 12.00001,0 0,-2 z" />
-  <text
-     y="856"
-     x="296.00006"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-4-0">
-    <tspan
-       id="tspan25-8-5-2-4-4"
-       y="882"
-       x="316.00006">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-3-2-8"
-     d="m 151.00011,830.99996 0,-8 a 8.0000022,8.0000017 0 0 1 8,-8.00001 l 8.00001,0 20,0 60,0 8,0 a 8.0000022,8.0000017 0 0 1 8.00001,8.00001 l 0,8 -8.00001,0 0,-6 -8,0 0,20 8,0 0,-6 8.00001,0 0,33.99996 -8.00001,0 0,-5.99996 -8,0 0,19.99996 8,0 0,-6 8.00001,0 0,8 a 8.0000022,8.0000017 0 0 1 -8.00001,8.0001 l -8,0 -60,0 -20,0 -8.00001,0 a 8.0000022,8.0000017 0 0 1 -8,-8.0001 l 0,-8 0,-41.99996 0,-2 -12,0 0,6 -4.0001,0 0,-16 4.0001,0 0,6 12,0 0,-2 z" />
-  <text
-     x="126.00012"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-0-9"
-     y="813.99994">
-    <tspan
-       id="tspan3802-6-2-5-7-6"
-       y="863"
-       x="236.00006">/</tspan>
-  </text>
   <g
-     id="g5147-8-1"
-     transform="translate(18.000002,771.99992)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-6-0"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-8-4"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-8-2">1</tspan>
-    </text>
+     transform="translate(87,126)"
+     id="g7240">
+    <g
+       transform="scale(1.5)"
+       id="g7238">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7232"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7236">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7234">5</tspan>
+      </text>
+    </g>
   </g>
-  <path
-     d="m 37.000002,872.99992 0,-7.99996 c 0,-4.41828 3.5818,-8 8,-8 l 8,0 0,4 20,0 0,-4 60.000008,0 8.0001,0 c 4.4182,0 8,3.58172 8,8 l 0,7.99996 0,8 0,8 c 0,4.4183 -3.7137,6.9285 -8,8.0001 l -8.0001,0 -60.000008,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.4182,0 -8,-3.5818 -8,-8.0001 l 0,-8 0,0 z"
-     id="path3124-4-2"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="118.82318"
-     y="883.9231"
-     id="text6137-3-2"><tspan
-       id="tspan6139-1-0"
-       x="118.82318"
-       y="883.9231"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-3-7"
-     d="m 457.00005,704.99994 0,-8.00001 a 8.0000015,8.0000011 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60.00001,0 8,0 a 8.0000015,8.0000011 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8,0 0,20.00001 8,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8,0 0,19.99999 8,0 0,-6 8,0 0,8 a 8.0000015,8.0000011 0 0 1 -8,8 l -8,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000015,8.0000011 0 0 1 -8,-8 l 0,-8 0,-42 0,-8 z" />
-  <text
-     y="687.99994"
-     x="456.00006"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-3-9">
-    <tspan
-       id="tspan3198-2-8-6"
-       y="736.99994"
-       x="550.00012">pitch</tspan>
-  </text>
-  <text
-     y="689.99994"
-     x="456.00006"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-0-0">
-    <tspan
-       id="tspan3202-0-5-4"
-       y="712.49994"
-       x="550.00012">name</tspan>
-  </text>
-  <text
-     y="691.99994"
-     x="456.00006"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-66-1">
-    <tspan
-       id="tspan3206-6-4-0"
-       y="756.49994"
-       x="550.00012">octave</tspan>
-  </text>
-  <path
-     d="m 571.00006,688.99993 120.00012,0 0,40.00002 -120.00012,0 0,-16.00001 0,-2 -12,0 0,6 -4,0 0,-16.00001 4,0 0,6.00001 12,0 0,-2 z"
-     id="path21-0-0-4"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="687.99994"
-     id="text23-6-0-8"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="600.00012">
-    <tspan
-       x="620.00012"
-       y="713.99994"
-       id="tspan25-2-4-7">re</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-6-0"
-     d="m 571.00006,730.99994 120.00012,0 0,40 -120.00012,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     y="729.99994"
-     x="606.00012"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-2-8">
-    <tspan
-       id="tspan25-8-8-6-6"
-       y="755.99994"
-       x="626.00012">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-7-2"
-     d="m 439.00005,620.99995 0,-8.00002 c 0,-4.41828 3.5818,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 60.00001,0 8,0 c 4.4183,0 9.0716,3.71364 8,8 l 0,8.00002 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41828 -3.5817,8 -8,8 l -8,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.5228,0 -10,4.47715 -10,10 l 0,7.99999 0,92.00002 0,7.99999 c 0,5.52285 4.6421,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.41828 -3.7136,9.07161 -8,8.00001 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.4182,0 -8,-3.58173 -8,-8.00001 l 0,-8 z" />
-  <text
-     x="436.00006"
-     y="601.99994"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-56-4">
-    <tspan
-       id="tspan3039-5-9-7"
-       y="632.5"
-       x="444.00006">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-8-9"
-     d="m 685.00018,646.99995 120.00001,0 0,40 -120.00001,0 0,-16.00001 0,-2 -12.00001,0 0,6 -4.0001,0 0,-15.99999 4.0001,0 0,5.99999 12.00001,0 0,-2 z" />
-  <text
-     y="646"
-     x="716.00012"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-7-3">
-    <tspan
-       id="tspan25-8-5-2-2-9"
-       y="671.99994"
-       x="736.00012">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-8-2"
-     d="m 571.00006,620.99995 0,-8.00002 a 8.0000015,8.0000011 0 0 1 8,-8 l 8.00001,0 20,0 60,0 8.0001,0 a 8.0000015,8.0000011 0 0 1 8.00001,8 l 0,8.00002 -8.00001,0 0,-6 -8.0001,0 0,20 8.0001,0 0,-6 8.00001,0 0,33.99999 -8.00001,0 0,-5.99999 -8.0001,0 0,19.99999 8.0001,0 0,-6 8.00001,0 0,8 a 8.0000015,8.0000011 0 0 1 -8.00001,8.00001 l -8.0001,0 -60,0 -20,0 -8.00001,0 a 8.0000015,8.0000011 0 0 1 -8,-8.00001 l 0,-8 0,-41.99999 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     x="546.00018"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-2-8"
-     y="603.99994">
-    <tspan
-       id="tspan3802-6-2-5-9-3"
-       y="652.99994"
-       x="656.00012">/</tspan>
-  </text>
   <g
-     id="g5147-9-0"
-     transform="translate(438.00004,561.99992)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-60-1"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-2-7"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-7-8">1</tspan>
-    </text>
+     transform="translate(0,189)"
+     id="g7254">
+    <g
+       transform="scale(1.5)"
+       id="g7252">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7242"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7246">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7244">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7250">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan7248" />
+      </text>
+    </g>
   </g>
-  <path
-     d="m 457.00005,662.99994 0,-7.99999 c 0,-4.41828 3.5818,-8 8,-8 l 8,0 0,4 20,0 0,-4 60.00001,0 8,0 c 4.4183,0 8,3.58172 8,8 l 0,7.99999 0,8 0,8 c 0,4.41828 -3.7136,6.92842 -8,8.00001 l -8,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.4182,0 -8,-3.58173 -8,-8.00001 l 0,-8 0,0 z"
-     id="path3124-6-9"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="538.82312"
-     y="673.9231"
-     id="text6137-1-1"><tspan
-       id="tspan6139-3-5"
-       x="538.82312"
-       y="673.9231"
-       style="font-size:22.5px">↓</tspan></text>
-  <path
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3194-2-1-2-4"
-     d="m 457.00005,914.99994 0,-8.00001 a 8.0000022,8.0000017 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 60.00001,0 8.0001,0 a 8.0000022,8.0000017 0 0 1 8,8 l 0,8.00001 -8,0 0,-6.00001 -8.0001,0 0,20.00001 8.0001,0 0,-6 8,0 0,34 -8,0 0,-5.99999 -8.0001,0 0,20 8.0001,0 0,-6.00001 8,0 0,8.00001 a 8.0000022,8.0000017 0 0 1 -8,8 l -8.0001,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8.0000022,8.0000017 0 0 1 -8,-8 l 0,-8.00001 0,-42 0,-8 z" />
-  <text
-     y="897.99994"
-     x="456.00006"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3196-91-5-1-9">
-    <tspan
-       id="tspan3198-2-5-5-2"
-       y="946.99994"
-       x="550.00012">pitch</tspan>
-  </text>
-  <text
-     y="899.99994"
-     x="456.00006"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3200-7-4-9-5">
-    <tspan
-       id="tspan3202-0-7-9-7"
-       y="922.49994"
-       x="550.00012">name</tspan>
-  </text>
-  <text
-     y="901.99994"
-     x="456.00006"
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3204-93-6-1-4">
-    <tspan
-       id="tspan3206-6-5-4-9"
-       y="966.49994"
-       x="550.00012">octave</tspan>
-  </text>
-  <path
-     d="m 571.00016,898.99993 120.00002,0 0,40.00002 -120.00002,0 0,-16 0,-2 -12,0 0,6 -4.0001,0 0,-16.00001 4.0001,0 0,6.00001 12,0 0,-2 z"
-     id="path21-0-6-9-9"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="897.99994"
-     id="text23-6-9-1-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     x="600.00024">
-    <tspan
-       x="620.00024"
-       y="923.99994"
-       id="tspan25-2-3-0-5">mi</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-6-7-7-9"
-     d="m 571.00016,940.99994 120.00002,0 0,40.00001 -120.00002,0 0,-16.00001 0,-2 -12,0 0,6.00001 -4.0001,0 0,-16.00001 4.0001,0 0,6 12,0 0,-2 z" />
-  <text
-     y="939.99994"
-     x="606.00024"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-1-4-5-3">
-    <tspan
-       id="tspan25-8-8-5-8-5"
-       y="965.99994"
-       x="626.00024">5</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-5-2-7-7"
-     d="m 439.00005,830.99994 0,-8 c 0,-4.41829 3.5818,-8.00001 8,-8.00001 l 8,0 0,4 20,0 0,-4 18,0 60.00001,0 8.0001,0 c 4.4182,0 9.0715,3.71364 8,8.00001 l 0,8 -8,0 0,-6 -8.0001,0 0,20 8.0001,0 0,-6 8,0 0,8 c 0,4.41828 -3.5818,8 -8,8 l -8.0001,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -5.5228,0 -10,4.47715 -10,10 l 0,8 0,92.00002 0,8 c 0,5.52285 4.6421,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,11.99994 0,8 c 0,4.4183 -3.7136,9.0717 -8,8.0001 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.4182,0 -8,-3.5818 -8,-8.0001 l 0,-8 z" />
-  <text
-     x="436.00006"
-     y="811.99994"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3-5-0-0">
-    <tspan
-       id="tspan3039-5-4-4-8"
-       y="842.49994"
-       x="444.00006">note value</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-6-1-7-7-8-1"
-     d="m 685.00018,856.99994 120.00001,0 0,40.00001 -120.00001,0 0,-16.00001 0,-2 -12.00001,0 0,6 -4,0 0,-16 4,0 0,6 12.00001,0 0,-2 z" />
-  <text
-     y="855.99994"
-     x="716.00012"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-9-82-9-4-0-9">
-    <tspan
-       id="tspan25-8-5-2-4-4-9"
-       y="881.99994"
-       x="736.00012">8</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3798-4-4-5-3-2-7"
-     d="m 571.00016,830.99994 0,-8 a 8.0000022,8.0000017 0 0 1 8,-8.00001 l 8.00001,0 20,0 60,0 8,0 a 8.0000022,8.0000017 0 0 1 8.00001,8.00001 l 0,8 -8.00001,0 0,-6 -8,0 0,20 8,0 0,-6 8.00001,0 0,34 -8.00001,0 0,-6 -8,0 0,20 8,0 0,-6 8.00001,0 0,8 a 8.0000022,8.0000017 0 0 1 -8.00001,8.00001 l -8,0 -60,0 -20,0 -8.00001,0 a 8.0000022,8.0000017 0 0 1 -8,-8.00001 l 0,-8 0,-42 0,-2 -12,0 0,6 -4.0001,0 0,-16 4.0001,0 0,6 12,0 0,-2 z" />
-  <text
-     x="546.00018"
-     style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-     id="text3800-3-2-0-0-9-8"
-     y="813.99988">
-    <tspan
-       id="tspan3802-6-2-5-7-6-2"
-       y="862.99994"
-       x="656.00012">/</tspan>
-  </text>
   <g
-     id="g5147-8-1-5"
-     transform="translate(438.00004,771.9999)">
-    <path
-       d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-8-2-1-0-6-6-0-3"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       x="279"
-       y="44"
-       id="text23-0-1-0-1-0-8-4-4"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="299"
-         y="70.000031"
-         id="tspan25-7-0-5-2-5-8-2-9">1</tspan>
-    </text>
+     transform="translate(96.22119,189)"
+     id="g7272">
+    <g
+       transform="scale(1.5)"
+       id="g7270">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7256"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7260">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7258">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7264">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7262" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7268">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7266" />
+      </text>
+    </g>
   </g>
-  <path
-     d="m 457.00005,872.99994 0,-8 c 0,-4.41828 3.5818,-8 8,-8 l 8,0 0,4 20,0 0,-4 60.00001,0 8.0001,0 c 4.4182,0 8,3.58172 8,8 l 0,8 0,8 0,8 c 0,4.41829 -3.7137,6.92842 -8,8.00001 l -8.0001,0 -60.00001,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.4182,0 -8,-3.58172 -8,-8.00001 l 0,-8 0,0 z"
-     id="path3124-4-2-0"
-     style="fill:#BE6152;fill-opacity:1;stroke:#923111;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="538.82324"
-     y="883.92303"
-     id="text6137-3-2-2"><tspan
-       id="tspan6139-1-0-0"
-       x="538.82324"
-       y="883.92303"
-       style="font-size:22.5px">↓</tspan></text>
+  <g
+     transform="translate(181.72119,189)"
+     id="g7282">
+    <g
+       transform="scale(1.5)"
+       id="g7280">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7274"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7278">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7276">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(181.72119,220.5)"
+     id="g7292">
+    <g
+       transform="scale(1.5)"
+       id="g7290">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7284"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7288">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7286">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,220.5)"
+     id="g7302">
+    <g
+       transform="scale(1.5)"
+       id="g7300">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7294"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7298">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7296">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,252)"
+     id="g7320">
+    <g
+       transform="scale(1.5)"
+       id="g7318">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7304"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7308">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan7306">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7312">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan7310">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7316">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan7314">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(87,252)"
+     id="g7330">
+    <g
+       transform="scale(1.5)"
+       id="g7328">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7322"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7326">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7324">mi</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(87,283.5)"
+     id="g7340">
+    <g
+       transform="scale(1.5)"
+       id="g7338">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7332"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7336">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7334">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(341.5,32.5)"
+     id="g7354">
+    <g
+       transform="scale(1.5)"
+       id="g7352">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7342"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7346">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7344">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7350">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan7348" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(437.72119,32.5)"
+     id="g7372">
+    <g
+       transform="scale(1.5)"
+       id="g7370">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7356"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7360">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7358">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7364">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7362" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7368">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7366" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,32.5)"
+     id="g7382">
+    <g
+       transform="scale(1.5)"
+       id="g7380">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7374"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7378">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7376">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,64)"
+     id="g7392">
+    <g
+       transform="scale(1.5)"
+       id="g7390">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7384"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7388">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7386">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,64)"
+     id="g7402">
+    <g
+       transform="scale(1.5)"
+       id="g7400">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7394"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7398">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7396">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,95.5)"
+     id="g7420">
+    <g
+       transform="scale(1.5)"
+       id="g7418">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7404"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7408">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan7406">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7412">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan7410">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7416">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan7414">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,95.5)"
+     id="g7430">
+    <g
+       transform="scale(1.5)"
+       id="g7428">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7422"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7426">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7424">re</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,127)"
+     id="g7440">
+    <g
+       transform="scale(1.5)"
+       id="g7438">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7432"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7436">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7434">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     id="g7454">
+    <g
+       transform="scale(1.5)"
+       id="g7452">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 81.69434 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7442"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7446">
+        <tspan
+           x="98.027672"
+           y="13.5"
+           id="tspan7444">set master volume</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7450">
+        <tspan
+           x="98.027672"
+           y="11.25"
+           id="tspan7448" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(151.0415)"
+     id="g7464">
+    <g
+       transform="scale(1.5)"
+       id="g7462">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7456"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7460">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7458">50</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(1,412)"
+     id="g7478">
+    <g
+       transform="scale(1.5)"
+       id="g7476">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 27.241211 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 210 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7466"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7470">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7468">staccato</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7474">
+        <tspan
+           x="52.574543"
+           y="11.25"
+           id="tspan7472" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(83.86182,412)"
+     id="g7496">
+    <g
+       transform="scale(1.5)"
+       id="g7494">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7480"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7484">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7482">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7488">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7486" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7492">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7490" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(169.36182,412)"
+     id="g7506">
+    <g
+       transform="scale(1.5)"
+       id="g7504">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7498"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7502">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7500">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(169.36182,443.5)"
+     id="g7516">
+    <g
+       transform="scale(1.5)"
+       id="g7514">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7508"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7512">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7510">32</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(14.5,443.5)"
+     id="g7526">
+    <g
+       transform="scale(1.5)"
+       id="g7524">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7518"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7522">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7520">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(328,408)"
+     id="g7540">
+    <g
+       transform="scale(1.5)"
+       id="g7538">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 210 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7528"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7532">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7530">slur</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7536">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan7534" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(400,408)"
+     id="g7558">
+    <g
+       transform="scale(1.5)"
+       id="g7556">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7542"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7546">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7544">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7550">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7548" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7554">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7552" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(485.5,408)"
+     id="g7568">
+    <g
+       transform="scale(1.5)"
+       id="g7566">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7560"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7564">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7562">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(485.5,439.5)"
+     id="g7578">
+    <g
+       transform="scale(1.5)"
+       id="g7576">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7570"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7574">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7572">16</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(341.5,439.5)"
+     id="g7588">
+    <g
+       transform="scale(1.5)"
+       id="g7586">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7580"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7584">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7582">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(328,1)"
+     id="g7602">
+    <g
+       transform="scale(1.5)"
+       id="g7600">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 59.755859 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 189 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#3ea4a3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7590"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7594">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7592">crescendo (+/–)</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7598">
+        <tspan
+           x="85.089195"
+           y="11.25"
+           id="tspan7596" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(459.63379,1)"
+     id="g7612">
+    <g
+       transform="scale(1.5)"
+       id="g7610">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7604"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7608">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7606">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(341.5,190)"
+     id="g7626">
+    <g
+       transform="scale(1.5)"
+       id="g7624">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7614"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7618">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7616">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7622">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan7620" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(437.72119,190)"
+     id="g7644">
+    <g
+       transform="scale(1.5)"
+       id="g7642">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7628"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7632">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7630">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7636">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7634" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7640">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7638" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,190)"
+     id="g7654">
+    <g
+       transform="scale(1.5)"
+       id="g7652">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7646"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7650">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7648">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,221.5)"
+     id="g7664">
+    <g
+       transform="scale(1.5)"
+       id="g7662">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7656"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7660">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7658">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,221.5)"
+     id="g7674">
+    <g
+       transform="scale(1.5)"
+       id="g7672">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7666"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7670">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7668">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,253)"
+     id="g7692">
+    <g
+       transform="scale(1.5)"
+       id="g7690">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7676"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7680">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan7678">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7684">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan7682">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7688">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan7686">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,253)"
+     id="g7702">
+    <g
+       transform="scale(1.5)"
+       id="g7700">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7694"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7698">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7696">mi</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,284.5)"
+     id="g7712">
+    <g
+       transform="scale(1.5)"
+       id="g7710">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7704"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7708">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7706">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(341.5,471)"
+     id="g7726">
+    <g
+       transform="scale(1.5)"
+       id="g7724">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7714"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7718">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7716">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7722">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan7720" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(437.72119,471)"
+     id="g7744">
+    <g
+       transform="scale(1.5)"
+       id="g7742">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7728"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7732">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7730">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7736">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7734" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7740">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7738" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,471)"
+     id="g7754">
+    <g
+       transform="scale(1.5)"
+       id="g7752">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7746"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7750">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7748">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,502.5)"
+     id="g7764">
+    <g
+       transform="scale(1.5)"
+       id="g7762">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7756"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7760">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7758">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,502.5)"
+     id="g7774">
+    <g
+       transform="scale(1.5)"
+       id="g7772">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7766"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7770">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7768">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,534)"
+     id="g7792">
+    <g
+       transform="scale(1.5)"
+       id="g7790">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7776"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7780">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan7778">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7784">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan7782">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7788">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan7786">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,534)"
+     id="g7802">
+    <g
+       transform="scale(1.5)"
+       id="g7800">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7794"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7798">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7796">re</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,565.5)"
+     id="g7812">
+    <g
+       transform="scale(1.5)"
+       id="g7810">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7804"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7808">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7806">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(341.5,628.5)"
+     id="g7826">
+    <g
+       transform="scale(1.5)"
+       id="g7824">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7814"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7818">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7816">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7822">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan7820" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(437.72119,628.5)"
+     id="g7844">
+    <g
+       transform="scale(1.5)"
+       id="g7842">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7828"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7832">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7830">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7836">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7834" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7840">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7838" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,628.5)"
+     id="g7854">
+    <g
+       transform="scale(1.5)"
+       id="g7852">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7846"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7850">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7848">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(523.22119,660)"
+     id="g7864">
+    <g
+       transform="scale(1.5)"
+       id="g7862">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7856"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7860">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7858">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,660)"
+     id="g7874">
+    <g
+       transform="scale(1.5)"
+       id="g7872">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7866"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7870">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7868">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(355,691.5)"
+     id="g7892">
+    <g
+       transform="scale(1.5)"
+       id="g7890">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7876"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7880">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan7878">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7884">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan7882">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7888">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan7886">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,691.5)"
+     id="g7902">
+    <g
+       transform="scale(1.5)"
+       id="g7900">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7894"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7898">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7896">mi</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(428.5,723)"
+     id="g7912">
+    <g
+       transform="scale(1.5)"
+       id="g7910">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7904"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7908">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7906">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(14.5,475)"
+     id="g7926">
+    <g
+       transform="scale(1.5)"
+       id="g7924">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7914"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7918">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7916">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7922">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan7920" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(110.72119,475)"
+     id="g7944">
+    <g
+       transform="scale(1.5)"
+       id="g7942">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7928"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7932">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7930">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7936">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7934" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7940">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7938" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(196.22119,475)"
+     id="g7954">
+    <g
+       transform="scale(1.5)"
+       id="g7952">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7946"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7950">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7948">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(196.22119,506.5)"
+     id="g7964">
+    <g
+       transform="scale(1.5)"
+       id="g7962">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7956"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7960">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7958">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(28,506.5)"
+     id="g7974">
+    <g
+       transform="scale(1.5)"
+       id="g7972">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7966"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7970">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7968">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(28,538)"
+     id="g7992">
+    <g
+       transform="scale(1.5)"
+       id="g7990">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7976"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7980">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan7978">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7984">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan7982">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7988">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan7986">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(101.5,538)"
+     id="g8002">
+    <g
+       transform="scale(1.5)"
+       id="g8000">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7994"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7998">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7996">re</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(101.5,569.5)"
+     id="g8012">
+    <g
+       transform="scale(1.5)"
+       id="g8010">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8004"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8008">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8006">5</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(14.5,632.5)"
+     id="g8026">
+    <g
+       transform="scale(1.5)"
+       id="g8024">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8014"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8018">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan8016">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8022">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan8020" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(110.72119,632.5)"
+     id="g8044">
+    <g
+       transform="scale(1.5)"
+       id="g8042">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8028"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8032">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan8030">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8036">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan8034" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8040">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan8038" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(196.22119,632.5)"
+     id="g8054">
+    <g
+       transform="scale(1.5)"
+       id="g8052">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8046"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8050">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8048">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(196.22119,664)"
+     id="g8064">
+    <g
+       transform="scale(1.5)"
+       id="g8062">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8056"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8060">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8058">8</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(28,664)"
+     id="g8074">
+    <g
+       transform="scale(1.5)"
+       id="g8072">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8066"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8070">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan8068">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(28,695.5)"
+     id="g8092">
+    <g
+       transform="scale(1.5)"
+       id="g8090">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8076"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8080">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan8078">pitch</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8084">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan8082">name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text8088">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan8086">octave</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(101.5,695.5)"
+     id="g8102">
+    <g
+       transform="scale(1.5)"
+       id="g8100">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8094"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8098">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8096">mi</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(101.5,727)"
+     id="g8112">
+    <g
+       transform="scale(1.5)"
+       id="g8110">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path8104"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text8108">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan8106">5</tspan>
+      </text>
+    </g>
+  </g>
 </svg>

--- a/guide/voices3.svg
+++ b/guide/voices3.svg
@@ -5,15 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   width="210.5378mm"
-   height="183.50192mm"
-   viewBox="0 0 746.00007 650.20366"
-   id="svg4075"
-   version="1.1">
-  <defs
-     id="defs4077" />
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="909.90088"
+   height="497.34308"
+   version="1.1"
+   id="svg4346"
+   sodipodi:docname="voices3.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata4080">
+     id="metadata4352">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,691 +25,892 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033"
-     y="190.67804"
-     x="388">
-    <tspan
-       id="tspan3035"
-       y="213.17804"
-       x="490" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3107"
-     y="255.64163"
-     x="406">
-    <tspan
-       id="tspan3109"
-       y="278.14163"
-       x="500" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033-0"
-     y="274.67804"
-     x="388">
-    <tspan
-       id="tspan3035-1"
-       y="297.17804"
-       x="490" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033-1"
-     y="358.67801"
-     x="388">
-    <tspan
-       id="tspan3035-8"
-       y="381.17801"
-       x="490" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033-0-9"
-     y="442.67801"
-     x="388">
-    <tspan
-       id="tspan3035-1-5"
-       y="465.17801"
-       x="490" />
-  </text>
-  <path
-     d="m 37,113.56206 v -8 a 8,8 0 0 1 8,-7.999996 h 8 v 3.999996 h 20 v -3.999996 h 80 8 a 8,8 0 0 1 8,7.999996 v 8 8 8 a 8,8 0 0 1 -8,8 h -8 -80 -2 v 4 H 55 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z"
-     id="path3058-23"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060-40"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="36"
-     y="96.562065">
-    <tspan
-       x="150"
-       y="124.56207"
-       id="tspan3062-0">action</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-7"
-     d="m 19,71.56205 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 H 55 v -4 h -2 -8 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 C 36.07773,100.34219 35,102.94406 35,105.56205 v 8 8 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.1888 -3.93628,6.98407 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.18879,0 -8,-3.8112 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-9"
-     y="54.56205"
-     x="18">
-    <tspan
-       id="tspan3039-4"
-       y="85.06205"
-       x="26">repeat</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-61"
-     d="m 131,55.56206 h 120 v 40 H 131 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-4"
-     y="56.562061"
-     x="161">
-    <tspan
-       id="tspan25-7-0"
-       y="82.562057"
-       x="181">4</tspan>
-  </text>
+  <defs
+     id="defs4350" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="695"
+     inkscape:window-height="480"
+     id="namedview4348"
+     showgrid="false"
+     inkscape:zoom="0.2079063"
+     inkscape:cx="577"
+     inkscape:cy="244.92154"
+     inkscape:window-x="0"
+     inkscape:window-y="282"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4346" />
   <g
-     id="g4085-8-2"
-     transform="translate(0,0.56204994)">
-    <path
-       d="m 1,29 v -8 c 0,-4.18879 3.8112098,-8 8,-8 h 8 L 27,1 37,13 h 18 60 8 c 4.18879,0 8,3.81121 8,8 v 8 8 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -60 -2 v 4 H 37 v -4 h -2 -8 c -2.617994,0 -5.219867,1.077731 -7.071068,2.928932 C 18.077731,57.780133 17,60.382006 17,63 v 8 92 8 c 0,2.61799 1.077731,5.21987 2.928932,7.07107 1.851201,1.8512 4.53124,3.56389 7.071068,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.936277,9.01593 -8,8 H 55 37 L 27,233 17,221 H 9 c -4.1887902,0 -8,-3.81121 -8,-8 v -8 z"
-       id="path3660-4-5"
-       style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text3662-8-4"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="8"
-         y="43"
-         id="tspan3664-5-20">start</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3660-4"
-     d="m 377,29.56206 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 10,-12.0000001 10,12.0000001 18,0 60,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 0,8 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 C 394.07773,58.342193 393,60.944066 393,63.56206 l 0,8 0,174 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.93628,9.01593 -8,8 l -8,0 -18,0 -10,12 -10,-12 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z" />
-  <text
-     y="0.56205994"
-     x="376"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3662-8">
-    <tspan
-       id="tspan3664-5"
-       y="43.562061"
-       x="384">start</tspan>
-  </text>
-  <path
-     d="m 431,155.20368 0,-8 a 8,8 0 0 1 8,-7.99999 l 8,0 0,3.99999 20,0 0,-3.99999 80,0 8,0 a 8,8 0 0 1 8,7.99999 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z"
-     id="path3058"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="430"
-     y="138.20369">
-    <tspan
-       x="544"
-       y="166.20369"
-       id="tspan3062">action</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035"
-     d="m 413,113.20367 0,-8 c 0,-4.18879 3.81121,-7.999996 8,-7.999996 l 8,0 0,3.999996 20,0 0,-3.999996 18,0 40,0 8,0 c 4.18879,0 8,3.811206 8,7.999996 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07774 -7.07107,2.92894 -1.8512,1.8512 -2.92893,4.45307 -2.92893,7.07106 l 0,8 0,8 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037"
-     y="96.203674"
-     x="412">
-    <tspan
-       id="tspan3039"
-       y="126.70367"
-       x="420">repeat</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8"
-     d="m 525,97.203684 120,0 0,39.999996 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0"
-     y="98.20369"
-     x="555">
-    <tspan
-       id="tspan25-7"
-       y="124.20368"
-       x="575">4</tspan>
-  </text>
-  <path
-     d="m 395,71.203674 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 158,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -158,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.077731 -7.07107,2.928932 C 412.07773,99.983807 411,102.58568 411,105.20367 l 0,8 0,8 0,92 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,2.29397 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z"
-     id="path3035-23"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="54.203674"
-     x="394"
-     id="text3037-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="402"
-       y="84.703674"
-       id="tspan3039-7-3">adjust transposition</tspan>
-  </text>
-  <path
-     d="m 625.00007,55.203671 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8-2"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="655.00006"
-     y="56.203671"
-     id="text23-0-2-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="675.00006"
-       y="82.203667"
-       id="tspan25-7-8-8">-12</tspan>
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3660-4-6"
-     d="m 377,362.64162 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 10,-12 10,12 18,0 60,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 0,8 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,174 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.93628,9.01593 -8,8 l -8,0 -18,0 -10,12 -10,-12 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z" />
-  <text
-     y="333.64163"
-     x="376"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3662-8-9">
-    <tspan
-       id="tspan3664-5-7"
-       y="376.64163"
-       x="384">start</tspan>
-  </text>
-  <path
-     d="m 431,487.20368 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 80,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z"
-     id="path3058-4"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060-8"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="430"
-     y="470.20367">
-    <tspan
-       x="544"
-       y="498.20367"
-       id="tspan3062-6">action</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-6"
-     d="m 413,445.20367 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 40,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.85121 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,8 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3"
-     y="428.20367"
-     x="412">
-    <tspan
-       id="tspan3039-8"
-       y="458.70367"
-       x="420">repeat</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-4"
-     d="m 525,429.20368 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-0"
-     y="430.20367"
-     x="555">
-    <tspan
-       id="tspan25-7-9"
-       y="456.20367"
-       x="575">4</tspan>
-  </text>
-  <path
-     d="m 395,403.20367 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 158,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -158,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,8 0,92 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,2.29397 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z"
-     id="path3035-23-9"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="386.20367"
-     x="394"
-     id="text3037-1-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="402"
-       y="416.70367"
-       id="tspan3039-7-3-8">adjust transposition</tspan>
-  </text>
-  <path
-     d="m 625.00007,387.20367 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8-2-0"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="655.00006"
-     y="388.20367"
-     id="text23-0-2-4-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="675.00006"
-       y="414.20367"
-       id="tspan25-7-8-8-1">-24</tspan>
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3660-4-4"
-     d="m 1,362.64162 0,-8 c 0,-4.18879 3.8112098,-8 8,-8 l 8,0 10,-12 10,12 18,0 60,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 0,8 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.617994,0 -5.219867,1.07773 -7.071068,2.92893 C 18.077731,391.42175 17,394.02363 17,396.64162 l 0,8 0,174 0,8 c 0,2.61799 1.077731,5.21987 2.928932,7.07107 1.851201,1.8512 4.53124,3.56389 7.071068,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.936277,9.01593 -8,8 l -8,0 -18,0 -10,12 -10,-12 -8,0 c -4.1887902,0 -8,-3.81121 -8,-8 l 0,-8 z" />
-  <text
-     y="333.64163"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3662-8-7">
-    <tspan
-       id="tspan3664-5-2"
-       y="376.64163"
-       x="8">start</tspan>
-  </text>
-  <path
-     d="m 55,487.20368 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 80,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z"
-     id="path3058-3"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060-4"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="54"
-     y="470.20367">
-    <tspan
-       x="168"
-       y="498.20367"
-       id="tspan3062-8">action</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-9"
-     d="m 37,445.20367 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 40,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 C 54.07773,473.98381 53,476.58568 53,479.20367 l 0,8 0,8 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-0"
-     y="428.20367"
-     x="36">
-    <tspan
-       id="tspan3039-0"
-       y="458.70367"
-       x="44">repeat</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-24"
-     d="m 149,429.20368 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-00"
-     y="430.20367"
-     x="179">
-    <tspan
-       id="tspan25-7-3"
-       y="456.20367"
-       x="199">4</tspan>
-  </text>
-  <path
-     d="m 19,403.20367 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 158,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -158,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.617994,0 -5.219867,1.07773 -7.071068,2.92893 C 36.077731,431.9838 35,434.58568 35,437.20367 l 0,8 0,8 0,92 c 0,2.61799 1.077731,5.21987 2.928932,7.07107 1.851201,1.8512 4.53124,2.29397 7.071068,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.936277,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z"
-     id="path3035-23-92"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="386.20367"
-     x="18"
-     id="text3037-1-3"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="26"
-       y="416.70367"
-       id="tspan3039-7-3-9">adjust transposition</tspan>
-  </text>
-  <path
-     d="m 249.00007,387.20367 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8-2-3"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="279.00006"
-     y="388.20367"
-     id="text23-0-2-4-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="299.00006"
-       y="414.20367"
-       id="tspan25-7-8-8-8">12</tspan>
-  </text>
-  <g
-     transform="matrix(1.4262992,0,0,1.4811676,-132.10432,-36.93438)"
-     id="g4634">
-    <path
-       style="fill:#ffc1c1;fill-opacity:1;stroke:#ff0000;stroke-width:0.37087584px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4725"
-       d="m 167.00762,39.539118 c 0,0 -0.46531,-0.370876 -0.74175,-0.370876 -0.55287,0 -1.09256,0.350814 -1.4835,0.741752 -0.58641,0.586406 -0.62773,1.552489 -1.11263,2.225255 -0.30668,0.425495 -0.68713,0.805948 -1.11263,1.112627 -0.67276,0.484903 -1.63885,0.526222 -2.22525,1.112628 -0.39094,0.390937 -0.74175,0.930634 -0.74175,1.483503 0,0.552869 0.43649,1.312961 0.74175,1.483503 0.96247,0.537721 0.31028,0.240518 0.74175,0.741752 0,0 -0.38587,1.22419 -0.37088,1.854379 0.0165,1.238632 0.45294,2.480604 0.74176,2.967007 0.18935,0.318895 1.34328,1.657344 2.22525,2.225255 0.88807,0.571841 1.97446,0.763668 3.02812,0.8376 1.13698,0.07978 2.21652,-0.132168 3.21565,-0.680635 0.61304,-0.336524 1.12013,-0.71383 1.54462,-1.269593 0.60499,-0.792083 1.22769,-1.632821 1.48351,-2.59613 0.15865,-0.597419 0.0755,-1.240885 0,-1.85438 -0.0623,-0.505901 -0.47178,-0.983869 -0.37088,-1.483503 0.12236,-0.605895 0.86033,-0.919212 1.11263,-1.483503 0.2573,-0.575467 0.62589,-1.277899 0.37087,-1.854379 -0.29162,-0.659231 -1.24525,-0.727152 -1.85438,-1.112628 -0.37665,-0.238358 -0.78107,-0.443829 -1.11262,-0.741752 -0.71819,-0.645351 -1.2767,-1.451586 -1.85438,-2.225255 -0.26668,-0.357158 -0.38752,-0.842067 -0.74175,-1.112627 -0.31068,-0.237297 -0.73215,-0.460695 -1.11263,-0.370876 -0.17016,0.04017 -0.37088,0.370876 -0.37088,0.370876" />
-    <path
-       d="m 172.57866,47.803117 c 0,0 0.54294,2.128427 0.37128,3.183536 -0.18671,1.147562 -0.64302,2.34396 -1.48511,3.183536 -0.76475,0.762463 -1.18949,1.049013 -2.22767,1.414905 -0.47858,0.168668 -1.84456,0.353726 -2.4159,0.353726 -0.57135,0 -1.93733,-0.185059 -2.41591,-0.353727 -1.03818,-0.365892 -1.46292,-0.652441 -2.22766,-1.414904 -0.84209,-0.839576 -1.29841,-2.035975 -1.48512,-3.183536 -0.17166,-1.055109 0.37128,-3.183536 0.37128,-3.183536 m 4.82661,-2.122358 c 0,0 -1.52881,1.745204 -2.59894,2.122358 -0.69643,0.245448 -1.5584,0.30646 -2.22767,0 -0.71423,-0.327051 -1.32906,-1.028431 -1.48511,-1.768631 -0.17743,-0.841581 0.2073,-1.529325 0.91624,-2.050581 0.76674,-0.563756 1.70542,-0.616723 2.42526,-1.132956 0.93281,-0.668963 1.08012,-1.998936 1.85639,-2.829809 0.52688,-0.563939 2.04463,-1.414905 2.04463,-1.414905 0,0 1.51774,0.850966 2.04462,1.414905 0.77627,0.830873 0.92358,2.160847 1.85639,2.82981 0.71984,0.516232 1.68334,0.54353 2.45008,1.085677 0.71847,0.508023 1.06885,1.256279 0.89142,2.097859 -0.15605,0.740201 -0.77087,1.44158 -1.48511,1.768631 -0.66927,0.30646 -1.53123,0.245448 -2.22767,0 -1.07013,-0.377153 -2.59894,-2.122357 -2.59894,-2.122357"
-       id="path4505-6"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     transform="translate(0.33333,0.42153745)"
+     id="g3938">
     <g
-       id="g4565"
-       transform="matrix(0.37127797,0,0,0.35372622,176.72956,39.358074)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <g
-         id="g4553"
-         transform="translate(0,-1)"
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1">
-        <path
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664"
-           id="path3411-7"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285"
-           id="path3413-5"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <g
-         id="g4557"
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1">
-        <path
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658"
-           id="path3411-3"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075"
-           id="path3413-56"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </g>
-    <g
-       id="g4636"
-       transform="matrix(0.37127797,0,0,0.35372622,176.92563,38.650622)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <ellipse
-         cx="-30.836912"
-         cy="14.612609"
-         id="circle3409-2"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <ellipse
-         cx="-23.593306"
-         cy="14.699166"
-         id="ellipse4229-9"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="g4632"
-       transform="matrix(0.37127797,0,0,0.35372622,176.96142,38.650622)"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+       transform="scale(1.5)"
+       id="g3936">
       <path
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25"
-         id="path4303-1"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25"
-         id="path4303-1-2"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path3930"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text3934">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan3932">start</tspan>
+      </text>
     </g>
-    <path
-       d="m 167.72688,38.606235 c -0.51355,0.487351 -0.73647,0.882428 -0.91229,0.882428 -0.24578,0 -0.47204,-0.395077 -0.91229,-0.882428 -0.36084,-0.399437 0.40844,-0.882428 0.91229,-0.882428 0.50385,0 1.3103,0.504726 0.91229,0.882428 z"
-       id="path4227-7"
-       style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.80251253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4653"
-       d="m 167.04984,55.935948 c 0,0 0.26819,1.158553 2.03989,1.361113 1.77169,0.202559 4.37064,-1.401457 5.48447,-3.523814 1.11384,-2.122358 0.8911,-4.261654 1.11384,-6.720799" />
   </g>
   <g
-     id="g4846"
-     transform="matrix(1.2836694,0,0,1.333051,342.08813,-438.89287)">
-    <path
-       style="fill:#a0b6ff;fill-opacity:1;stroke:#003cff;stroke-width:0.41208419px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4725-6"
-       d="m 108.21551,345.46506 c 0,0 -0.51701,-0.41208 -0.82417,-0.41208 -0.6143,0 -1.21395,0.38979 -1.64833,0.82417 -0.65157,0.65156 -0.69748,1.72499 -1.23625,2.4725 -0.34076,0.47278 -0.76348,0.8955 -1.23626,1.23626 -0.74751,0.53878 -1.82094,0.58469 -2.4725,1.23625 -0.43438,0.43437 -0.824165,1.03404 -0.824165,1.64834 0,0.61429 0.484985,1.45884 0.824165,1.64833 1.06941,0.59747 0.34476,0.26724 0.82417,0.82417 0,0 -0.42875,1.36021 -0.41209,2.06042 0.0183,1.37626 0.50327,2.75623 0.82418,3.29668 0.21039,0.35432 1.49253,1.84149 2.4725,2.4725 0.98674,0.63538 2.19384,0.84852 3.36457,0.93067 1.26331,0.0886 2.4628,-0.14686 3.57295,-0.75626 0.68115,-0.37392 1.24459,-0.79315 1.71624,-1.41066 0.67221,-0.88009 1.3641,-1.81425 1.64835,-2.88459 0.17627,-0.6638 0.0839,-1.37876 0,-2.06042 -0.0692,-0.56211 -0.5242,-1.09319 -0.41209,-1.64834 0.13595,-0.67322 0.95592,-1.02135 1.23625,-1.64834 0.28589,-0.6394 0.69543,-1.41988 0.41208,-2.06042 -0.32402,-0.73247 -1.38361,-0.80794 -2.06042,-1.23625 -0.4185,-0.26484 -0.86786,-0.49314 -1.23625,-0.82417 -0.79799,-0.71705 -1.41855,-1.61287 -2.06042,-2.4725 -0.29631,-0.39685 -0.43058,-0.93563 -0.82416,-1.23626 -0.3452,-0.26366 -0.8135,-0.51188 -1.23626,-0.41208 -0.18907,0.0446 -0.41209,0.41208 -0.41209,0.41208" />
-    <path
-       d="m 114.40555,354.64728 c 0,0 0.60327,2.36492 0.41254,3.53727 -0.20746,1.27506 -0.71447,2.6044 -1.65012,3.53726 -0.84973,0.84718 -1.32166,1.16557 -2.47519,1.57211 -0.53176,0.18741 -2.04951,0.39303 -2.68434,0.39303 -0.63483,0 -2.15258,-0.20562 -2.68434,-0.39303 -1.15353,-0.40654 -1.62547,-0.72493 -2.47518,-1.57211 -0.93565,-0.93286 -1.44267,-2.2622 -1.65013,-3.53726 -0.19073,-1.17235 0.41253,-3.53727 0.41253,-3.53727 m 5.3629,-2.35817 c 0,0 -1.69868,1.93911 -2.88771,2.35817 -0.77381,0.27272 -1.73155,0.34052 -2.47519,0 -0.79359,-0.36339 -1.47673,-1.1427 -1.650119,-1.96514 -0.197144,-0.93509 0.230329,-1.69925 1.018049,-2.27842 0.85193,-0.6264 1.89491,-0.68525 2.69473,-1.25884 1.03645,-0.7433 1.20013,-2.22104 2.06265,-3.14424 0.58543,-0.62659 2.27181,-1.57211 2.27181,-1.57211 0,0 1.68638,0.94552 2.2718,1.57211 0.86253,0.9232 1.0262,2.40095 2.06266,3.14424 0.79982,0.57359 1.87038,0.60392 2.72231,1.20631 0.7983,0.56447 1.18761,1.39586 0.99047,2.33095 -0.17339,0.82244 -0.85653,1.60175 -1.65013,1.96514 -0.74363,0.34052 -1.70136,0.27272 -2.47518,0 -1.18904,-0.41905 -2.88771,-2.35817 -2.88771,-2.35817"
-       id="path4505-6-7"
-       style="fill:none;fill-opacity:1;stroke:#003cff;stroke-width:0.80532396;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     transform="translate(0,258.42154)"
+     id="g3948">
     <g
-       id="g4565-5"
-       transform="matrix(0.412531,0,0,0.39302906,119.01766,345.26391)"
-       style="fill:none;fill-opacity:1;stroke:#003cff;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <g
-         id="g4553-3"
-         transform="translate(0,-1)"
-         style="fill:none;fill-opacity:1;stroke:#003cff;stroke-opacity:1">
-        <path
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664"
-           id="path3411-7-5"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285"
-           id="path3413-5-6"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <g
-         id="g4557-2"
-         style="fill:none;fill-opacity:1;stroke:#003cff;stroke-opacity:1">
-        <path
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658"
-           id="path3411-3-9"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075"
-           id="path3413-56-1"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </g>
-    <g
-       id="g4636-2"
-       transform="matrix(0.412531,0,0,0.39302906,119.23552,344.47785)"
-       style="fill:none;fill-opacity:1;stroke:#003cff;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <ellipse
-         cx="-30.836912"
-         cy="14.612609"
-         id="circle3409-2-7"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <ellipse
-         cx="-23.593306"
-         cy="14.699166"
-         id="ellipse4229-9-0"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="g4632-9"
-       transform="matrix(0.412531,0,0,0.39302906,119.27529,344.47785)"
-       style="fill:none;fill-opacity:1;stroke:#003cff;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+       transform="scale(1.5)"
+       id="g3946">
       <path
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25"
-         id="path4303-1-3"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25"
-         id="path4303-1-2-6"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 84 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path3940"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text3944">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan3942">start</tspan>
+      </text>
     </g>
-    <path
-       d="m 109.01469,344.42853 c -0.57061,0.5415 -0.8183,0.98047 -1.01366,0.98047 -0.27309,0 -0.52449,-0.43897 -1.01365,-0.98047 -0.40094,-0.44382 0.45382,-0.98048 1.01365,-0.98048 0.55984,0 1.45589,0.56081 1.01366,0.98048 z"
-       id="path4227-7-0"
-       style="fill:#003cff;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:0.89168042;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#003cff;stroke-width:0.80532396;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4653-6"
-       d="m 108.26242,363.68376 c 0,0 0.29799,1.28728 2.26655,1.51235 1.96854,0.22506 4.85626,-1.55718 6.09385,-3.91535 1.2376,-2.35817 0.99011,-4.73517 1.2376,-7.46755" />
   </g>
   <g
-     transform="matrix(1.2836694,0,0,1.333051,-137.12495,327.25258)"
-     id="g4757">
-    <path
-       style="fill:#a0ffa4;fill-opacity:1;stroke:#079f0d;stroke-width:0.41208419px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4725-6-6"
-       d="m 481.53054,20.45008 c 0,0 -0.51701,-0.41208 -0.82417,-0.41208 -0.6143,0 -1.21395,0.38979 -1.64833,0.82417 -0.65157,0.65156 -0.69748,1.72499 -1.23625,2.4725 -0.34076,0.47278 -0.76348,0.8955 -1.23626,1.23626 -0.74751,0.53878 -1.82094,0.58469 -2.4725,1.23625 -0.43438,0.43437 -0.82417,1.03404 -0.82417,1.64834 0,0.61429 0.48499,1.45884 0.82417,1.64833 1.06941,0.59747 0.34476,0.26724 0.82417,0.82417 0,0 -0.42875,1.36021 -0.41209,2.06042 0.0183,1.37626 0.50327,2.75623 0.82418,3.29668 0.21039,0.35432 1.49253,1.84149 2.4725,2.4725 0.98674,0.63538 2.19384,0.84852 3.36457,0.93067 1.26331,0.0886 2.4628,-0.14686 3.57295,-0.75626 0.68115,-0.37392 1.24459,-0.79315 1.71624,-1.41066 0.67221,-0.88009 1.3641,-1.81425 1.64835,-2.88459 0.17627,-0.6638 0.0839,-1.37876 0,-2.06042 -0.0692,-0.56211 -0.5242,-1.09319 -0.41209,-1.64834 0.13595,-0.67322 0.95592,-1.02135 1.23625,-1.64834 0.28589,-0.6394 0.69543,-1.41988 0.41208,-2.06042 -0.32402,-0.73247 -1.38361,-0.80794 -2.06042,-1.23625 -0.4185,-0.26484 -0.86786,-0.49314 -1.23625,-0.82417 -0.79799,-0.71705 -1.41855,-1.61287 -2.06042,-2.4725 -0.29631,-0.39685 -0.43058,-0.93563 -0.82416,-1.23626 -0.3452,-0.26366 -0.8135,-0.51188 -1.23626,-0.41208 -0.18907,0.0446 -0.41209,0.41208 -0.41209,0.41208" />
-    <path
-       d="m 487.72058,29.6323 c 0,0 0.60327,2.36492 0.41254,3.53727 -0.20746,1.27506 -0.71447,2.6044 -1.65012,3.53726 -0.84973,0.84718 -1.32166,1.16557 -2.47519,1.57211 -0.53176,0.18741 -2.04951,0.39303 -2.68434,0.39303 -0.63483,0 -2.15258,-0.20562 -2.68434,-0.39303 -1.15353,-0.40654 -1.62547,-0.72493 -2.47518,-1.57211 -0.93565,-0.93286 -1.44267,-2.2622 -1.65013,-3.53726 -0.19073,-1.17235 0.41253,-3.53727 0.41253,-3.53727 m 5.3629,-2.35817 c 0,0 -1.69868,1.93911 -2.88771,2.35817 -0.77381,0.27272 -1.73155,0.34052 -2.47519,0 -0.79359,-0.36339 -1.47673,-1.1427 -1.65012,-1.96514 -0.19714,-0.93509 0.23033,-1.69925 1.01805,-2.27842 0.85193,-0.6264 1.89491,-0.68525 2.69473,-1.25884 1.03645,-0.7433 1.20013,-2.22104 2.06265,-3.14424 0.58543,-0.62659 2.27181,-1.57211 2.27181,-1.57211 0,0 1.68638,0.94552 2.2718,1.57211 0.86253,0.9232 1.0262,2.40095 2.06266,3.14424 0.79982,0.57359 1.87038,0.60392 2.72231,1.20631 0.7983,0.56447 1.18761,1.39586 0.99047,2.33095 -0.17339,0.82244 -0.85653,1.60175 -1.65013,1.96514 -0.74363,0.34052 -1.70136,0.27272 -2.47518,0 -1.18904,-0.41905 -2.88771,-2.35817 -2.88771,-2.35817"
-       id="path4505-6-7-7"
-       style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-width:0.80532396;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     transform="translate(458,256.42154)"
+     id="g3958">
     <g
-       id="g4565-5-5"
-       transform="matrix(0.412531,0,0,0.39302906,492.33269,20.24893)"
-       style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <g
-         id="g4553-3-3"
-         transform="translate(0,-1)"
-         style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-opacity:1">
-        <path
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664"
-           id="path3411-7-5-5"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285"
-           id="path3413-5-6-6"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <g
-         id="g4557-2-2"
-         style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-opacity:1">
-        <path
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658"
-           id="path3411-3-9-9"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075"
-           id="path3413-56-1-1"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </g>
-    <g
-       id="g4636-2-2"
-       transform="matrix(0.412531,0,0,0.39302906,492.55055,19.46287)"
-       style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <ellipse
-         cx="-30.836912"
-         cy="14.612609"
-         id="circle3409-2-7-7"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <ellipse
-         cx="-23.593306"
-         cy="14.699166"
-         id="ellipse4229-9-0-0"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="g4632-9-9"
-       transform="matrix(0.412531,0,0,0.39302906,492.59032,19.46287)"
-       style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+       transform="scale(1.5)"
+       id="g3956">
       <path
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25"
-         id="path4303-1-3-3"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25"
-         id="path4303-1-2-6-6"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 84 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path3950"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text3954">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan3952">start</tspan>
+      </text>
     </g>
-    <path
-       d="m 482.32972,19.41355 c -0.57061,0.5415 -0.8183,0.98047 -1.01366,0.98047 -0.27309,0 -0.52449,-0.43897 -1.01365,-0.98047 -0.40094,-0.44382 0.45382,-0.98048 1.01365,-0.98048 0.55984,0 1.45589,0.56081 1.01366,0.98048 z"
-       id="path4227-7-0-0"
-       style="fill:#079f0d;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:0.89168042;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-width:0.80532396;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4653-6-6"
-       d="m 481.57745,38.66878 c 0,0 0.29799,1.28728 2.26655,1.51235 1.96854,0.22506 4.85626,-1.55718 6.09385,-3.91535 1.2376,-2.35817 0.99011,-4.73517 1.2376,-7.46755" />
   </g>
   <g
-     transform="matrix(1.2836694,0,0,1.333051,-105.88578,0.77473177)"
-     id="g4859">
-    <path
-       style="fill:#fffbc1;fill-opacity:1;stroke:#9f9607;stroke-width:0.41208422px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4725-61"
-       d="m 165.13932,265.36033 c 0,0 -0.51702,-0.41209 -0.82417,-0.41209 -0.6143,0 -1.21396,0.3898 -1.64833,0.82417 -0.65157,0.65157 -0.69748,1.72499 -1.23626,2.47251 -0.34076,0.47277 -0.76348,0.8955 -1.23625,1.23625 -0.74752,0.53878 -1.82095,0.58469 -2.4725,1.23625 -0.43438,0.43438 -0.82417,1.03404 -0.82417,1.64834 0,0.6143 0.48499,1.45885 0.82417,1.64834 1.06941,0.59746 0.34475,0.26724 0.82416,0.82417 0,0 -0.42874,1.36021 -0.41209,2.06042 0.0183,1.37625 0.50327,2.75622 0.82418,3.29667 0.21039,0.35433 1.49253,1.84149 2.4725,2.47251 0.98674,0.63537 2.19384,0.84852 3.36458,0.93066 1.26331,0.0887 2.4628,-0.14685 3.57294,-0.75626 0.68116,-0.37391 1.24459,-0.79314 1.71625,-1.41066 0.67221,-0.88009 1.3641,-1.81424 1.64834,-2.88459 0.17628,-0.66379 0.0839,-1.37876 0,-2.06042 -0.0692,-0.56211 -0.5242,-1.09319 -0.41209,-1.64833 0.13596,-0.67322 0.95592,-1.02135 1.23626,-1.64834 0.28589,-0.63941 0.69543,-1.41989 0.41207,-2.06042 -0.32402,-0.73248 -1.38361,-0.80795 -2.06042,-1.23625 -0.4185,-0.26485 -0.86785,-0.49315 -1.23624,-0.82417 -0.79799,-0.71706 -1.41856,-1.61288 -2.06042,-2.47251 -0.29631,-0.39684 -0.43058,-0.93563 -0.82417,-1.23625 -0.3452,-0.26366 -0.8135,-0.51188 -1.23626,-0.41209 -0.18906,0.0446 -0.41208,0.41209 -0.41208,0.41209" />
-    <path
-       d="m 171.32936,274.54255 c 0,0 0.60327,2.36492 0.41253,3.53726 -0.20745,1.27507 -0.71446,2.6044 -1.65012,3.53726 -0.84972,0.84718 -1.32165,1.16557 -2.47519,1.57212 -0.53175,0.18741 -2.04951,0.39303 -2.68433,0.39303 -0.63483,0 -2.15259,-0.20562 -2.68435,-0.39303 -1.15353,-0.40655 -1.62546,-0.72494 -2.47517,-1.57212 -0.93566,-0.93286 -1.44268,-2.26219 -1.65014,-3.53726 -0.19073,-1.17234 0.41254,-3.53726 0.41254,-3.53726 m 5.3629,-2.35818 c 0,0 -1.69868,1.93912 -2.88771,2.35818 -0.77381,0.27272 -1.73156,0.34051 -2.47519,0 -0.79359,-0.36339 -1.47674,-1.1427 -1.65012,-1.96515 -0.19715,-0.93509 0.23033,-1.69925 1.01804,-2.27842 0.85193,-0.62639 1.89491,-0.68525 2.69473,-1.25884 1.03646,-0.74329 1.20014,-2.22104 2.06266,-3.14423 0.58542,-0.6266 2.27181,-1.57212 2.27181,-1.57212 0,0 1.68638,0.94552 2.2718,1.57212 0.86252,0.92319 1.0262,2.40094 2.06265,3.14423 0.79983,0.57359 1.87038,0.60392 2.72231,1.20631 0.7983,0.56447 1.18762,1.39586 0.99047,2.33095 -0.17339,0.82245 -0.85652,1.60176 -1.65012,1.96515 -0.74363,0.34051 -1.70137,0.27272 -2.47519,0 -1.18903,-0.41906 -2.88771,-2.35818 -2.88771,-2.35818"
-       id="path4505-6-8"
-       style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-width:0.80532402;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     transform="translate(459,3.4215375)"
+     id="g3968">
     <g
-       id="g4565-7"
-       transform="matrix(0.41253104,0,0,0.39302909,175.94147,265.15917)"
-       style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <g
-         id="g4553-9"
-         transform="translate(0,-1)"
-         style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-opacity:1">
-        <path
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664"
-           id="path3411-7-2"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285"
-           id="path3413-5-0"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <g
-         id="g4557-23"
-         style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-opacity:1">
-        <path
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658"
-           id="path3411-3-7"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075"
-           id="path3413-56-5"
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </g>
-    <g
-       id="g4636-9"
-       transform="matrix(0.41253104,0,0,0.39302909,176.15933,264.37311)"
-       style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <ellipse
-         cx="-30.836912"
-         cy="14.612609"
-         id="circle3409-2-2"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <ellipse
-         cx="-23.593306"
-         cy="14.699166"
-         id="ellipse4229-9-2"
-         rx="1.8846371"
-         ry="2.0666313"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="g4632-8"
-       transform="matrix(0.41253104,0,0,0.39302909,176.19909,264.37311)"
-       style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+       transform="scale(1.5)"
+       id="g3966">
       <path
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25"
-         id="path4303-1-9"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25"
-         id="path4303-1-2-7"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 84 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path3960"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text3964">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan3962">start</tspan>
+      </text>
     </g>
-    <path
-       d="m 165.93849,264.32379 c -0.57061,0.5415 -0.8183,0.98048 -1.01365,0.98048 -0.27309,0 -0.52449,-0.43898 -1.01366,-0.98048 -0.40093,-0.44382 0.45382,-0.98047 1.01366,-0.98047 0.55983,0 1.45589,0.5608 1.01365,0.98047 z"
-       id="path4227-7-3"
-       style="fill:#9f9607;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:0.89168048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-width:0.80532402;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4653-61"
-       d="m 165.18623,283.57903 c 0,0 0.29799,1.28728 2.26654,1.51234 1.96855,0.22507 4.85627,-1.55717 6.09386,-3.91534 1.2376,-2.35818 0.99011,-4.73517 1.2376,-7.46756" />
+  </g>
+  <g
+     transform="translate(13.83333,40.921537)"
+     id="g3982">
+    <g
+       transform="scale(1.5)"
+       id="g3980">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path3970"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text3974">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan3972">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text3978">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan3976" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.83333,40.921537)"
+     id="g3992">
+    <g
+       transform="scale(1.5)"
+       id="g3990">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path3984"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text3988">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan3986">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27.33333,72.421537)"
+     id="g4002">
+    <g
+       transform="scale(1.5)"
+       id="g4000">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path3994"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text3998">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan3996">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(499.5,106.92154)"
+     id="g4012">
+    <g
+       transform="scale(1.5)"
+       id="g4010">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4004"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4008">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan4006">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.5,361.92154)"
+     id="g4022">
+    <g
+       transform="scale(1.5)"
+       id="g4020">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4014"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4018">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan4016">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(498.5,359.92154)"
+     id="g4032">
+    <g
+       transform="scale(1.5)"
+       id="g4030">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4024"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4028">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan4026">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,330.42154)"
+     id="g4046">
+    <g
+       transform="scale(1.5)"
+       id="g4044">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4034"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4038">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4036">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4042">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan4040" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(99,330.42154)"
+     id="g4056">
+    <g
+       transform="scale(1.5)"
+       id="g4054">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4048"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4052">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4050">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(486,75.421537)"
+     id="g4070">
+    <g
+       transform="scale(1.5)"
+       id="g4068">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4058"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4062">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4060">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4066">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan4064" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(558,75.421537)"
+     id="g4080">
+    <g
+       transform="scale(1.5)"
+       id="g4078">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4072"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4076">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4074">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(485,328.42154)"
+     id="g4094">
+    <g
+       transform="scale(1.5)"
+       id="g4092">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4082"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4086">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4084">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4090">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan4088" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(557,328.42154)"
+     id="g4104">
+    <g
+       transform="scale(1.5)"
+       id="g4102">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4096"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4100">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4098">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(472.5,43.921537)"
+     id="g4118">
+    <g
+       transform="scale(1.5)"
+       id="g4116">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4106"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4110">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4108">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4114">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan4112" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(635.40088,43.921537)"
+     id="g4136">
+    <g
+       transform="scale(1.5)"
+       id="g4134">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4120"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4124">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4122">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4128">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4126" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4132">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4130" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(720.90088,43.921537)"
+     id="g4146">
+    <g
+       transform="scale(1.5)"
+       id="g4144">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4138"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4142">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4140">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(720.90088,75.421537)"
+     id="g4164">
+    <g
+       transform="scale(1.5)"
+       id="g4162">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4148"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4152">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4150">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4156">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4154" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4160">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4158" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(806.40088,75.421537)"
+     id="g4174">
+    <g
+       transform="scale(1.5)"
+       id="g4172">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4166"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4170">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4168">-1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(806.40088,106.92154)"
+     id="g4184">
+    <g
+       transform="scale(1.5)"
+       id="g4182">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4176"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4180">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4178">12</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(471.5,296.92154)"
+     id="g4198">
+    <g
+       transform="scale(1.5)"
+       id="g4196">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4186"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4190">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4188">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4194">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan4192" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(634.40088,296.92154)"
+     id="g4216">
+    <g
+       transform="scale(1.5)"
+       id="g4214">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4200"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4204">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4202">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4208">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4206" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4212">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4210" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(719.90088,296.92154)"
+     id="g4226">
+    <g
+       transform="scale(1.5)"
+       id="g4224">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4218"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4222">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4220">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(719.90088,328.42154)"
+     id="g4244">
+    <g
+       transform="scale(1.5)"
+       id="g4242">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4228"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4232">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4230">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4236">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4234" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4240">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4238" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(805.40088,328.42154)"
+     id="g4254">
+    <g
+       transform="scale(1.5)"
+       id="g4252">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4246"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4250">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4248">-2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(805.40088,359.92154)"
+     id="g4264">
+    <g
+       transform="scale(1.5)"
+       id="g4262">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4256"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4260">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4258">12</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,298.92154)"
+     id="g4278">
+    <g
+       transform="scale(1.5)"
+       id="g4276">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4266"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4270">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan4268">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4274">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan4272" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(176.40088,298.92154)"
+     id="g4296">
+    <g
+       transform="scale(1.5)"
+       id="g4294">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4280"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4284">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4282">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4288">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4286" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4292">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4290" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(261.90088,298.92154)"
+     id="g4306">
+    <g
+       transform="scale(1.5)"
+       id="g4304">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4298"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4302">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4300">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(261.90088,330.42154)"
+     id="g4324">
+    <g
+       transform="scale(1.5)"
+       id="g4322">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4308"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4312">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan4310">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4316">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan4314" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text4320">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan4318" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(347.40088,330.42154)"
+     id="g4334">
+    <g
+       transform="scale(1.5)"
+       id="g4332">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4326"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4330">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4328">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(347.40088,361.92154)"
+     id="g4344">
+    <g
+       transform="scale(1.5)"
+       id="g4342">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path4336"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text4340">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan4338">12</tspan>
+      </text>
+    </g>
   </g>
 </svg>

--- a/guide/voices4.svg
+++ b/guide/voices4.svg
@@ -5,15 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   width="217.31114mm"
-   height="270.42636mm"
-   viewBox="0 0 770.00011 958.20365"
-   id="svg4075"
-   version="1.1">
-  <defs
-     id="defs4077" />
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="912.80176"
+   height="775.34308"
+   version="1.1"
+   id="svg7458"
+   sodipodi:docname="voices4.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata4080">
+     id="metadata7464">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,946 +25,1368 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033"
-     y="200.67804"
-     x="388">
-    <tspan
-       id="tspan3035"
-       y="223.17804"
-       x="490" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3107"
-     y="265.6416"
-     x="406">
-    <tspan
-       id="tspan3109"
-       y="288.1416"
-       x="500" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033-0"
-     y="284.67804"
-     x="388">
-    <tspan
-       id="tspan3035-1"
-       y="307.17804"
-       x="490" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033-1"
-     y="368.67798"
-     x="388">
-    <tspan
-       id="tspan3035-8"
-       y="391.17798"
-       x="490" />
-  </text>
-  <text
-     style="font-size:13.33333302px;font-family:Sans;text-anchor:end;fill:#000000"
-     id="text3033-0-9"
-     y="452.67798"
-     x="388">
-    <tspan
-       id="tspan3035-1-5"
-       y="475.17798"
-       x="490" />
-  </text>
+  <defs
+     id="defs7462" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     id="namedview7460"
+     showgrid="false"
+     inkscape:zoom="0.83162518"
+     inkscape:cx="585.06643"
+     inkscape:cy="341.07936"
+     inkscape:window-x="-8"
+     inkscape:window-y="274"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7458" />
   <g
-     transform="translate(4.8241901e-7,-14)"
-     id="g4384">
-    <path
-       style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-       id="path3058-23"
-       d="m 37,405.56206 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 80 8 a 8,8 0 0 1 8,8 v 8 8 8 a 8,8 0 0 1 -8,8 h -8 -80 -2 v 4 H 55 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z" />
-    <text
-       y="388.56207"
-       x="36"
-       style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-       id="text3060-40">
-      <tspan
-         id="tspan3062-0"
-         y="416.56207"
-         x="150">action</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-7"
-     d="m 19,349.56205 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 H 55 v -4 h -2 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 C 36.07773,378.34219 35,380.94406 35,383.56205 v 8 8 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.1888 -3.93628,6.98407 -8,8 H 73 55 53 v 4 H 37 v -4 h -2 -8 c -4.18879,0 -8,-3.8112 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-9"
-     y="332.56204"
-     x="18">
-    <tspan
-       id="tspan3039-4"
-       y="363.06204"
-       x="26">repeat</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-61"
-     d="m 131,333.56206 h 120 v 40 H 131 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-4"
-     y="334.56207"
-     x="161">
-    <tspan
-       id="tspan25-7-0"
-       y="360.56207"
-       x="181">4</tspan>
-  </text>
-  <g
-     id="g4085-8-2"
-     transform="translate(4.8241901e-7,278.56205)">
-    <path
-       d="m 1,29 v -8 c 0,-4.18879 3.8112098,-8 8,-8 h 8 L 27,1 37,13 h 18 60 8 c 4.18879,0 8,3.81121 8,8 v 8 8 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -60 -2 v 4 H 37 v -4 h -2 -8 c -2.617994,0 -5.219867,1.077731 -7.071068,2.928932 C 18.077731,57.780133 17,60.382006 17,63 v 8 92 8 c 0,2.61799 1.077731,5.21987 2.928932,7.07107 1.851201,1.8512 4.53124,3.56389 7.071068,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.936277,9.01593 -8,8 H 55 37 L 27,233 17,221 H 9 c -4.1887902,0 -8,-3.81121 -8,-8 v -8 z"
-       id="path3660-4-5"
-       style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text3662-8-4"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-      <tspan
-         x="8"
-         y="43"
-         id="tspan3664-5-20">start</tspan>
-    </text>
-  </g>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3660-4-4"
-     d="m 1.0000005,544.64161 0,-8 c 0,-4.18879 3.8112098,-8 8,-8 l 7.9999995,0 10,-12 10,12 18,0 60,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 0,8 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.617994,0 -5.219867,1.07773 -7.071068,2.92893 C 18.077731,573.42174 17,576.02362 17,578.64161 l 0,8 0,300 0,8 c 0,2.61799 1.077731,5.21987 2.928932,7.07107 1.851201,1.8512 4.53124,3.56389 7.071068,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.936277,9.01593 -8,8 l -8,0 -18,0 -10,12 -10,-12 -7.9999995,0 c -4.1887902,0 -8,-3.81121 -8,-8 l 0,-8 z" />
-  <text
-     y="515.6416"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3662-8-7"
-     x="4.8241827e-07">
-    <tspan
-       id="tspan3664-5-2"
-       y="558.6416"
-       x="8.000001">start</tspan>
-  </text>
-  <path
-     d="m 55,795.20367 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 80,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z"
-     id="path3058-3"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060-4"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="54"
-     y="778.20367">
-    <tspan
-       x="168"
-       y="806.20367"
-       id="tspan3062-8">action</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-9"
-     d="m 37,753.20366 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 40,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 C 54.07773,781.9838 53,784.58567 53,787.20366 l 0,8 0,8 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-0"
-     y="736.20367"
-     x="36">
-    <tspan
-       id="tspan3039-0"
-       y="766.70367"
-       x="44">repeat</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-24"
-     d="m 149,737.20367 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-00"
-     y="738.20367"
-     x="179">
-    <tspan
-       id="tspan25-7-3"
-       y="764.20367"
-       x="199">4</tspan>
-  </text>
-  <path
-     d="m 19,711.20366 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 158,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -158,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.617994,0 -5.219867,1.07773 -7.071068,2.92893 C 36.077731,739.98379 35,742.58567 35,745.20366 l 0,8 0,8 0,92 c 0,2.61799 1.077731,5.21987 2.928932,7.07107 1.851201,1.8512 4.53124,2.29397 7.071068,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.936277,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z"
-     id="path3035-23-92"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="694.20367"
-     x="18"
-     id="text3037-1-3"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="26"
-       y="724.70367"
-       id="tspan3039-7-3-9">adjust transposition</tspan>
-  </text>
-  <path
-     d="m 249.00007,695.20366 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8-2-3"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="279.00006"
-     y="696.20367"
-     id="text23-0-2-4-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="299.00006"
-       y="722.20367"
-       id="tspan25-7-8-8-8">12</tspan>
-  </text>
-  <path
-     d="m 37,627.20366 0,-8 a 8,8 0 0 1 8,-7.99999 l 8,0 0,3.99999 20,0 0,-3.99999 80,0 8,0 a 8,8 0 0 1 8,7.99999 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z"
-     id="path3058-23-3"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060-40-3"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="36"
-     y="610.20367">
-    <tspan
-       x="150"
-       y="638.20367"
-       id="tspan3062-0-4">delay</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-7-1"
-     d="m 19,585.20365 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 40,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 C 36.07773,613.98379 35,616.58566 35,619.20365 l 0,8 0,8 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-9-2"
-     y="568.20367"
-     x="18">
-    <tspan
-       id="tspan3039-4-9"
-       y="598.70367"
-       x="26">repeat</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-61-6"
-     d="m 131,569.20366 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-4-1"
-     y="570.20367"
-     x="161">
-    <tspan
-       id="tspan25-7-0-2"
-       y="596.20367"
-       x="181">4</tspan>
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3660-4-6"
-     d="m 401.00003,502.64161 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 10,-12 10,12 18,0 60,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 0,8 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -60,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45308 -2.92893,7.07107 l 0,8 2,300 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.93628,9.01593 -8,8 l -8,0 -18,0 -10,12 -10,-12 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z" />
-  <text
-     y="473.6416"
-     x="400.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3662-8-9">
-    <tspan
-       id="tspan3664-5-7"
-       y="516.6416"
-       x="408.00003">start</tspan>
-  </text>
-  <path
-     d="m 455.00003,753.20367 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 80,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z"
-     id="path3058-4"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060-8"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="454.00003"
-     y="736.20367">
-    <tspan
-       x="568.00006"
-       y="764.20367"
-       id="tspan3062-6">action</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-6"
-     d="m 437.00003,711.20366 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 40,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.85121 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,8 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-3"
-     y="694.20367"
-     x="436.00003">
-    <tspan
-       id="tspan3039-8"
-       y="724.70367"
-       x="444.00003">repeat</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-4"
-     d="m 549.00003,695.20367 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-0"
-     y="696.20367"
-     x="579.00006">
-    <tspan
-       id="tspan25-7-9"
-       y="722.20367"
-       x="599.00006">4</tspan>
-  </text>
-  <path
-     d="m 419.00003,669.20366 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 158,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -158,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,8 0,92 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,2.29397 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18879 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.81121 -8,-8 l 0,-8 z"
-     id="path3035-23-9"
-     style="fill:#76C61C;fill-opacity:1;stroke:#538D38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="652.20367"
-     x="418.00003"
-     id="text3037-1-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="426.00003"
-       y="682.70367"
-       id="tspan3039-7-3-8">adjust transposition</tspan>
-  </text>
-  <path
-     d="m 649.0001,653.20366 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-     id="path21-8-2-0"
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="679.00012"
-     y="654.20367"
-     id="text23-0-2-4-9"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="699.00012"
-       y="680.20367"
-       id="tspan25-7-8-8-1">-24</tspan>
-  </text>
-  <path
-     d="m 437.00003,586.20366 0,-8 a 8,8 0 0 1 8,-7.99999 l 8,0 0,3.99999 20,0 0,-3.99999 80,0 8,0 a 8,8 0 0 1 8,7.99999 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -80,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z"
-     id="path3058-23-3-1"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060-40-3-7"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436.00003"
-     y="569.20367">
-    <tspan
-       x="550.00006"
-       y="597.20367"
-       id="tspan3062-0-4-5">delay</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-7-1-7"
-     d="m 419.00003,544.20365 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 40,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -40,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.85121 -2.92893,4.45308 -2.92893,7.07107 l 0,8 0,8 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.1888 -3.93628,6.98407 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.18879,0 -8,-3.8112 -8,-8 l 0,-8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-9-2-1"
-     y="527.20367"
-     x="418.00003">
-    <tspan
-       id="tspan3039-4-9-1"
-       y="557.70367"
-       x="426.00003">repeat</tspan>
-  </text>
-  <path
-     style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-61-6-7"
-     d="m 531.00003,528.20366 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-4-1-7"
-     y="529.20367"
-     x="561.00006">
-    <tspan
-       id="tspan25-7-0-2-9"
-       y="555.20367"
-       x="581.00006">6</tspan>
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3660-4"
-     d="m 401.00003,29.56205 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 l 10,-12 10,12 h 18 60 8 c 4.18879,0 8,3.81121 8,8 v 8 8 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -60 -2 v 4 h -16 v -4 h -2 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45308 -2.92893,7.07107 v 8 300 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.93628,9.01593 -8,8 h -8 -18 l -10,12 -10,-12 h -8 c -4.18879,0 -8,-3.81121 -8,-8 v -8 z" />
-  <text
-     y="0.56204987"
-     x="400.00003"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3662-8">
-    <tspan
-       id="tspan3664-5"
-       y="43.56205"
-       x="408.00003">start</tspan>
-  </text>
-  <path
-     d="m 455.00003,279.20367 v -8 a 8,8 0 0 1 8,-8 h 8 v 4 h 20 v -4 h 80 8 a 8,8 0 0 1 8,8 v 8 8 8 a 8,8 0 0 1 -8,8 h -8 -80 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z"
-     id="path3058"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="454.00003"
-     y="262.20367">
-    <tspan
-       x="568.00006"
-       y="290.20367"
-       id="tspan3062">action</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035"
-     d="m 437.00003,237.20366 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 h -16 v -4 h -2 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.85121 -2.92893,4.45308 -2.92893,7.07107 v 8 8 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.1888 -3.93628,6.98407 -8,8 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.18879,0 -8,-3.8112 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037"
-     y="220.20367"
-     x="436.00003">
-    <tspan
-       id="tspan3039"
-       y="250.70364"
-       x="444.00003">repeat</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8"
-     d="m 549.00003,221.20367 h 120 v 40 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0"
-     y="222.20367"
-     x="579.00006">
-    <tspan
-       id="tspan25-7"
-       y="248.20367"
-       x="599.00006">4</tspan>
-  </text>
-  <path
-     d="m 419.00003,195.20366 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 158 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -158 -2 v 4 h -16 v -4 h -2 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.8512 -2.92893,4.45308 -2.92893,7.07107 v 8 8 92 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,2.29397 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.18879 -3.93628,6.98407 -8,8 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.18879,0 -8,-3.81121 -8,-8 v -8 z"
-     id="path3035-23"
-     style="fill:#76c61c;fill-opacity:1;stroke:#538d38;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     y="178.20367"
-     x="418.00003"
-     id="text3037-1"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="426.00003"
-       y="208.70367"
-       id="tspan3039-7-3">adjust transposition</tspan>
-  </text>
-  <path
-     d="m 649.0001,179.20366 h 120 v 40 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z"
-     id="path21-8-2"
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     x="679.00012"
-     y="180.20364"
-     id="text23-0-2-4"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000">
-    <tspan
-       x="699.00012"
-       y="206.20364"
-       id="tspan25-7-8-8">-12</tspan>
-  </text>
-  <path
-     d="m 437.00003,112.20366 v -8 a 8,8 0 0 1 8,-7.99999 h 8 v 3.99999 h 20 v -3.99999 h 80 8 a 8,8 0 0 1 8,7.99999 v 8 8 8 a 8,8 0 0 1 -8,8 h -8 -80 -2 v 4 h -16 v -4 h -2 -8 a 8,8 0 0 1 -8,-8 v -8 z"
-     id="path3058-23-3-1-0"
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060-40-3-7-5"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="436.00003"
-     y="95.203659">
-    <tspan
-       x="550.00006"
-       y="123.20367"
-       id="tspan3062-0-4-5-3">delay</tspan>
-  </text>
-  <path
-     style="fill:#e37a00;fill-opacity:1;stroke:#a34600;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-7-1-7-1"
-     d="m 419.00003,70.20365 v -8 c 0,-4.18879 3.81121,-8 8,-8 h 8 v 4 h 20 v -4 h 18 40 8 c 4.18879,0 8,3.81121 8,8 v 8 h -8 v -6 h -8 v 20 h 8 v -6 h 8 v 8 c 0,4.18879 -3.81121,8 -8,8 h -8 -40 -2 v 4 h -16 v -4 h -2 -8 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 -1.8512,1.85121 -2.92893,4.45308 -2.92893,7.07107 v 8 8 8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.53124,3.56389 7.07107,2.92893 h 8 v 4 h 20 v -4 h 16 v 12 12 8 c 0,4.1888 -3.93628,6.98407 -8,8 h -8 -18 -2 v 4 h -16 v -4 h -2 -8 c -4.18879,0 -8,-3.8112 -8,-8 v -8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-9-2-1-3"
-     y="53.203644"
-     x="418.00003">
-    <tspan
-       id="tspan3039-4-9-1-5"
-       y="83.703644"
-       x="426.00003">repeat</tspan>
-  </text>
-  <path
-     style="fill:#ee97a8;fill-opacity:1;stroke:#a75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-8-61-6-7-5"
-     d="m 531.00003,54.20366 h 120 v 40 h -120 v -16 -2 h -12 v 6 h -4 v -16 h 4 v 6 h 12 v -2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-0-4-1-7-3"
-     y="55.203659"
-     x="561.00006">
-    <tspan
-       id="tspan25-7-0-2-9-1"
-       y="81.203659"
-       x="581.00006">2</tspan>
-  </text>
-  <path
-     style="fill:#ffc000;fill-opacity:1;stroke:#c48d00;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3027-4"
-     d="m 1,29.56205 0,-8 c 0,-4.18879 3.81121,-8 8,-8 l 8,0 10,-12.0000001 10,12.0000001 18,0 70,0 8,0 c 4.18879,0 8,3.81121 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.18879 -3.81121,8 -8,8 l -8,0 -70,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -2.61799,0 -5.21987,1.07773 -7.07107,2.92893 C 18.07773,58.34218 17,60.94405 17,63.56205 l 0,8 0,134 0,8 c 0,2.61799 1.07773,5.21987 2.92893,7.07107 1.8512,1.8512 4.531247,2.29397 7.07107,2.92893 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12 0,8 c 0,4.18878 -3.93628,9.01593 -8,8 l -8,0 -18,0 -10,12 -10,-12 -8,0 c -4.18879,0 -8,-3.81122 -8,-8 l 0,-8 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3029-4"
-     y="-1.7267047"
-     x="-0.055397034">
-    <tspan
-       id="tspan3031-5"
-       y="41.273296"
-       x="7.944603">action</tspan>
-  </text>
-  <path
-     style="fill:#5DC1BC;fill-opacity:1;stroke:#5AA4AF;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path21-2-0"
-     d="m 143,13.56205 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
-  <text
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text23-2"
-     y="12.018046"
-     x="149.21786">
-    <tspan
-       id="tspan25-1"
-       y="38.018032"
-       x="169.21786">delay</tspan>
-  </text>
-  <path
-     d="m 37.000031,155.20364 0,-8 a 8,8 0 0 1 8,-8 l 8,0 0,4 20,0 0,-4 79.999999,0 8,0 a 8,8 0 0 1 8,8 l 0,8 0,8 0,8 a 8,8 0 0 1 -8,8 l -8,0 -79.999999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 z"
-     id="path3058-36"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     id="text3060-7"
-     style="font-size:20px;font-family:Sans;text-anchor:end;fill:#000000"
-     x="36.000015"
-     y="138.20364">
-    <tspan
-       x="150.00005"
-       y="166.20364"
-       id="tspan3062-5">silence</tspan>
-  </text>
-  <path
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-     id="path3035-0"
-     d="m 19.000031,71.20364 0,-8 c 0,-4.41828 3.58172,-8 8,-8 l 8,0 0,4 20,0 0,-4 18,0 59.999999,0 8,0 c 4.41828,0 9.07159,3.71364 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 c 0,4.41827 -3.58172,8 -8,8 l -8,0 -59.999999,0 -2,0 0,4.000005 -16,0 0,-4.000005 -2,0 -8,0 c -5.52285,0 -10,4.477155 -10,10 l 0,8.00001 0,50 0,7.99999 c 0,5.52286 4.64205,11.3395 10,10 l 8,0 0,4 20,0 0,-4 16,0 0,12 0,12.00001 0,8 c 0,4.41828 -3.71365,9.0716 -8,8 l -8,0 -18,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 z" />
-  <text
-     x="16.000017"
-     y="52.203644"
-     style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-     id="text3037-6">
-    <tspan
-       id="tspan3039-2-3"
-       y="82.703659"
-       x="24.000017">note value</tspan>
-  </text>
-  <g
-     id="g5152-6"
-     transform="translate(18.000031,96.20364)">
-    <path
-       d="m 247,1.000003 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path21-6-1-1"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       id="text23-9-82-8"
-       style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-       x="282"
-       y="4.7314452e-06">
-      <tspan
-         x="302"
-         y="26.000004"
-         id="tspan25-8-5-7">1</tspan>
-    </text>
-  </g>
-  <g
-     id="g5157-9"
-     transform="translate(18.000031,54.20364)">
-    <path
-       d="m 133,17 0,-8 a 8,8 0 0 1 8,-8 l 8,0 20,0 60,0 8,0 a 8,8 0 0 1 8,8 l 0,8 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,34 -8,0 0,-6 -8,0 0,20 8,0 0,-6 8,0 0,8 a 8,8 0 0 1 -8,8 l -8,0 -60,0 -20,0 -8,0 a 8,8 0 0 1 -8,-8 l 0,-8 0,-42 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z"
-       id="path3798-4-4-5-2"
-       style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-    <text
-       y="-2.2888184e-05"
-       id="text3800-3-2-0-0"
-       style="font-size:28px;font-family:sans-serif;text-anchor:end;fill:#000000"
-       x="108">
-      <tspan
-         x="218"
-         y="49"
-         id="tspan3802-6-2-5-2">/</tspan>
-    </text>
+     transform="translate(0.33333,223.42154)"
+     id="g6822">
     <g
-       transform="translate(0,-42)"
-       id="g5147-3">
+       transform="scale(1.5)"
+       id="g6820">
       <path
-         style="fill:#EE97A8;fill-opacity:1;stroke:#A75862;stroke-width:2;stroke-linecap:round;stroke-opacity:1"
-         id="path21-8-2-1-0-6-7"
-         d="m 247,43 120,0 0,40 -120,0 0,-16 0,-2 -12,0 0,6 -4,0 0,-16 4,0 0,6 12,0 0,-2 z" />
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 42 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6814"
+         inkscape:connector-curvature="0" />
       <text
-         style="font-size:20px;font-family:Sans;text-anchor:start;fill:#000000"
-         id="text23-0-1-0-1-0-5"
-         y="44"
-         x="279">
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6818">
         <tspan
-           id="tspan25-7-0-5-2-5-9"
-           y="70.000031"
-           x="299">1</tspan>
+           x="5.3333335"
+           y="21.5"
+           id="tspan6816">start</tspan>
       </text>
     </g>
   </g>
-  <path
-     d="m 37.000031,113.20365 0,-8 c 0,-4.41827 3.58172,-8.00001 8,-8.00001 l 8,0 0,4.00001 20,0 0,-4.00001 59.999999,0 8,0 c 4.41828,0 8,3.58173 8,8.00001 l 0,8 0,8 0,8 c 0,4.41828 -3.71364,6.92841 -8,8 l -8,0 -59.999999,0 -2,0 0,4 -16,0 0,-4 -2,0 -8,0 c -4.41828,0 -8,-3.58172 -8,-8 l 0,-8 0,0 z"
-     id="path3124-2"
-     style="fill:#F2740B;fill-opacity:1;stroke:#A86129;stroke-width:2;stroke-linecap:round;stroke-opacity:1" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:16px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="118.82301"
-     y="124.12674"
-     id="text6137-2"><tspan
-       id="tspan6139-8"
-       x="118.82301"
-       y="124.12674"
-       style="font-size:22.5px">↓</tspan></text>
   <g
-     id="g4634"
-     transform="matrix(1.111111,0,0,1.111111,-76.86208,259.44906)">
-    <path
-       d="m 167.00762,39.539118 c 0,0 -0.46531,-0.370876 -0.74175,-0.370876 -0.55287,0 -1.09256,0.350814 -1.4835,0.741752 -0.58641,0.586406 -0.62773,1.552489 -1.11263,2.225255 -0.30668,0.425495 -0.68713,0.805948 -1.11263,1.112627 -0.67276,0.484903 -1.63885,0.526222 -2.22525,1.112628 -0.39094,0.390937 -0.74175,0.930634 -0.74175,1.483503 0,0.552869 0.43649,1.312961 0.74175,1.483503 0.96247,0.537721 0.31028,0.240518 0.74175,0.741752 0,0 -0.38587,1.22419 -0.37088,1.854379 0.0165,1.238632 0.45294,2.480604 0.74176,2.967007 0.18935,0.318895 1.34328,1.657344 2.22525,2.225255 0.88807,0.571841 1.97446,0.763668 3.02812,0.8376 1.13698,0.07978 2.21652,-0.132168 3.21565,-0.680635 0.61304,-0.336524 1.12013,-0.71383 1.54462,-1.269593 0.60499,-0.792083 1.22769,-1.632821 1.48351,-2.59613 0.15865,-0.597419 0.0755,-1.240885 0,-1.85438 -0.0623,-0.505901 -0.47178,-0.983869 -0.37088,-1.483503 0.12236,-0.605895 0.86033,-0.919212 1.11263,-1.483503 0.2573,-0.575467 0.62589,-1.277899 0.37087,-1.854379 -0.29162,-0.659231 -1.24525,-0.727152 -1.85438,-1.112628 -0.37665,-0.238358 -0.78107,-0.443829 -1.11262,-0.741752 -0.71819,-0.645351 -1.2767,-1.451586 -1.85438,-2.225255 -0.26668,-0.357158 -0.38752,-0.842067 -0.74175,-1.112627 -0.31068,-0.237297 -0.73215,-0.460695 -1.11263,-0.370876 -0.17016,0.04017 -0.37088,0.370876 -0.37088,0.370876"
-       id="path4725"
-       style="fill:#ffc1c1;fill-opacity:1;stroke:#ff0000;stroke-width:0.37087584px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4505-6"
-       d="m 172.57866,47.803117 c 0,0 0.54294,2.128427 0.37128,3.183536 -0.18671,1.147562 -0.64302,2.34396 -1.48511,3.183536 -0.76475,0.762463 -1.18949,1.049013 -2.22767,1.414905 -0.47858,0.168668 -1.84456,0.353726 -2.4159,0.353726 -0.57135,0 -1.93733,-0.185059 -2.41591,-0.353727 -1.03818,-0.365892 -1.46292,-0.652441 -2.22766,-1.414904 -0.84209,-0.839576 -1.29841,-2.035975 -1.48512,-3.183536 -0.17166,-1.055109 0.37128,-3.183536 0.37128,-3.183536 m 4.82661,-2.122358 c 0,0 -1.52881,1.745204 -2.59894,2.122358 -0.69643,0.245448 -1.5584,0.30646 -2.22767,0 -0.71423,-0.327051 -1.32906,-1.028431 -1.48511,-1.768631 -0.17743,-0.841581 0.2073,-1.529325 0.91624,-2.050581 0.76674,-0.563756 1.70542,-0.616723 2.42526,-1.132956 0.93281,-0.668963 1.08012,-1.998936 1.85639,-2.829809 0.52688,-0.563939 2.04463,-1.414905 2.04463,-1.414905 0,0 1.51774,0.850966 2.04462,1.414905 0.77627,0.830873 0.92358,2.160847 1.85639,2.82981 0.71984,0.516232 1.68334,0.54353 2.45008,1.085677 0.71847,0.508023 1.06885,1.256279 0.89142,2.097859 -0.15605,0.740201 -0.77087,1.44158 -1.48511,1.768631 -0.66927,0.30646 -1.53123,0.245448 -2.22767,0 -1.07013,-0.377153 -2.59894,-2.122357 -2.59894,-2.122357" />
+     transform="translate(17.5,42.921537)"
+     id="g6836">
     <g
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.37127797,0,0,0.35372622,176.72956,39.358074)"
-       id="g4565">
-      <g
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1"
-         transform="translate(0,-1)"
-         id="g4553">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-7"
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-5"
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285" />
-      </g>
-      <g
-         style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-opacity:1"
-         id="g4557">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-3"
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-56"
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075" />
-      </g>
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.37127797,0,0,0.35372622,176.92563,38.650622)"
-       id="g4636">
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="circle3409-2"
-         cy="14.612609"
-         cx="-30.836912" />
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="ellipse4229-9"
-         cy="14.699166"
-         cx="-23.593306" />
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.37127797,0,0,0.35372622,176.96142,38.650622)"
-       id="g4632">
+       transform="scale(1.5)"
+       id="g6834">
       <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1"
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1-2"
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25" />
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 36.147461 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6824"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6828">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan6826">note value</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6832">
+        <tspan
+           x="61.480793"
+           y="11.25"
+           id="tspan6830" />
+      </text>
     </g>
-    <path
-       style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.80251253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4227-7"
-       d="m 167.72688,38.606235 c -0.51355,0.487351 -0.73647,0.882428 -0.91229,0.882428 -0.24578,0 -0.47204,-0.395077 -0.91229,-0.882428 -0.36084,-0.399437 0.40844,-0.882428 0.91229,-0.882428 0.50385,0 1.3103,0.504726 0.91229,0.882428 z" />
-    <path
-       d="m 167.04984,55.935948 c 0,0 0.26819,1.158553 2.03989,1.361113 1.77169,0.202559 4.37064,-1.401457 5.48447,-3.523814 1.11384,-2.122358 0.8911,-4.261654 1.11384,-6.720799"
-       id="path4653"
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:0.72479171;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
   <g
-     id="g4859"
-     transform="translate(-56.437395,272.39608)">
-    <path
-       d="m 165.13932,265.36033 c 0,0 -0.51702,-0.41209 -0.82417,-0.41209 -0.6143,0 -1.21396,0.3898 -1.64833,0.82417 -0.65157,0.65157 -0.69748,1.72499 -1.23626,2.47251 -0.34076,0.47277 -0.76348,0.8955 -1.23625,1.23625 -0.74752,0.53878 -1.82095,0.58469 -2.4725,1.23625 -0.43438,0.43438 -0.82417,1.03404 -0.82417,1.64834 0,0.6143 0.48499,1.45885 0.82417,1.64834 1.06941,0.59746 0.34475,0.26724 0.82416,0.82417 0,0 -0.42874,1.36021 -0.41209,2.06042 0.0183,1.37625 0.50327,2.75622 0.82418,3.29667 0.21039,0.35433 1.49253,1.84149 2.4725,2.47251 0.98674,0.63537 2.19384,0.84852 3.36458,0.93066 1.26331,0.0887 2.4628,-0.14685 3.57294,-0.75626 0.68116,-0.37391 1.24459,-0.79314 1.71625,-1.41066 0.67221,-0.88009 1.3641,-1.81424 1.64834,-2.88459 0.17628,-0.66379 0.0839,-1.37876 0,-2.06042 -0.0692,-0.56211 -0.5242,-1.09319 -0.41209,-1.64833 0.13596,-0.67322 0.95592,-1.02135 1.23626,-1.64834 0.28589,-0.63941 0.69543,-1.41989 0.41207,-2.06042 -0.32402,-0.73248 -1.38361,-0.80795 -2.06042,-1.23625 -0.4185,-0.26485 -0.86785,-0.49315 -1.23624,-0.82417 -0.79799,-0.71706 -1.41856,-1.61288 -2.06042,-2.47251 -0.29631,-0.39684 -0.43058,-0.93563 -0.82417,-1.23625 -0.3452,-0.26366 -0.8135,-0.51188 -1.23626,-0.41209 -0.18906,0.0446 -0.41208,0.41209 -0.41208,0.41209"
-       id="path4725-61"
-       style="fill:#fffbc1;fill-opacity:1;stroke:#9f9607;stroke-width:0.41208422px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-width:0.80532402;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4505-6-8"
-       d="m 171.32936,274.54255 c 0,0 0.60327,2.36492 0.41253,3.53726 -0.20745,1.27507 -0.71446,2.6044 -1.65012,3.53726 -0.84972,0.84718 -1.32165,1.16557 -2.47519,1.57212 -0.53175,0.18741 -2.04951,0.39303 -2.68433,0.39303 -0.63483,0 -2.15259,-0.20562 -2.68435,-0.39303 -1.15353,-0.40655 -1.62546,-0.72494 -2.47517,-1.57212 -0.93566,-0.93286 -1.44268,-2.26219 -1.65014,-3.53726 -0.19073,-1.17234 0.41254,-3.53726 0.41254,-3.53726 m 5.3629,-2.35818 c 0,0 -1.69868,1.93912 -2.88771,2.35818 -0.77381,0.27272 -1.73156,0.34051 -2.47519,0 -0.79359,-0.36339 -1.47674,-1.1427 -1.65012,-1.96515 -0.19715,-0.93509 0.23033,-1.69925 1.01804,-2.27842 0.85193,-0.62639 1.89491,-0.68525 2.69473,-1.25884 1.03646,-0.74329 1.20014,-2.22104 2.06266,-3.14423 0.58542,-0.6266 2.27181,-1.57212 2.27181,-1.57212 0,0 1.68638,0.94552 2.2718,1.57212 0.86252,0.92319 1.0262,2.40094 2.06265,3.14423 0.79983,0.57359 1.87038,0.60392 2.72231,1.20631 0.7983,0.56447 1.18762,1.39586 0.99047,2.33095 -0.17339,0.82245 -0.85652,1.60176 -1.65012,1.96515 -0.74363,0.34051 -1.70137,0.27272 -2.47519,0 -1.18903,-0.41906 -2.88771,-2.35818 -2.88771,-2.35818" />
+     transform="translate(113.72119,42.921537)"
+     id="g6854">
     <g
-       style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.41253104,0,0,0.39302909,175.94147,265.15917)"
-       id="g4565-7">
-      <g
-         style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-opacity:1"
-         transform="translate(0,-1)"
-         id="g4553-9">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-7-2"
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-5-0"
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285" />
-      </g>
-      <g
-         style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-opacity:1"
-         id="g4557-23">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-3-7"
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-56-5"
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075" />
-      </g>
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.41253104,0,0,0.39302909,176.15933,264.37311)"
-       id="g4636-9">
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="circle3409-2-2"
-         cy="14.612609"
-         cx="-30.836912" />
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="ellipse4229-9-2"
-         cy="14.699166"
-         cx="-23.593306" />
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.41253104,0,0,0.39302909,176.19909,264.37311)"
-       id="g4632-8">
+       transform="scale(1.5)"
+       id="g6852">
       <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1-9"
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1-2-7"
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25" />
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6838"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6842">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan6840">/</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6846">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan6844" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6850">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan6848" />
+      </text>
     </g>
-    <path
-       style="fill:#9f9607;fill-opacity:1;fill-rule:evenodd;stroke:#9f9607;stroke-width:0.89168048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4227-7-3"
-       d="m 165.93849,264.32379 c -0.57061,0.5415 -0.8183,0.98048 -1.01365,0.98048 -0.27309,0 -0.52449,-0.43898 -1.01366,-0.98048 -0.40093,-0.44382 0.45382,-0.98047 1.01366,-0.98047 0.55983,0 1.45589,0.5608 1.01365,0.98047 z" />
-    <path
-       d="m 165.18623,283.57903 c 0,0 0.29799,1.28728 2.26654,1.51234 1.96855,0.22507 4.85627,-1.55717 6.09386,-3.91534 1.2376,-2.35818 0.99011,-4.73517 1.2376,-7.46756"
-       id="path4653-61"
-       style="fill:none;fill-opacity:1;stroke:#9f9607;stroke-width:0.80532402;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
   <g
-     transform="translate(403.70902,-322.98221)"
-     id="g4846">
-    <path
-       d="m 108.21551,345.46506 c 0,0 -0.51701,-0.41208 -0.82417,-0.41208 -0.6143,0 -1.21395,0.38979 -1.64833,0.82417 -0.65157,0.65156 -0.69748,1.72499 -1.23625,2.4725 -0.34076,0.47278 -0.76348,0.8955 -1.23626,1.23626 -0.74751,0.53878 -1.82094,0.58469 -2.4725,1.23625 -0.43438,0.43437 -0.824165,1.03404 -0.824165,1.64834 0,0.61429 0.484985,1.45884 0.824165,1.64833 1.06941,0.59747 0.34476,0.26724 0.82417,0.82417 0,0 -0.42875,1.36021 -0.41209,2.06042 0.0183,1.37626 0.50327,2.75623 0.82418,3.29668 0.21039,0.35432 1.49253,1.84149 2.4725,2.4725 0.98674,0.63538 2.19384,0.84852 3.36457,0.93067 1.26331,0.0886 2.4628,-0.14686 3.57295,-0.75626 0.68115,-0.37392 1.24459,-0.79315 1.71624,-1.41066 0.67221,-0.88009 1.3641,-1.81425 1.64835,-2.88459 0.17627,-0.6638 0.0839,-1.37876 0,-2.06042 -0.0692,-0.56211 -0.5242,-1.09319 -0.41209,-1.64834 0.13595,-0.67322 0.95592,-1.02135 1.23625,-1.64834 0.28589,-0.6394 0.69543,-1.41988 0.41208,-2.06042 -0.32402,-0.73247 -1.38361,-0.80794 -2.06042,-1.23625 -0.4185,-0.26484 -0.86786,-0.49314 -1.23625,-0.82417 -0.79799,-0.71705 -1.41855,-1.61287 -2.06042,-2.4725 -0.29631,-0.39685 -0.43058,-0.93563 -0.82416,-1.23626 -0.3452,-0.26366 -0.8135,-0.51188 -1.23626,-0.41208 -0.18907,0.0446 -0.41209,0.41208 -0.41209,0.41208"
-       id="path4725-6"
-       style="fill:#a0b6ff;fill-opacity:1;stroke:#003cff;stroke-width:0.41208419px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#003cff;stroke-width:0.80532396;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4505-6-7"
-       d="m 114.40555,354.64728 c 0,0 0.60327,2.36492 0.41254,3.53727 -0.20746,1.27506 -0.71447,2.6044 -1.65012,3.53726 -0.84973,0.84718 -1.32166,1.16557 -2.47519,1.57211 -0.53176,0.18741 -2.04951,0.39303 -2.68434,0.39303 -0.63483,0 -2.15258,-0.20562 -2.68434,-0.39303 -1.15353,-0.40654 -1.62547,-0.72493 -2.47518,-1.57211 -0.93565,-0.93286 -1.44267,-2.2622 -1.65013,-3.53726 -0.19073,-1.17235 0.41253,-3.53727 0.41253,-3.53727 m 5.3629,-2.35817 c 0,0 -1.69868,1.93911 -2.88771,2.35817 -0.77381,0.27272 -1.73155,0.34052 -2.47519,0 -0.79359,-0.36339 -1.47673,-1.1427 -1.650119,-1.96514 -0.197144,-0.93509 0.230329,-1.69925 1.018049,-2.27842 0.85193,-0.6264 1.89491,-0.68525 2.69473,-1.25884 1.03645,-0.7433 1.20013,-2.22104 2.06265,-3.14424 0.58543,-0.62659 2.27181,-1.57211 2.27181,-1.57211 0,0 1.68638,0.94552 2.2718,1.57211 0.86253,0.9232 1.0262,2.40095 2.06266,3.14424 0.79982,0.57359 1.87038,0.60392 2.72231,1.20631 0.7983,0.56447 1.18761,1.39586 0.99047,2.33095 -0.17339,0.82244 -0.85653,1.60175 -1.65013,1.96514 -0.74363,0.34052 -1.70136,0.27272 -2.47518,0 -1.18904,-0.41905 -2.88771,-2.35817 -2.88771,-2.35817" />
+     transform="translate(199.22119,42.921537)"
+     id="g6864">
     <g
-       style="fill:none;fill-opacity:1;stroke:#003cff;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.412531,0,0,0.39302906,119.01766,345.26391)"
-       id="g4565-5">
-      <g
-         style="fill:none;fill-opacity:1;stroke:#003cff;stroke-opacity:1"
-         transform="translate(0,-1)"
-         id="g4553-3">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-7-5"
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-5-6"
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285" />
-      </g>
-      <g
-         style="fill:none;fill-opacity:1;stroke:#003cff;stroke-opacity:1"
-         id="g4557-2">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-3-9"
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-56-1"
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075" />
-      </g>
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#003cff;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.412531,0,0,0.39302906,119.23552,344.47785)"
-       id="g4636-2">
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="circle3409-2-7"
-         cy="14.612609"
-         cx="-30.836912" />
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="ellipse4229-9-0"
-         cy="14.699166"
-         cx="-23.593306" />
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#003cff;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.412531,0,0,0.39302906,119.27529,344.47785)"
-       id="g4632-9">
+       transform="scale(1.5)"
+       id="g6862">
       <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1-3"
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1-2-6"
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25" />
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6856"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6860">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6858">1</tspan>
+      </text>
     </g>
-    <path
-       style="fill:#003cff;fill-opacity:1;fill-rule:evenodd;stroke:#003cff;stroke-width:0.89168042;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4227-7-0"
-       d="m 109.01469,344.42853 c -0.57061,0.5415 -0.8183,0.98047 -1.01366,0.98047 -0.27309,0 -0.52449,-0.43897 -1.01365,-0.98047 -0.40094,-0.44382 0.45382,-0.98048 1.01365,-0.98048 0.55984,0 1.45589,0.56081 1.01366,0.98048 z" />
-    <path
-       d="m 108.26242,363.68376 c 0,0 0.29799,1.28728 2.26655,1.51235 1.96854,0.22506 4.85626,-1.55718 6.09385,-3.91535 1.2376,-2.35817 0.99011,-4.73517 1.2376,-7.46755"
-       id="path4653-6"
-       style="fill:none;fill-opacity:1;stroke:#003cff;stroke-width:0.80532396;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
   <g
-     id="g4757"
-     transform="translate(30.39399,476.05633)">
-    <path
-       d="m 481.53054,20.45008 c 0,0 -0.51701,-0.41208 -0.82417,-0.41208 -0.6143,0 -1.21395,0.38979 -1.64833,0.82417 -0.65157,0.65156 -0.69748,1.72499 -1.23625,2.4725 -0.34076,0.47278 -0.76348,0.8955 -1.23626,1.23626 -0.74751,0.53878 -1.82094,0.58469 -2.4725,1.23625 -0.43438,0.43437 -0.82417,1.03404 -0.82417,1.64834 0,0.61429 0.48499,1.45884 0.82417,1.64833 1.06941,0.59747 0.34476,0.26724 0.82417,0.82417 0,0 -0.42875,1.36021 -0.41209,2.06042 0.0183,1.37626 0.50327,2.75623 0.82418,3.29668 0.21039,0.35432 1.49253,1.84149 2.4725,2.4725 0.98674,0.63538 2.19384,0.84852 3.36457,0.93067 1.26331,0.0886 2.4628,-0.14686 3.57295,-0.75626 0.68115,-0.37392 1.24459,-0.79315 1.71624,-1.41066 0.67221,-0.88009 1.3641,-1.81425 1.64835,-2.88459 0.17627,-0.6638 0.0839,-1.37876 0,-2.06042 -0.0692,-0.56211 -0.5242,-1.09319 -0.41209,-1.64834 0.13595,-0.67322 0.95592,-1.02135 1.23625,-1.64834 0.28589,-0.6394 0.69543,-1.41988 0.41208,-2.06042 -0.32402,-0.73247 -1.38361,-0.80794 -2.06042,-1.23625 -0.4185,-0.26484 -0.86786,-0.49314 -1.23625,-0.82417 -0.79799,-0.71705 -1.41855,-1.61287 -2.06042,-2.4725 -0.29631,-0.39685 -0.43058,-0.93563 -0.82416,-1.23626 -0.3452,-0.26366 -0.8135,-0.51188 -1.23626,-0.41208 -0.18907,0.0446 -0.41209,0.41208 -0.41209,0.41208"
-       id="path4725-6-6"
-       style="fill:#a0ffa4;fill-opacity:1;stroke:#079f0d;stroke-width:0.41208419px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-width:0.80532396;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4505-6-7-7"
-       d="m 487.72058,29.6323 c 0,0 0.60327,2.36492 0.41254,3.53727 -0.20746,1.27506 -0.71447,2.6044 -1.65012,3.53726 -0.84973,0.84718 -1.32166,1.16557 -2.47519,1.57211 -0.53176,0.18741 -2.04951,0.39303 -2.68434,0.39303 -0.63483,0 -2.15258,-0.20562 -2.68434,-0.39303 -1.15353,-0.40654 -1.62547,-0.72493 -2.47518,-1.57211 -0.93565,-0.93286 -1.44267,-2.2622 -1.65013,-3.53726 -0.19073,-1.17235 0.41253,-3.53727 0.41253,-3.53727 m 5.3629,-2.35817 c 0,0 -1.69868,1.93911 -2.88771,2.35817 -0.77381,0.27272 -1.73155,0.34052 -2.47519,0 -0.79359,-0.36339 -1.47673,-1.1427 -1.65012,-1.96514 -0.19714,-0.93509 0.23033,-1.69925 1.01805,-2.27842 0.85193,-0.6264 1.89491,-0.68525 2.69473,-1.25884 1.03645,-0.7433 1.20013,-2.22104 2.06265,-3.14424 0.58543,-0.62659 2.27181,-1.57211 2.27181,-1.57211 0,0 1.68638,0.94552 2.2718,1.57211 0.86253,0.9232 1.0262,2.40095 2.06266,3.14424 0.79982,0.57359 1.87038,0.60392 2.72231,1.20631 0.7983,0.56447 1.18761,1.39586 0.99047,2.33095 -0.17339,0.82244 -0.85653,1.60175 -1.65013,1.96514 -0.74363,0.34052 -1.70136,0.27272 -2.47518,0 -1.18904,-0.41905 -2.88771,-2.35817 -2.88771,-2.35817" />
+     transform="translate(199.22119,74.421537)"
+     id="g6874">
     <g
-       style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.412531,0,0,0.39302906,492.33269,20.24893)"
-       id="g4565-5-5">
-      <g
-         style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-opacity:1"
-         transform="translate(0,-1)"
-         id="g4553-3-3">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-7-5-5"
-           d="M -30.228157,8.514322 C -33.422908,9.40349 -38.624018,5.874516 -40.102591,4.585664" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-5-6-6"
-           d="M -29.760199,5.904536 C -33.101366,5.473905 -35.931474,3.7361852 -37.633646,2.3416285" />
-      </g>
-      <g
-         style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-opacity:1"
-         id="g4557-2-2">
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3411-3-9-9"
-           d="m -23.145912,7.514322 c 3.194751,0.889168 8.395861,-2.639806 9.874434,-3.928658" />
-        <path
-           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.93205309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path3413-56-1-1"
-           d="m -23.61387,4.904536 c 3.341167,-0.430631 6.171275,-2.168351 7.873447,-3.5629075" />
-      </g>
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.412531,0,0,0.39302906,492.55055,19.46287)"
-       id="g4636-2-2">
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="circle3409-2-7-7"
-         cy="14.612609"
-         cx="-30.836912" />
-      <ellipse
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         ry="2.0666313"
-         rx="1.8846371"
-         id="ellipse4229-9-0-0"
-         cy="14.699166"
-         cx="-23.593306" />
-    </g>
-    <g
-       style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0.412531,0,0,0.39302906,492.59032,19.46287)"
-       id="g4632-9-9">
+       transform="scale(1.5)"
+       id="g6872">
       <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1-3-3"
-         d="m -37.186516,14.624518 c -14.340024,2.75008 -4.810404,15.671871 4.375,5.25" />
-      <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4303-1-2-6-6"
-         d="m -17.436517,14.624518 c 14.3400245,2.75008 4.810404,15.671872 -4.375,5.25" />
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6866"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6870">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6868">1</tspan>
+      </text>
     </g>
-    <path
-       style="fill:#079f0d;fill-opacity:1;fill-rule:evenodd;stroke:#079f0d;stroke-width:0.89168042;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4227-7-0-0"
-       d="m 482.32972,19.41355 c -0.57061,0.5415 -0.8183,0.98047 -1.01366,0.98047 -0.27309,0 -0.52449,-0.43897 -1.01365,-0.98047 -0.40094,-0.44382 0.45382,-0.98048 1.01365,-0.98048 0.55984,0 1.45589,0.56081 1.01366,0.98048 z" />
-    <path
-       d="m 481.57745,38.66878 c 0,0 0.29799,1.28728 2.26655,1.51235 1.96854,0.22506 4.85626,-1.55718 6.09385,-3.91535 1.2376,-2.35817 0.99011,-4.73517 1.2376,-7.46755"
-       id="path4653-6-6"
-       style="fill:none;fill-opacity:1;stroke:#079f0d;stroke-width:0.80532396;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <g
+     transform="translate(31,74.421537)"
+     id="g6884">
+    <g
+       transform="scale(1.5)"
+       id="g6882">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6876"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6880">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan6878">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(31,105.92154)"
+     id="g6894">
+    <g
+       transform="scale(1.5)"
+       id="g6892">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 31.12793 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ff8b2d;fill-opacity:1;stroke:#520000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6886"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6890">
+        <tspan
+           x="47.461262"
+           y="13.5"
+           id="tspan6888">silence</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(4,2.4215375)"
+     id="g6908">
+    <g
+       transform="scale(1.5)"
+       id="g6906">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6896"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6900">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan6898">action</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6904">
+        <tspan
+           x="60.333332"
+           y="5.25"
+           id="tspan6902" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(98.5,11.421537)"
+     id="g6918">
+    <g
+       transform="scale(1.5)"
+       id="g6916">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6910"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6914">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6912">delay</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.83333,263.92154)"
+     id="g6932">
+    <g
+       transform="scale(1.5)"
+       id="g6930">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6920"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6924">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan6922">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6928">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan6926" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.83333,263.92154)"
+     id="g6942">
+    <g
+       transform="scale(1.5)"
+       id="g6940">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6934"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6938">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6936">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27.33333,295.42154)"
+     id="g6952">
+    <g
+       transform="scale(1.5)"
+       id="g6950">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6944"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6948">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan6946">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(327,0.42153745)"
+     id="g6962">
+    <g
+       transform="scale(1.5)"
+       id="g6960">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 168 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6954"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6958">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan6956">start</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(340.5,40.921537)"
+     id="g6976">
+    <g
+       transform="scale(1.5)"
+       id="g6974">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6964"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6968">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan6966">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6972">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan6970" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(412.5,40.921537)"
+     id="g6986">
+    <g
+       transform="scale(1.5)"
+       id="g6984">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6978"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text6982">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan6980">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(354,72.421537)"
+     id="g6996">
+    <g
+       transform="scale(1.5)"
+       id="g6994">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6988"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6992">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan6990">delay</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(340.5,135.42154)"
+     id="g7010">
+    <g
+       transform="scale(1.5)"
+       id="g7008">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6998"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7002">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7000">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7006">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan7004" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(503.40088,135.42154)"
+     id="g7028">
+    <g
+       transform="scale(1.5)"
+       id="g7026">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7012"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7016">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7014">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7020">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7018" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7024">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7022" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(588.90088,135.42154)"
+     id="g7038">
+    <g
+       transform="scale(1.5)"
+       id="g7036">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7030"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7034">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7032">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(588.90088,166.92154)"
+     id="g7056">
+    <g
+       transform="scale(1.5)"
+       id="g7054">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7040"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7044">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7042">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7048">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7046" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7052">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7050" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(674.40088,166.92154)"
+     id="g7066">
+    <g
+       transform="scale(1.5)"
+       id="g7064">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7058"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7062">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7060">-1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(674.40088,198.42154)"
+     id="g7076">
+    <g
+       transform="scale(1.5)"
+       id="g7074">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7068"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7072">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7070">12</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(354,166.92154)"
+     id="g7086">
+    <g
+       transform="scale(1.5)"
+       id="g7084">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7078"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7082">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7080">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(354,198.42154)"
+     id="g7100">
+    <g
+       transform="scale(1.5)"
+       id="g7098">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7088"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7092">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7090">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7096">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan7094" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(426,198.42154)"
+     id="g7110">
+    <g
+       transform="scale(1.5)"
+       id="g7108">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7102"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7106">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7104">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(367.5,229.92154)"
+     id="g7120">
+    <g
+       transform="scale(1.5)"
+       id="g7118">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7112"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7116">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan7114">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(0,410.42154)"
+     id="g7130">
+    <g
+       transform="scale(1.5)"
+       id="g7128">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 168 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7122"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7126">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan7124">start</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(467.73035,391.62208)"
+     id="g7140">
+    <g
+       transform="scale(1.5)"
+       id="g7138">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 168 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7132"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7136">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan7134">start</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,450.92154)"
+     id="g7154">
+    <g
+       transform="scale(1.5)"
+       id="g7152">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7142"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7146">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7144">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7150">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan7148" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.5,450.92154)"
+     id="g7164">
+    <g
+       transform="scale(1.5)"
+       id="g7162">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7156"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7160">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7158">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,482.42154)"
+     id="g7174">
+    <g
+       transform="scale(1.5)"
+       id="g7172">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7166"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7170">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan7168">delay</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.5,545.42154)"
+     id="g7188">
+    <g
+       transform="scale(1.5)"
+       id="g7186">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7176"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7180">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7178">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7184">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan7182" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(176.40088,545.42154)"
+     id="g7206">
+    <g
+       transform="scale(1.5)"
+       id="g7204">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7190"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7194">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7192">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7198">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7196" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7202">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7200" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(261.90088,545.42154)"
+     id="g7216">
+    <g
+       transform="scale(1.5)"
+       id="g7214">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7208"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7212">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7210">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(261.90088,576.92154)"
+     id="g7234">
+    <g
+       transform="scale(1.5)"
+       id="g7232">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7218"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7222">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7220">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7226">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7224" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7230">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7228" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(347.40088,576.92154)"
+     id="g7244">
+    <g
+       transform="scale(1.5)"
+       id="g7242">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7236"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7240">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7238">1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(347.40088,608.42154)"
+     id="g7254">
+    <g
+       transform="scale(1.5)"
+       id="g7252">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7246"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7250">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7248">12</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,576.92154)"
+     id="g7264">
+    <g
+       transform="scale(1.5)"
+       id="g7262">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7256"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7260">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7258">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(27,608.42154)"
+     id="g7278">
+    <g
+       transform="scale(1.5)"
+       id="g7276">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7266"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7270">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7268">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7274">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan7272" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(99,608.42154)"
+     id="g7288">
+    <g
+       transform="scale(1.5)"
+       id="g7286">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7280"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7284">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7282">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(40.5,639.92154)"
+     id="g7298">
+    <g
+       transform="scale(1.5)"
+       id="g7296">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7290"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7294">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan7292">action</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(479.73035,430.62208)"
+     id="g7312">
+    <g
+       transform="scale(1.5)"
+       id="g7310">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7300"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7304">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7302">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7308">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan7306" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(550.23035,432.12208)"
+     id="g7322">
+    <g
+       transform="scale(1.5)"
+       id="g7320">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7314"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7318">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7316">6</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(491.73035,460.62208)"
+     id="g7332">
+    <g
+       transform="scale(1.5)"
+       id="g7330">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7324"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7328">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan7326">delay</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(478.23035,523.62208)"
+     id="g7346">
+    <g
+       transform="scale(1.5)"
+       id="g7344">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7334"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7338">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7336">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7342">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan7340" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(641.30176,530.92154)"
+     id="g7364">
+    <g
+       transform="scale(1.5)"
+       id="g7362">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7348"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7352">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7350">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7356">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7354" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7360">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7358" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(725.30176,529.42154)"
+     id="g7374">
+    <g
+       transform="scale(1.5)"
+       id="g7372">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7366"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7370">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7368">0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(725.30176,560.92154)"
+     id="g7392">
+    <g
+       transform="scale(1.5)"
+       id="g7390">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7376"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7380">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan7378">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7384">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan7382" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7388">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan7386" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(809.30176,562.42154)"
+     id="g7402">
+    <g
+       transform="scale(1.5)"
+       id="g7400">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7394"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7398">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7396">-2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(809.30176,592.42154)"
+     id="g7412">
+    <g
+       transform="scale(1.5)"
+       id="g7410">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7404"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7408">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7406">12</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(490.40088,563.92154)"
+     id="g7422">
+    <g
+       transform="scale(1.5)"
+       id="g7420">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 20 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#d57e6f;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7414"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7418">
+        <tspan
+           x="36.333332"
+           y="13.5"
+           id="tspan7416">↓</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(488.90088,593.92154)"
+     id="g7436">
+    <g
+       transform="scale(1.5)"
+       id="g7434">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7424"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7428">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan7426">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7432">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan7430" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(559.40088,595.42154)"
+     id="g7446">
+    <g
+       transform="scale(1.5)"
+       id="g7444">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7438"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text7442">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan7440">4</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(500.90088,626.92154)"
+     id="g7456">
+    <g
+       transform="scale(1.5)"
+       id="g7454">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path7448"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text7452">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan7450">action</tspan>
+      </text>
+    </g>
   </g>
 </svg>

--- a/guide/voices5.svg
+++ b/guide/voices5.svg
@@ -5,12 +5,16 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   id="svg2490"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="970.56757"
+   height="654.84308"
    version="1.1"
-   height="638.02521"
-   width="710.37616">
+   id="svg6154"
+   sodipodi:docname="voices5.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <metadata
-     id="metadata2496">
+     id="metadata6160">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -22,1308 +26,1691 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs2494" />
+     id="defs6158" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="662"
+     inkscape:window-height="480"
+     id="namedview6156"
+     showgrid="false"
+     inkscape:zoom="0.2079063"
+     inkscape:cx="576.66667"
+     inkscape:cy="400.42154"
+     inkscape:window-x="0"
+     inkscape:window-y="282"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6154" />
   <g
-     transform="translate(-252.9767)"
-     id="g7248">
+     transform="translate(-3.3333333e-6,2.4215375)"
+     id="g5266">
     <g
-       id="g6961"
-       transform="translate(68.342303,-77.578463)">
-      <g
-         id="g302"
-         transform="translate(424,78)">
-        <g
-           id="g300"
-           transform="scale(1.5)">
-          <path
-             id="path294"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text298"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan296"
-               y="21.5"
-               x="5.3333335">start</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g6934">
-        <g
-           transform="translate(437.5,118.5)"
-           id="g2040">
-          <g
-             transform="scale(1.5)"
-             id="g2038">
-            <path
-               d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
-               style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-               id="path2024" />
-            <text
-               style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
-               id="text2028">
-              <tspan
-                 x="46.333332"
-                 y="24"
-                 id="tspan2026">on</tspan>
-            </text>
-            <text
-               style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
-               id="text2032">
-              <tspan
-                 x="46.333332"
-                 y="11.25"
-                 id="tspan2030">event</tspan>
-            </text>
-            <text
-               style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
-               id="text2036">
-              <tspan
-                 x="46.333332"
-                 y="32.25"
-                 id="tspan2034">do</tspan>
-            </text>
-          </g>
-        </g>
-        <g
-           transform="translate(511,118.5)"
-           id="g2050">
-          <g
-             transform="scale(1.5)"
-             id="g2048">
-            <path
-               d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
-               style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-               id="path2042" />
-            <text
-               style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-               id="text2046">
-              <tspan
-                 x="13.333333"
-                 y="13.833333"
-                 id="tspan2044">b</tspan>
-            </text>
-          </g>
-        </g>
-        <g
-           transform="translate(511,150)"
-           id="g2060">
-          <g
-             transform="scale(1.5)"
-             id="g2058">
-            <path
-               d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
-               style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-               id="path2052" />
-            <text
-               style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-               id="text2056">
-              <tspan
-                 x="13.333333"
-                 y="13.833333"
-                 id="tspan2054">b</tspan>
-            </text>
-          </g>
-        </g>
-      </g>
-    </g>
-    <g
-       id="g6844"
-       transform="translate(-2.657697,25.51267)">
-      <g
-         id="g1182"
-         transform="translate(495,190)">
-        <g
-           id="g1180"
-           transform="scale(1.5)">
-          <path
-             id="path1174"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text1178"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan1176"
-               y="21.5"
-               x="5.3333335">start</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2238"
-         transform="translate(508.5,230.5)">
-        <g
-           id="g2236"
-           transform="scale(1.5)">
-          <path
-             id="path2222"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z" />
-          <text
-             id="text2226"
-             style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2224"
-               y="24"
-               x="46.333332">on</tspan>
-          </text>
-          <text
-             id="text2230"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2228"
-               y="11.25"
-               x="46.333332">event</tspan>
-          </text>
-          <text
-             id="text2234"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2232"
-               y="32.25"
-               x="46.333332">do</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2248"
-         transform="translate(582,230.5)">
-        <g
-           id="g2246"
-           transform="scale(1.5)">
-          <path
-             id="path2240"
-             style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text2244"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2242"
-               y="13.833333"
-               x="13.333333">c</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2258"
-         transform="translate(582,262)">
-        <g
-           id="g2256"
-           transform="scale(1.5)">
-          <path
-             id="path2250"
-             style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text2254"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2252"
-               y="13.833333"
-               x="13.333333">c</tspan>
-          </text>
-        </g>
-      </g>
-    </g>
-    <g
-       id="g6913"
-       transform="translate(87.342303,-39.39636)">
-      <g
-         id="g1202"
-         transform="translate(405,470)">
-        <g
-           id="g1200"
-           transform="scale(1.5)">
-          <path
-             id="path1194"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text1198"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan1196"
-               y="21.5"
-               x="5.3333335">start</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2276"
-         transform="translate(418.5,510.5)">
-        <g
-           id="g2274"
-           transform="scale(1.5)">
-          <path
-             id="path2260"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z" />
-          <text
-             id="text2264"
-             style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2262"
-               y="24"
-               x="46.333332">on</tspan>
-          </text>
-          <text
-             id="text2268"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2266"
-               y="11.25"
-               x="46.333332">event</tspan>
-          </text>
-          <text
-             id="text2272"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2270"
-               y="32.25"
-               x="46.333332">do</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2286"
-         transform="translate(492,510.5)">
-        <g
-           id="g2284"
-           transform="scale(1.5)">
-          <path
-             id="path2278"
-             style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text2282"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2280"
-               y="13.833333"
-               x="13.333333">d</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2296"
-         transform="translate(492,542)">
-        <g
-           id="g2294"
-           transform="scale(1.5)">
-          <path
-             id="path2288"
-             style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text2292"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2290"
-               y="13.833333"
-               x="13.333333">d</tspan>
-          </text>
-        </g>
-      </g>
+       transform="scale(1.5)"
+       id="g5264">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 315 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5258"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5262">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan5260">start</tspan>
+      </text>
     </g>
   </g>
   <g
-     transform="translate(-288.9767)"
-     id="g7376">
+     transform="translate(284.66667,3.4215375)"
+     id="g5276">
     <g
-       id="g7127"
-       transform="translate(92.10968,-164.48733)">
-      <g
-         id="g1212"
-         transform="translate(661,483.5)">
-        <g
-           id="g1210"
-           transform="scale(1.5)">
-          <path
-             id="path1204"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text1208"
-             style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan1206"
-               y="13.5"
-               x="56.333332">action</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g1332"
-         transform="translate(647.5,452)">
-        <g
-           id="g1330"
-           transform="scale(1.5)">
-          <path
-             id="path1320"
-             style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 76.16211 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text1324"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan1322"
-               y="15.25"
-               x="5.3333335">adjust transposition</tspan>
-          </text>
-          <text
-             id="text1328"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan1326"
-               y="11.25"
-               x="101.49545" />
-          </text>
-        </g>
-      </g>
-      <g
-         id="g1342"
-         transform="translate(803.74316,452)">
-        <g
-           id="g1340"
-           transform="scale(1.5)">
-          <path
-             id="path1334"
-             style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text1338"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan1336"
-               y="13.833333"
-               x="13.333333">-24</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2310"
-         transform="translate(634,380)">
-        <g
-           id="g2308"
-           transform="scale(1.5)">
-          <path
-             id="path2298"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text2302"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2300"
-               y="21.5"
-               x="5.3333335">action</tspan>
-          </text>
-          <text
-             id="text2306"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2304"
-               y="5.25"
-               x="60.333332" />
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2320"
-         transform="translate(728.5,389)">
-        <g
-           id="g2318"
-           transform="scale(1.5)">
-          <path
-             id="path2312"
-             style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text2316"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2314"
-               y="13.833333"
-               x="13.333333">c</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2406"
-         transform="translate(647.5,420.5)">
-        <g
-           id="g2404"
-           transform="scale(1.5)">
-          <path
-             id="path2394"
-             style="fill:#949494;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 53.354492 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text2398"
-             style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2396"
-               y="13.5"
-               x="69.687828">mouse sync</tspan>
-          </text>
-          <text
-             id="text2402"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2400"
-               y="11.25"
-               x="69.687828" />
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2416"
-         transform="translate(756.03174,420.5)">
-        <g
-           id="g2414"
-           transform="scale(1.5)">
-          <path
-             id="path2408"
-             style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text2412"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2410"
-               y="13.833333"
-               x="13.333333">Mr. Mouse</tspan>
-          </text>
-        </g>
-      </g>
-    </g>
-    <g
-       id="g6887"
-       transform="translate(444.10968,-199.39636)">
-      <g
-         id="g1192"
-         transform="translate(309,733.5)">
-        <g
-           id="g1190"
-           transform="scale(1.5)">
-          <path
-             id="path1184"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text1188"
-             style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan1186"
-               y="13.5"
-               x="56.333332">action</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g1356"
-         transform="translate(295.5,702)">
-        <g
-           id="g1354"
-           transform="scale(1.5)">
-          <path
-             id="path1344"
-             style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 76.16211 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text1348"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan1346"
-               y="15.25"
-               x="5.3333335">adjust transposition</tspan>
-          </text>
-          <text
-             id="text1352"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan1350"
-               y="11.25"
-               x="101.49545" />
-          </text>
-        </g>
-      </g>
-      <g
-         id="g1366"
-         transform="translate(451.74316,702)">
-        <g
-           id="g1364"
-           transform="scale(1.5)">
-          <path
-             id="path1358"
-             style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text1362"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan1360"
-               y="13.833333"
-               x="13.333333">12</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2334"
-         transform="translate(282,630)">
-        <g
-           id="g2332"
-           transform="scale(1.5)">
-          <path
-             id="path2322"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text2326"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2324"
-               y="21.5"
-               x="5.3333335">action</tspan>
-          </text>
-          <text
-             id="text2330"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2328"
-               y="5.25"
-               x="60.333332" />
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2344"
-         transform="translate(376.5,639)">
-        <g
-           id="g2342"
-           transform="scale(1.5)">
-          <path
-             id="path2336"
-             style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text2340"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2338"
-               y="13.833333"
-               x="13.333333">d</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2430"
-         transform="translate(295.5,670.5)">
-        <g
-           id="g2428"
-           transform="scale(1.5)">
-          <path
-             id="path2418"
-             style="fill:#949494;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 53.354492 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text2422"
-             style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2420"
-               y="13.5"
-               x="69.687828">mouse sync</tspan>
-          </text>
-          <text
-             id="text2426"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2424"
-               y="11.25"
-               x="69.687828" />
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2440"
-         transform="translate(404.03174,670.5)">
-        <g
-           id="g2438"
-           transform="scale(1.5)">
-          <path
-             id="path2432"
-             style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text2436"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2434"
-               y="13.833333"
-               x="13.333333">Mr. Mouse</tspan>
-          </text>
-        </g>
-      </g>
-    </g>
-    <g
-       id="g7170"
-       transform="translate(32.10968,-567.5784)">
-      <g
-         id="g1222"
-         transform="translate(721,671.5)">
-        <g
-           id="g1220"
-           transform="scale(1.5)">
-          <path
-             id="path1214"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text1218"
-             style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan1216"
-               y="13.5"
-               x="56.333332">action</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g1380"
-         transform="translate(707.5,640)">
-        <g
-           id="g1378"
-           transform="scale(1.5)">
-          <path
-             id="path1368"
-             style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 76.16211 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text1372"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan1370"
-               y="15.25"
-               x="5.3333335">adjust transposition</tspan>
-          </text>
-          <text
-             id="text1376"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan1374"
-               y="11.25"
-               x="101.49545" />
-          </text>
-        </g>
-      </g>
-      <g
-         id="g1390"
-         transform="translate(863.74316,640)">
-        <g
-           id="g1388"
-           transform="scale(1.5)">
-          <path
-             id="path1382"
-             style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text1386"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan1384"
-               y="13.833333"
-               x="13.333333">-12</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2012"
-         transform="translate(694,568)">
-        <g
-           id="g2010"
-           transform="scale(1.5)">
-          <path
-             id="path2000"
-             style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text2004"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2002"
-               y="21.5"
-               x="5.3333335">action</tspan>
-          </text>
-          <text
-             id="text2008"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2006"
-               y="5.25"
-               x="60.333332" />
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2022"
-         transform="translate(788.5,577)">
-        <g
-           id="g2020"
-           transform="scale(1.5)">
-          <path
-             id="path2014"
-             style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text2018"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2016"
-               y="13.833333"
-               x="13.333333">b</tspan>
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2454"
-         transform="translate(707.5,608.5)">
-        <g
-           id="g2452"
-           transform="scale(1.5)">
-          <path
-             id="path2442"
-             style="fill:#949494;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 53.354492 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z" />
-          <text
-             id="text2446"
-             style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2444"
-               y="13.5"
-               x="69.687828">mouse sync</tspan>
-          </text>
-          <text
-             id="text2450"
-             style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000">
-            <tspan
-               id="tspan2448"
-               y="11.25"
-               x="69.687828" />
-          </text>
-        </g>
-      </g>
-      <g
-         id="g2464"
-         transform="translate(816.03174,608.5)">
-        <g
-           id="g2462"
-           transform="scale(1.5)">
-          <path
-             id="path2456"
-             style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-             d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z" />
-          <text
-             id="text2460"
-             style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000">
-            <tspan
-               id="tspan2458"
-               y="13.833333"
-               x="13.333333">Mr. Mouse</tspan>
-          </text>
-        </g>
-      </g>
+       transform="scale(1.5)"
+       id="g5274">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5268"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5272">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan5270">start</tspan>
+      </text>
     </g>
   </g>
   <g
-     transform="translate(-181,-87.578463)"
-     id="g7084">
+     transform="translate(289.66667,315.42154)"
+     id="g5286">
     <g
-       transform="translate(181,88)"
-       id="g10">
-      <g
-         transform="scale(1.5)"
-         id="g8">
-        <path
-           d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 315 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text6">
-          <tspan
-             x="5.3333335"
-             y="21.5"
-             id="tspan4">start</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5284">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5278"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5282">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan5280">start</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(288.66667,156.42154)"
+     id="g5296">
     <g
-       transform="translate(194.5,254.5)"
-       id="g2074">
-      <g
-         transform="scale(1.5)"
-         id="g2072">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 43.916016 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2062" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2066">
-          <tspan
-             x="60.249348"
-             y="13.5"
-             id="tspan2064">broadcast</tspan>
-        </text>
-        <text
-           style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2070">
-          <tspan
-             x="60.249348"
-             y="11.25"
-             id="tspan2068" />
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5294">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 30 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 21 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5288"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5292">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan5290">start</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(13.499997,74.421537)"
+     id="g5310">
     <g
-       transform="translate(288.87402,254.5)"
-       id="g2084">
-      <g
-         transform="scale(1.5)"
-         id="g2082">
-        <path
-           d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
-           style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2076" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2080">
-          <tspan
-             x="13.333333"
-             y="13.833333"
-             id="tspan2078">b</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5308">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5298"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5302">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5300">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5306">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan5304" />
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(85.499997,74.421537)"
+     id="g5320">
     <g
-       transform="translate(194.5,160)"
-       id="g2098">
-      <g
-         transform="scale(1.5)"
-         id="g2096">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2086" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2090">
-          <tspan
-             x="5.3333335"
-             y="15.25"
-             id="tspan2088">repeat</tspan>
-        </text>
-        <text
-           style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2094">
-          <tspan
-             x="45.333332"
-             y="11.25"
-             id="tspan2092" />
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5318">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5312"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5316">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5314">2</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(533.16667,296.42154)"
+     id="g5334">
     <g
-       transform="translate(266.5,160)"
-       id="g2108">
-      <g
-         transform="scale(1.5)"
-         id="g2106">
-        <path
-           d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
-           style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2100" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2104">
-          <tspan
-             x="13.333333"
-             y="13.833333"
-             id="tspan2102">2</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5332">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5322"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5326">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5324">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5330">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan5328" />
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(696.06755,296.42154)"
+     id="g5352">
     <g
-       transform="translate(208,191.5)"
-       id="g2118">
-      <g
-         transform="scale(1.5)"
-         id="g2116">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2110" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2114">
-          <tspan
-             x="56.333332"
-             y="13.5"
-             id="tspan2112">chunk0</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5350">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5336"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5340">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5338">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5344">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5342" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5348">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5346" />
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(781.56755,296.42154)"
+     id="g5362">
     <g
-       transform="translate(194.5,286)"
-       id="g2132">
-      <g
-         transform="scale(1.5)"
-         id="g2130">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2120" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2124">
-          <tspan
-             x="5.3333335"
-             y="15.25"
-             id="tspan2122">repeat</tspan>
-        </text>
-        <text
-           style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2128">
-          <tspan
-             x="45.333332"
-             y="11.25"
-             id="tspan2126" />
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5360">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5354"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5358">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5356">0</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(781.56755,327.92154)"
+     id="g5380">
     <g
-       transform="translate(266.5,286)"
-       id="g2142">
-      <g
-         transform="scale(1.5)"
-         id="g2140">
-        <path
-           d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
-           style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2134" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2138">
-          <tspan
-             x="13.333333"
-             y="13.833333"
-             id="tspan2136">2</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5378">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5364"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5368">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5366">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5372">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5370" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5376">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5374" />
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(867.06755,327.92154)"
+     id="g5390">
     <g
-       transform="translate(208,317.5)"
-       id="g2152">
-      <g
-         transform="scale(1.5)"
-         id="g2150">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2144" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2148">
-          <tspan
-             x="56.333332"
-             y="13.5"
-             id="tspan2146">chunk1</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5388">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5382"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5386">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5384">-2</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(867.06755,359.42154)"
+     id="g5400">
     <g
-       transform="translate(194.5,412)"
-       id="g2166">
-      <g
-         transform="scale(1.5)"
-         id="g2164">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2154" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2158">
-          <tspan
-             x="5.3333335"
-             y="15.25"
-             id="tspan2156">repeat</tspan>
-        </text>
-        <text
-           style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2162">
-          <tspan
-             x="45.333332"
-             y="11.25"
-             id="tspan2160" />
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5398">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5392"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5396">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5394">12</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(532.16667,519.42154)"
+     id="g5414">
     <g
-       transform="translate(266.5,412)"
-       id="g2176">
-      <g
-         transform="scale(1.5)"
-         id="g2174">
-        <path
-           d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
-           style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2168" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2172">
-          <tspan
-             x="13.333333"
-             y="13.833333"
-             id="tspan2170">2</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5412">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5402"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5406">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5404">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5410">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan5408" />
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(695.06755,519.42154)"
+     id="g5432">
     <g
-       transform="translate(208,443.5)"
-       id="g2186">
-      <g
-         transform="scale(1.5)"
-         id="g2184">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2178" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2182">
-          <tspan
-             x="56.333332"
-             y="13.5"
-             id="tspan2180">chunk2</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5430">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5416"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5420">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5418">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5424">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5422" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5428">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5426" />
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(780.56755,519.42154)"
+     id="g5442">
     <g
-       transform="translate(194.5,538)"
-       id="g2200">
-      <g
-         transform="scale(1.5)"
-         id="g2198">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2188" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2192">
-          <tspan
-             x="5.3333335"
-             y="15.25"
-             id="tspan2190">repeat</tspan>
-        </text>
-        <text
-           style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2196">
-          <tspan
-             x="45.333332"
-             y="11.25"
-             id="tspan2194" />
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5440">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5434"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5438">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5436">0</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(780.56755,550.92154)"
+     id="g5460">
     <g
-       transform="translate(266.5,538)"
-       id="g2210">
-      <g
-         transform="scale(1.5)"
-         id="g2208">
-        <path
-           d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
-           style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2202" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2206">
-          <tspan
-             x="13.333333"
-             y="13.833333"
-             id="tspan2204">2</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5458">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5444"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5448">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5446">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5452">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5450" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5456">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5454" />
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(866.06755,550.92154)"
+     id="g5470">
     <g
-       transform="translate(208,569.5)"
-       id="g2220">
-      <g
-         transform="scale(1.5)"
-         id="g2218">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2212" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2216">
-          <tspan
-             x="56.333332"
-             y="13.5"
-             id="tspan2214">chunk3</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5468">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5462"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5466">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5464">1</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(866.06755,582.42154)"
+     id="g5480">
     <g
-       transform="translate(194.5,380.5)"
-       id="g2358">
-      <g
-         transform="scale(1.5)"
-         id="g2356">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 43.916016 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2346" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2350">
-          <tspan
-             x="60.249348"
-             y="13.5"
-             id="tspan2348">broadcast</tspan>
-        </text>
-        <text
-           style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2354">
-          <tspan
-             x="60.249348"
-             y="11.25"
-             id="tspan2352" />
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5478">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5472"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5476">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5474">12</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(533.16667,72.421537)"
+     id="g5494">
     <g
-       transform="translate(288.87402,380.5)"
-       id="g2368">
-      <g
-         transform="scale(1.5)"
-         id="g2366">
-        <path
-           d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
-           style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2360" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2364">
-          <tspan
-             x="13.333333"
-             y="13.833333"
-             id="tspan2362">c</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5492">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 80.60059 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 27.5 h -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#93e042;fill-opacity:1;stroke:#004000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5482"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5486">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5484">semi-tone transpose</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5490">
+        <tspan
+           x="105.93392"
+           y="11.25"
+           id="tspan5488" />
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(696.06755,72.421537)"
+     id="g5512">
     <g
-       transform="translate(194.5,506.5)"
-       id="g2382">
-      <g
-         transform="scale(1.5)"
-         id="g2380">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 43.916016 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2370" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2374">
-          <tspan
-             x="60.249348"
-             y="13.5"
-             id="tspan2372">broadcast</tspan>
-        </text>
-        <text
-           style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2378">
-          <tspan
-             x="60.249348"
-             y="11.25"
-             id="tspan2376" />
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5510">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5496"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5500">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5498">+</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5504">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5502" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5508">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5506" />
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(781.56755,72.421537)"
+     id="g5522">
     <g
-       transform="translate(288.87402,506.5)"
-       id="g2392">
-      <g
-         transform="scale(1.5)"
-         id="g2390">
-        <path
-           d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
-           style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2384" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2388">
-          <tspan
-             x="13.333333"
-             y="13.833333"
-             id="tspan2386">d</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5520">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5514"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5518">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5516">0</tspan>
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(781.56755,103.92154)"
+     id="g5540">
     <g
-       transform="translate(194.5,128.5)"
-       id="g2478">
-      <g
-         transform="scale(1.5)"
-         id="g2476">
-        <path
-           d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 57.807617 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
-           style="fill:#949494;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2466" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2470">
-          <tspan
-             x="74.140953"
-             y="13.5"
-             id="tspan2468">mouse name</tspan>
-        </text>
-        <text
-           style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
-           id="text2474">
-          <tspan
-             x="74.140953"
-             y="11.25"
-             id="tspan2472" />
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5538">
+      <path
+         d="m 8.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 10 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -10 -4 a 4,4 90 0 1 -4,-4 v -4 -21 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5524"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:14px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5528">
+        <tspan
+           x="54.333332"
+           y="23.799999"
+           id="tspan5526">×</tspan>
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5532">
+        <tspan
+           x="54.333332"
+           y="10.75"
+           id="tspan5530" />
+      </text>
+      <text
+         style="font-size:9.33333302px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5536">
+        <tspan
+           x="54.333332"
+           y="31.75"
+           id="tspan5534" />
+      </text>
     </g>
+  </g>
+  <g
+     transform="translate(867.06755,103.92154)"
+     id="g5550">
     <g
-       transform="translate(309.71143,128.5)"
-       id="g2488">
-      <g
-         transform="scale(1.5)"
-         id="g2486">
-        <path
-           d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
-           style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
-           id="path2480" />
-        <text
-           style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
-           id="text2484">
-          <tspan
-             x="13.333333"
-             y="13.833333"
-             id="tspan2482">Mr. Mouse</tspan>
-        </text>
-      </g>
+       transform="scale(1.5)"
+       id="g5548">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5542"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5546">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5544">-1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(867.06755,135.42154)"
+     id="g5560">
+    <g
+       transform="scale(1.5)"
+       id="g5558">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5552"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5556">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5554">12</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,42.921537)"
+     id="g5574">
+    <g
+       transform="scale(1.5)"
+       id="g5572">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 57.807617 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#949494;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5562"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5566">
+        <tspan
+           x="74.140953"
+           y="13.5"
+           id="tspan5564">mouse name</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5570">
+        <tspan
+           x="74.140953"
+           y="11.25"
+           id="tspan5568" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(128.71143,42.921537)"
+     id="g5584">
+    <g
+       transform="scale(1.5)"
+       id="g5582">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5576"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5580">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5578">Mr. Mouse</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(533.16667,40.921537)"
+     id="g5598">
+    <g
+       transform="scale(1.5)"
+       id="g5596">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 53.354492 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#949494;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5586"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5590">
+        <tspan
+           x="69.687828"
+           y="13.5"
+           id="tspan5588">mouse sync</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5594">
+        <tspan
+           x="69.687828"
+           y="11.25"
+           id="tspan5592" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(641.69841,40.921537)"
+     id="g5608">
+    <g
+       transform="scale(1.5)"
+       id="g5606">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5600"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5604">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5602">Mr. Mouse</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(533.16667,264.92154)"
+     id="g5622">
+    <g
+       transform="scale(1.5)"
+       id="g5620">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 53.354492 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#949494;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5610"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5614">
+        <tspan
+           x="69.687828"
+           y="13.5"
+           id="tspan5612">mouse sync</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5618">
+        <tspan
+           x="69.687828"
+           y="11.25"
+           id="tspan5616" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(641.69841,264.92154)"
+     id="g5632">
+    <g
+       transform="scale(1.5)"
+       id="g5630">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5624"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5628">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5626">Mr. Mouse</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(532.16667,487.92154)"
+     id="g5646">
+    <g
+       transform="scale(1.5)"
+       id="g5644">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 53.354492 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#949494;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5634"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5638">
+        <tspan
+           x="69.687828"
+           y="13.5"
+           id="tspan5636">mouse sync</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5642">
+        <tspan
+           x="69.687828"
+           y="11.25"
+           id="tspan5640" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(640.69841,487.92154)"
+     id="g5656">
+    <g
+       transform="scale(1.5)"
+       id="g5654">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5648"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5652">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5650">Mr. Mouse</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,420.92154)"
+     id="g5670">
+    <g
+       transform="scale(1.5)"
+       id="g5668">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 43.916016 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5658"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5662">
+        <tspan
+           x="60.249348"
+           y="13.5"
+           id="tspan5660">broadcast</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5666">
+        <tspan
+           x="60.249348"
+           y="11.25"
+           id="tspan5664" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(107.87403,420.92154)"
+     id="g5680">
+    <g
+       transform="scale(1.5)"
+       id="g5678">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5672"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5676">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5674">d</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,168.92154)"
+     id="g5694">
+    <g
+       transform="scale(1.5)"
+       id="g5692">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 43.916016 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5682"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5686">
+        <tspan
+           x="60.249348"
+           y="13.5"
+           id="tspan5684">broadcast</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5690">
+        <tspan
+           x="60.249348"
+           y="11.25"
+           id="tspan5688" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(107.87403,168.92154)"
+     id="g5704">
+    <g
+       transform="scale(1.5)"
+       id="g5702">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5696"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5700">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5698">b</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,294.92154)"
+     id="g5718">
+    <g
+       transform="scale(1.5)"
+       id="g5716">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 43.916016 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 H 18.5 h -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5706"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5710">
+        <tspan
+           x="60.249348"
+           y="13.5"
+           id="tspan5708">broadcast</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5714">
+        <tspan
+           x="60.249348"
+           y="11.25"
+           id="tspan5712" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(107.87403,294.92154)"
+     id="g5728">
+    <g
+       transform="scale(1.5)"
+       id="g5726">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5720"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5724">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5722">c</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,200.42154)"
+     id="g5742">
+    <g
+       transform="scale(1.5)"
+       id="g5740">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5730"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5734">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5732">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5738">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan5736" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.499997,200.42154)"
+     id="g5752">
+    <g
+       transform="scale(1.5)"
+       id="g5750">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5744"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5748">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5746">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,326.42154)"
+     id="g5766">
+    <g
+       transform="scale(1.5)"
+       id="g5764">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5754"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5758">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5756">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5762">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan5760" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.499997,326.42154)"
+     id="g5776">
+    <g
+       transform="scale(1.5)"
+       id="g5774">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5768"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5772">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5770">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(13.499997,452.42154)"
+     id="g5790">
+    <g
+       transform="scale(1.5)"
+       id="g5788">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 9 20 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -20 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#e9a066;fill-opacity:1;stroke:#3f0a00;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5778"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5782">
+        <tspan
+           x="5.3333335"
+           y="15.25"
+           id="tspan5780">repeat</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5786">
+        <tspan
+           x="45.333332"
+           y="11.25"
+           id="tspan5784" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(85.499997,452.42154)"
+     id="g5800">
+    <g
+       transform="scale(1.5)"
+       id="g5798">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#ffb2bc;fill-opacity:1;stroke:#601136;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5792"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5796">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5794">2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(298.16667,43.921537)"
+     id="g5818">
+    <g
+       transform="scale(1.5)"
+       id="g5816">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5802"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5806">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan5804">on</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5810">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan5808">event</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5814">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan5812">do</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(371.66667,43.921537)"
+     id="g5828">
+    <g
+       transform="scale(1.5)"
+       id="g5826">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5820"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5824">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5822">b</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(371.66667,75.421537)"
+     id="g5838">
+    <g
+       transform="scale(1.5)"
+       id="g5836">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5830"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5834">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5832">b</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(302.16667,196.92154)"
+     id="g5856">
+    <g
+       transform="scale(1.5)"
+       id="g5854">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5840"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5844">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan5842">on</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5848">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan5846">event</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5852">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan5850">do</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(375.66667,196.92154)"
+     id="g5866">
+    <g
+       transform="scale(1.5)"
+       id="g5864">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5858"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5862">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5860">c</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(375.66667,228.42154)"
+     id="g5876">
+    <g
+       transform="scale(1.5)"
+       id="g5874">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5868"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5872">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5870">c</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(303.16667,355.92154)"
+     id="g5894">
+    <g
+       transform="scale(1.5)"
+       id="g5892">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 30 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 17 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -30 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 -21 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5878"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5882">
+        <tspan
+           x="46.333332"
+           y="24"
+           id="tspan5880">on</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5886">
+        <tspan
+           x="46.333332"
+           y="11.25"
+           id="tspan5884">event</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5890">
+        <tspan
+           x="46.333332"
+           y="32.25"
+           id="tspan5888">do</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(376.66667,355.92154)"
+     id="g5904">
+    <g
+       transform="scale(1.5)"
+       id="g5902">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5896"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5900">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5898">d</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(376.66667,387.42154)"
+     id="g5914">
+    <g
+       transform="scale(1.5)"
+       id="g5912">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5906"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5910">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5908">d</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(519.66667,0.42153745)"
+     id="g5928">
+    <g
+       transform="scale(1.5)"
+       id="g5926">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5916"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5920">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan5918">action</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5924">
+        <tspan
+           x="60.333332"
+           y="5.25"
+           id="tspan5922" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(614.16667,9.4215375)"
+     id="g5938">
+    <g
+       transform="scale(1.5)"
+       id="g5936">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5930"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5934">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5932">b</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(519.66667,224.42154)"
+     id="g5952">
+    <g
+       transform="scale(1.5)"
+       id="g5950">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5940"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5944">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan5942">action</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5948">
+        <tspan
+           x="60.333332"
+           y="5.25"
+           id="tspan5946" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(614.16667,233.42154)"
+     id="g5962">
+    <g
+       transform="scale(1.5)"
+       id="g5960">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5954"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5958">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5956">c</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(518.66667,447.42154)"
+     id="g5976">
+    <g
+       transform="scale(1.5)"
+       id="g5974">
+      <path
+         d="m 0.5,14.5 v -4 a 4,4 90 0 1 4,-4 h 4 l 5,-6 5,6 h 9 35 4 a 4,4 90 0 1 4,4 v 4 h -4 v -3 h -4 v 10 h 4 v -3 h 4 v 4 a 4,4 90 0 1 -4,4 h -4 -35 -1 v 2 h -8 v -2 h -1 -4 a 5,5 90 0 0 -5,5 v 4 4 63 4 a 5,5 90 0 0 5,5 h 4 v 2 h 10 v -2 h 8 v 6 6 4 a 4,4 90 0 1 -4,4 h -4 -9 l -5,6 -5,-6 h -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5964"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5968">
+        <tspan
+           x="5.3333335"
+           y="21.5"
+           id="tspan5966">action</tspan>
+      </text>
+      <text
+         style="font-size:6.66666651px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5972">
+        <tspan
+           x="60.333332"
+           y="5.25"
+           id="tspan5970" />
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(613.16667,456.42154)"
+     id="g5986">
+    <g
+       transform="scale(1.5)"
+       id="g5984">
+      <path
+         d="m 8.5,0.5 h 60 v 20 h -60 v -8 -1 h -6 v 3 h -2 v -8 h 2 v 3 h 6 v -1 z"
+         style="fill:#76dbd7;fill-opacity:1;stroke:#003b41;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5978"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:start;fill:#000000"
+         id="text5982">
+        <tspan
+           x="13.333333"
+           y="13.833333"
+           id="tspan5980">d</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(546.66667,103.92154)"
+     id="g5996">
+    <g
+       transform="scale(1.5)"
+       id="g5994">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5988"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text5992">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan5990">chunk0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(546.66667,327.92154)"
+     id="g6006">
+    <g
+       transform="scale(1.5)"
+       id="g6004">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path5998"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6002">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan6000">chunk0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(545.66667,550.92154)"
+     id="g6016">
+    <g
+       transform="scale(1.5)"
+       id="g6014">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6008"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6012">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan6010">chunk0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,105.92154)"
+     id="g6050">
+    <g
+       transform="scale(1.5)"
+       id="g6048">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6042"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6046">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan6044">chunk0</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,231.92154)"
+     id="g6084">
+    <g
+       transform="scale(1.5)"
+       id="g6082">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6076"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6080">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan6078">chunk1</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,357.92154)"
+     id="g6118">
+    <g
+       transform="scale(1.5)"
+       id="g6116">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6110"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6114">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan6112">chunk2</tspan>
+      </text>
+    </g>
+  </g>
+  <g
+     transform="translate(26.999997,483.92154)"
+     id="g6152">
+    <g
+       transform="scale(1.5)"
+       id="g6150">
+      <path
+         d="m 0.5,8.5 v -4 a 4,4 90 0 1 4,-4 h 4 v 2 h 10 v -2 h 40 4 a 4,4 90 0 1 4,4 v 4 4 4 a 4,4 90 0 1 -4,4 h -4 -40 -1 v 2 h -8 v -2 h -1 -4 a 4,4 90 0 1 -4,-4 v -4 z"
+         style="fill:#ffe05c;fill-opacity:1;stroke:#644300;stroke-width:1;stroke-linecap:round;stroke-opacity:1"
+         id="path6144"
+         inkscape:connector-curvature="0" />
+      <text
+         style="font-size:10px;font-family:sans-serif;text-anchor:end;fill:#000000"
+         id="text6148">
+        <tspan
+           x="56.333332"
+           y="13.5"
+           id="tspan6146">chunk3</tspan>
+      </text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
This pull request is for issue #881 . Most of the changes in images are related to how transpose is now semi-tone transpose, however I also included new images for other discrepancies I noticed such as how duplicate notes is now duplicate, change in augmented and minor blocks, as well as the change in color for the tempo block.