### PR TITLE
Warning to noise block added

### DIFF
--- a/js/musicutils.js
+++ b/js/musicutils.js
@@ -1930,6 +1930,7 @@ function Synth() {
         case 'noise3':
             instrumentsSource[instrumentName] = [4, sourceName];
             console.log(sourceName);
+            console.log("pitches are ignored when noise feature is used");
             var builtin_synth = new Tone.NoiseSynth(synthOptions);
             break;
         default:


### PR DESCRIPTION
I added a warning to the noise block so that users would know that changing the pitch of the note block in the set timbre clamp would not result in any change.