### PR TITLE
Added screen position blocks to Music Blocks

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -255,6 +255,12 @@ const TACAT = {
     'speak': 'media',
     'sinewave': 'media',
     'description': 'media',
+    'leftpos': 'media',
+    'rightpos': 'media',
+    'toppos': 'media',
+    'bottompos': 'media',
+    'width': 'media',
+    'height': 'media',
 
     'savepix': 'ignore',
     'savesvg': 'ignore',

--- a/js/basicblocks.js
+++ b/js/basicblocks.js
@@ -2637,6 +2637,48 @@ function initBasicProtoBlocks(palettes, blocks) {
 
     // MEDIA PALETTE
 
+    var leftposBlock = new ProtoBlock('leftpos');
+    leftposBlock.palette = palettes.dict['media'];
+    blocks.protoBlockDict['leftpos'] = leftposBlock;
+    leftposBlock.staticLabels.push(_('left'));
+    leftposBlock.adjustWidthToLabel();
+    leftposBlock.parameterBlock();
+
+    var rightposBlock = new ProtoBlock('rightpos');
+    rightposBlock.palette = palettes.dict['media'];
+    blocks.protoBlockDict['rightpos'] = rightposBlock;
+    rightposBlock.staticLabels.push(_('right'));
+    rightposBlock.adjustWidthToLabel();
+    rightposBlock.parameterBlock();
+
+    var topposBlock = new ProtoBlock('toppos');
+    topposBlock.palette = palettes.dict['media'];
+    blocks.protoBlockDict['toppos'] = topposBlock;
+    topposBlock.staticLabels.push(_('top'));
+    topposBlock.adjustWidthToLabel();
+    topposBlock.parameterBlock();
+
+    var bottomposBlock = new ProtoBlock('bottompos');
+    bottomposBlock.palette = palettes.dict['media'];
+    blocks.protoBlockDict['bottompos'] = bottomposBlock;
+    bottomposBlock.staticLabels.push(_('bottom'));
+    bottomposBlock.adjustWidthToLabel();
+    bottomposBlock.parameterBlock();
+
+    var widthBlock = new ProtoBlock('width');
+    widthBlock.palette = palettes.dict['media'];
+    blocks.protoBlockDict['width'] = widthBlock;
+    widthBlock.staticLabels.push(_('width'));
+    widthBlock.adjustWidthToLabel();
+    widthBlock.parameterBlock();
+
+    var heightBlock = new ProtoBlock('height');
+    heightBlock.palette = palettes.dict['media'];
+    blocks.protoBlockDict['height'] = heightBlock;
+    heightBlock.staticLabels.push(_('height'));
+    heightBlock.adjustWidthToLabel();
+    heightBlock.parameterBlock();
+
     var audioStopBlock = new ProtoBlock('stopplayback');
     audioStopBlock.palette = palettes.dict['media'];
     blocks.protoBlockDict['stopplayback'] = audioStopBlock;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3786,55 +3786,6 @@ function Blocks () {
 
                 this._makeNewBlockWithConnections('number', blockOffset, blkData[4], postProcess, thisBlock);
                 break;
-            case 'leftpos':
-                postProcess = function (thisBlock) {
-                    that.blockList[thisBlock].value = -(canvas.width / 2);
-                    that.updateBlockText(thisBlock);
-                };
-
-                this._makeNewBlockWithConnections('number', blockOffset, blkData[4], postProcess, thisBlock);
-                break;
-            case 'rightpos':
-                postProcess = function (thisBlock) {
-                    that.blockList[thisBlock].value = (canvas.width / 2);
-                    that.updateBlockText(thisBlock);
-                };
-
-                this._makeNewBlockWithConnections('number', blockOffset, blkData[4], postProcess, thisBlock);
-                break;
-            case 'toppos':
-                postProcess = function (thisBlock) {
-                    that.blockList[thisBlock].value = (canvas.height / 2);
-                    that.updateBlockText(thisBlock);
-                };
-
-                this._makeNewBlockWithConnections('number', blockOffset, blkData[4], postProcess, thisBlock);
-                break;
-            case 'botpos':
-            case 'bottompos':
-                postProcess = function (thisBlock) {
-                    that.blockList[thisBlock].value = -(canvas.height / 2);
-                    that.updateBlockText(thisBlock);
-                };
-
-                this._makeNewBlockWithConnections('number', blockOffset, blkData[4], postProcess, thisBlock);
-                break;
-            case 'width':
-                postProcess = function (thisBlock) {
-                    that.blockList[thisBlock].value = canvas.width;
-                    that.updateBlockText(thisBlock);
-                };
-
-                this._makeNewBlockWithConnections('number', blockOffset, blkData[4], postProcess, thisBlock);
-                break;
-            case 'height':
-                postProcess = function (thisBlock) {
-                    that.blockList[thisBlock].value = canvas.height;
-                    that.updateBlockText(thisBlock);
-                };
-
-                this._makeNewBlockWithConnections('number', blockOffset, blkData[4], postProcess, thisBlock);
-                break;
             case 'loadFile':
                 postProcess = function (args) {
                     that.blockList[args[0]].value = args[1];

--- a/js/logo.js
+++ b/js/logo.js
@@ -608,6 +608,12 @@ function Logo () {
             case 'time':
             case 'mousex':
             case 'mousey':
+            case 'toppos':
+            case 'rightpos':
+            case 'leftpos':
+            case 'bottompos':
+            case 'width':
+            case 'height':
             case 'keyboard':
             case 'loudness':
             case 'consonantstepsizeup':
@@ -717,6 +723,24 @@ function Logo () {
                 break;
             case 'mousey':
                 value = toFixed2(this.getStageY());
+                break;
+            case 'toppos':
+                value = toFixed2((this.turtles._canvas.height / (2.0 * this.turtles.scale)));
+                break;
+            case 'rightpos':
+                value = toFixed2((this.turtles._canvas.width / (2.0 * this.turtles.scale)));
+                break;
+            case 'leftpos':
+                value = toFixed2(-1*(this.turtles._canvas.width / (2.0 * this.turtles.scale)));
+                break;
+            case 'bottompos':
+                value = toFixed2(-1*(this.turtles._canvas.height / (2.0 * this.turtles.scale)));
+                break;
+            case 'width':
+                value = toFixed2(this.canvas.width);
+                break;
+            case 'height':
+                value = toFixed2(this.canvas.height);
                 break;
             case 'keyboard':
                 value = this.lastKeyCode;
@@ -8170,6 +8194,24 @@ function Logo () {
                 break;
             case 'mousey':
                 that.blocks.blockList[blk].value = that.getStageY();
+                break;
+            case 'toppos':
+                that.blocks.blockList[blk].value = (that.turtles._canvas.height / (2.0 * that.turtles.scale));
+                break;
+            case 'rightpos':
+                that.blocks.blockList[blk].value = (that.turtles._canvas.width / (2.0 * that.turtles.scale));
+                break;
+            case 'leftpos':
+                that.blocks.blockList[blk].value = -1*(that.turtles._canvas.width / (2.0 * that.turtles.scale));
+                break;
+            case 'bottompos':
+                that.blocks.blockList[blk].value = -1*(that.turtles._canvas.height / (2.0 * that.turtles.scale));
+                break;
+            case 'width':
+                that.blocks.blockList[blk].value = that.canvas.width;
+                break;
+            case 'height':
+                that.blocks.blockList[blk].value = that.canvas.height;
                 break;
             case 'mousebutton':
                 that.blocks.blockList[blk].value = that.getStageMouseDown();

--- a/js/logo.js
+++ b/js/logo.js
@@ -737,10 +737,10 @@ function Logo () {
                 value = toFixed2(-1*(this.turtles._canvas.height / (2.0 * this.turtles.scale)));
                 break;
             case 'width':
-                value = toFixed2(this.canvas.width);
+                value = toFixed2(that.turtles._canvas.width / (that.turtles.scale));
                 break;
             case 'height':
-                value = toFixed2(this.canvas.height);
+                value = toFixed2(that.turtles._canvas.height / (that.turtles.scale));
                 break;
             case 'keyboard':
                 value = this.lastKeyCode;
@@ -8208,10 +8208,10 @@ function Logo () {
                 that.blocks.blockList[blk].value = -1*(that.turtles._canvas.height / (2.0 * that.turtles.scale));
                 break;
             case 'width':
-                that.blocks.blockList[blk].value = that.canvas.width;
+                that.blocks.blockList[blk].value = (that.turtles._canvas.width / (that.turtles.scale));
                 break;
             case 'height':
-                that.blocks.blockList[blk].value = that.canvas.height;
+                that.blocks.blockList[blk].value = (that.turtles._canvas.height / (that.turtles.scale));
                 break;
             case 'mousebutton':
                 that.blocks.blockList[blk].value = that.getStageMouseDown();


### PR DESCRIPTION
eohomegrownapps-GCI

As per the task description, I added 'leftpos', 'toppos', 'rightpos', 'bottompos', 'width' and 'height' blocks to the 'media' palette. Please do let me know if the coordinates are meant to be those of the canvas (as in the pull request) or those of the dotted orange 'bounding box' within the canvas.