### PR TITLE
Allows Music Blocks to function as a chrome extension

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,0 +1,8 @@
+chrome.browserAction.onClicked.addListener(function(tab) {
+  window.open(chrome.runtime.getURL("index.html"));
+});
+
+chrome.runtime.onInstalled.addListener(function (callback) {
+  window.open(chrome.runtime.getURL("index.html"));
+
+});

--- a/js/background.js
+++ b/js/background.js
@@ -2,7 +2,21 @@ chrome.browserAction.onClicked.addListener(function(tab) {
   window.open(chrome.runtime.getURL("index.html"));
 });
 
-chrome.runtime.onInstalled.addListener(function (callback) {
-  window.open(chrome.runtime.getURL("index.html"));
+// Firefox
+browser.browserAction.onClicked.addListener(function(tab) {
+    browser.tabs.update({
+        url: "index.html"
+    });
+});
 
+
+chrome.runtime.onInstalled.addListener(function (tab) {
+  window.open(chrome.runtime.getURL("index.html"));
+});
+
+//Firefox
+browser.runtime.onInstalled.addListener(function (tab) {
+  browser.tabs.update({
+      url: "index.html"
+  });
 });

--- a/js/launch.js
+++ b/js/launch.js
@@ -1,7 +1,0 @@
-chrome.app.runtime.onLaunched.addListener(function() {
-	// Create window
-	var mainwin = chrome.app.window.create('../index.html', {
-		id: "mainwin",
-	},function(created) {
-	});
-});

--- a/manifest.json
+++ b/manifest.json
@@ -5,18 +5,20 @@
     "author": "Sugar Labs",
     "description": "Learn to program music with snap-together blocks.",
     "icons": {
-	"512": "/activity/activity-icon-color-512.png",
-	"128": "/activity/activity-icon-color-128.png"
+        "512": "/activity/activity-icon-color-512.png",
+      	"128": "/activity/activity-icon-color-128.png"
     },
-    "app": {
-	"background": {
-	    "scripts": ["js/launch.js"]
-	}
+    "background": {
+       "scripts": ["js/background.js"]
     },
+    "web_accessible_resources": [
+        "index.html"
+    ],
     "permissions": [
-	"storage",
-	"unlimitedStorage",
-	"audioCapture",
-	"videoCapture"
-    ]
+      	"storage",
+      	"unlimitedStorage"
+    ],
+    "browser_action": {
+        "default_icon": "/activity/activity-icon-color-128.png"
+    }
 }


### PR DESCRIPTION
This is for the purpose of easily installing Music Blocks, and being able to use it without being connected to the internet. Fixes #647 

<img width="1678" alt="image" src="https://user-images.githubusercontent.com/13735595/34073196-1f2588dc-e262-11e7-8902-ef9f83cf6f78.png">
Clicking the button on the top right opens musicblocks from locally installed extension files. It also opens when the extension is first installed. 

As an additional feature, should MusicBlocks also launch when the music blocks site is visited? 

We should definitely publish this in the webstore, and I'll probably be making a Firefox extension too. 