### PR TITLE
changing the noise valume default to a conservative "2" 

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -11,7 +11,7 @@
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
 const DEFAULTVOLUME = 50;
-const DEFAULTNOISEVOLUME = 10;
+const DEFAULTNOISEVOLUME = 2;
 const TONEBPM = 240;  // Seems to be the default.
 const TARGETBPM = 90;  // What we'd like to use for beats per minute
 const DEFAULTDELAY = 500;  // milleseconds


### PR DESCRIPTION
-- anything from 2-5 is tolerable with earbuds/headphones

I am testing with headphones and I found even 10 to be too loud. 5 is really the max, but I find 2 to be a more comparable volume (in terms of perception) to the pitch output.