### PR TITLE
disable keys for search + search menu fixes

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1464,7 +1464,6 @@ define(MYDEFINES, function (compatibility) {
             }
 
             searchWidget.style.visibility = 'hidden';
-            searchWidget.value = null;
         };
 
         function showSearchWidget() {

--- a/js/activity.js
+++ b/js/activity.js
@@ -1458,18 +1458,24 @@ define(MYDEFINES, function (compatibility) {
 
         function hideSearchWidget() {
             // Hide the jQuery search results widget
-            var obj = docByClass('ui-helper-hidden-accessible');
+            var obj = docByClass('ui-menu');
             if (obj.length > 0) {
                 obj[0].style.visibility = 'hidden';
             }
 
             searchWidget.style.visibility = 'hidden';
+            searchWidget.value = null;
         };
 
         function showSearchWidget() {
             if (searchWidget.style.visibility === 'visible') {
                 hideSearchWidget();
             } else {
+                var obj = docByClass('ui-menu');
+                if (obj.length > 0) {
+                    obj[0].style.visibility = 'visible';
+                }
+                searchWidget.value = null;
                 docById('searchResults').style.visibility = 'visible';
                 searchWidget.style.visibility = 'visible';
                 searchWidget.style.left = (utilityBox.getPos()[0] + 10) * turtleBlocksScale + 'px';
@@ -1623,8 +1629,7 @@ define(MYDEFINES, function (compatibility) {
             const KEYCODE_L = 76; // la
             const KEYCODE_T = 84; // ti
 
-	    var disableKeys = docById('lilypondModal').style.display === 'block';
-
+	    var disableKeys = docById('lilypondModal').style.display === 'block' || docById('searchWidget').style.visibility === 'visible';
             if (event.altKey && !disableKeys) {
                 switch (event.keyCode) {
                 case 66: // 'B'


### PR DESCRIPTION
I was using the search function for MB when I realized that the search results menu doesn't actually hide if there is an existing input.

![screen shot 2017-12-29 at 6 55 29 pm](https://user-images.githubusercontent.com/21200681/34435602-e37fbc7c-ecc9-11e7-899e-01218d7363f3.png)

**Steps to reproduce:**

1.  open the search widget, key in any search. eg 'note value'.
2. without clearing the search, exit out of the search widget.

What I have done is that I changed `ui-helper-hidden-accessible` to `ui-menu`, keep the existing `hidden visibility` on `hidesearchwidget` and made it visible when `showsearchwidget` is called.

Now, even if I go through the above steps, the search results menu would be hidden from the canvas  after exit.

One more thing, I included the `disableKeys` if the search widget is visible, keeping my code in format with how `disablekeys` were set previously. 