### PR TITLE
Fixes issue #956

### DIFF
--- a/css/activity.css
+++ b/css/activity.css
@@ -1,4 +1,4 @@
-input[type=text] {
+#search[type=text] {
     width: 400px;
     box-sizing: border-box;
     position: absolute;
@@ -9,7 +9,7 @@ input[type=text] {
     transition: width 0.4s ease-in-out;
 }
 
-input:focus {
+#search:focus {
     border: 2px solid #87CEFA;
 }
 


### PR DESCRIPTION
This issue was caused by code in activity.css (meant to style the search bar) having too wide a scope and styling all input fields like the search bar - even the fields for names in Planet. I fixed this issue by changing the CSS from `input` to `#search` thus restricting the effect of the styling to only elements with id 'search' (i.e. the search bar).