### PR TITLE
Add keyboard shortcuts for creating notes

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1496,6 +1496,21 @@ define(MYDEFINES, function (compatibility) {
             }
         };
 
+        function __makeNewNote(octave, solf){
+            var newNote = [
+                [0, 'newnote', 300, 300, [null, 1, 4, 8]],
+                [1, 'divide', 0, 0, [0, 2, 3]],
+                [2, ['number', {'value': 1}], 0, 0, [1]],
+                [3, ['number', {'value': 4}], 0, 0, [1]],
+                [4, 'vspace', 0, 0, [0, 5]],
+                [5, 'pitch', 0, 0, [4, 6, 7, null]],
+                [6, ['solfege', {'value': solf}], 0, 0, [5]],
+                [7, ['number', {'value': octave}], 0, 0, [5]],
+                [8, 'hidden', 0, 0, [0, null]]
+            ];
+            blocks.loadNewBlocks(newNote);
+        }
+
         function __keyPressed(event) {
             if (docById('labelDiv').classList.contains('hasKeyboard')) {
                 return;
@@ -1544,6 +1559,15 @@ define(MYDEFINES, function (compatibility) {
             const KEYCODE_DOWN = 40;
             const DEL = 46;
 
+            // Shortcuts for creating new notes
+            const KEYCODE_D = 68; // do
+            const KEYCODE_R = 82; // re
+            const KEYCODE_M = 77; // mi
+            const KEYCODE_F = 70; // fa
+            const KEYCODE_S = 83; // so
+            const KEYCODE_L = 76; // la
+            const KEYCODE_T = 84; // ti
+
             if (event.altKey) {
                 switch (event.keyCode) {
                 case 66: // 'B'
@@ -1569,6 +1593,30 @@ define(MYDEFINES, function (compatibility) {
                     break;
                 }
             } else if (event.ctrlKey) {
+            } else if (event.shiftKey){
+                switch (event.keyCode) {
+                    case KEYCODE_D:
+                        __makeNewNote(5, "do");
+                        break
+                    case KEYCODE_R:
+                        __makeNewNote(5, "re");
+                        break
+                    case KEYCODE_M:
+                        __makeNewNote(5, "mi");
+                        break
+                    case KEYCODE_F:
+                        __makeNewNote(5, "fa");
+                        break
+                    case KEYCODE_S:
+                        __makeNewNote(5, "sol");
+                        break
+                    case KEYCODE_L:
+                        __makeNewNote(5, "la");
+                        break
+                    case KEYCODE_T:
+                        __makeNewNote(5, "ti");
+                        break
+                }
             } else {
                 switch (event.keyCode) {
                 case END:
@@ -1665,6 +1713,28 @@ define(MYDEFINES, function (compatibility) {
                         }
                     }
                     break;
+
+                case KEYCODE_D:
+                    __makeNewNote(4, "do");
+                    break
+                case KEYCODE_R:
+                    __makeNewNote(4, "re");
+                    break
+                case KEYCODE_M:
+                    __makeNewNote(4, "mi");
+                    break
+                case KEYCODE_F:
+                    __makeNewNote(4, "fa");
+                    break
+                case KEYCODE_S:
+                    __makeNewNote(4, "sol");
+                    break
+                case KEYCODE_L:
+                    __makeNewNote(4, "la");
+                    break
+                case KEYCODE_T:
+                    __makeNewNote(4, "ti");
+                    break
                 default:
                     break;
                 }

--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -78,6 +78,7 @@ function createHelpContent() {
         [_('Palette buttons'),
         //.TRANS: Please add commas to list: Rhythm, Pitch, Tone, Action, and more.
 	 _('This toolbar contains the palette buttons, including Rhythm Pitch Tone Action and more.') + ' ' + _('Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them.'), 'images/icons.svg'],
+        [_('Play music'), _('Click to run the music note by note. Alternatively, you can hit the ENTER or RETURN key.'), 'header-icons/play-button.svg'],
         [_('Run fast'), _('Click the run button to run the project in fast mode.'), 'header-icons/run-button.svg'],
         [_('Run slow'), _('Long press the run button to run the project in slow mode.'), 'header-icons/slow-button.svg'],
         [_('Run music slow'), _('Extra-long press the run button to run the music in slow mode.'), 'header-icons/slow-music-button.svg'],
@@ -94,8 +95,8 @@ function createHelpContent() {
         [_('Load project from files'), _('You can also load projects from the file system.'), 'header-icons/open-button.svg'],
         [_('Save project'), _('Save your project to a file.'), 'header-icons/save-button.svg'],
         [_('Save sheet music'), _('Save your project to as a Lilypond file.'), 'header-icons/lilypond-button.svg'],
-        [_('Copy'), _('To copy a stack to the clipboard, do a long press on the stack.') + ' ' + _('The Paste Button will highlight.'), 'header-icons/paste-button.svg'],
-        [_('Paste'), _('The paste button is enabled when there are blocks copied onto the clipboard.'), 'header-icons/paste-disabled-button.svg'],
+        [_('Copy'), _('To copy a stack to the clipboard, do a long press on the stack. You can also use Alt+C to copy a stack of blocks. ') + ' ' + _('The Paste Button will highlight.'), 'header-icons/paste-button.svg'],
+        [_('Paste'), _('The paste button is enabled when there are blocks copied onto the clipboard. You can also use Alt+P to paste a stack of blocks. '), 'header-icons/paste-disabled-button.svg'],
         [_('Cartesian') + '/' + _('Polar'), _('Show or hide a coordinate grid.'), 'header-icons/Cartesian-polar-button.svg'],
         // [_('Polar'), _('Show or hide a polar-coordinate grid.'), 'header-icons/polar-button.svg'],
         [_('Settings'), _('Open a panel for configuring Music Blocks.'), 'header-icons/utility-button.svg'],


### PR DESCRIPTION
Originally had ABC notation (with C being C), however I found that to be confusing as pitches in Music Blocks are defined by the solfege. Instead, `d` is `do`, `r` is `re` and so on. 

Will include chaining of notes in a separate PR